### PR TITLE
feat: ast-outline install — prompt + Read hook for 7 coding CLIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,11 @@ ignore = "0.4.22"
 rayon = "1.10"
 tree-sitter-md = "0.5.3"
 colored = "3.1.1"
+serde = { version = "1", features = ["derive"] }
+serde_json = { version = "1", features = ["preserve_order"] }
+serde_yaml = "0.9"
+dirs = "5"
+similar = "2"
+
+[dev-dependencies]
+tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ast-outline"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Fast, AST-based structural outline for source files. Built for LLM coding agents and humans."
 authors = ["Aero <aero.windwalker@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -114,17 +114,42 @@ ast-outline prompt >> AGENTS.md
 
 ## Using with LLM coding agents
 
-This is the main use case. Add the snippet below to your `CLAUDE.md`,
-`AGENTS.md`, subagent file, or any system prompt that steers a coding
-agent. It will then prefer `ast-outline` over reading full files.
+This is the main use case. The fastest path is `ast-outline install`,
+which writes the agent prompt snippet (and, where supported, a real
+`Read`-interceptor hook) into your coding agent's config.
 
-The snippet ships with the tool — `ast-outline prompt` prints it
-verbatim, so you can append it to a project's agent config without
-copy-pasting:
+```bash
+# Install into every supported CLI it can detect on your system.
+ast-outline install --all
+
+# Or pick a single target.
+ast-outline install --target claude-code
+ast-outline install --target gemini --min-lines 150
+
+# See exactly what would change before writing.
+ast-outline install --all --dry-run
+
+# Per-repo install (default is global).
+ast-outline install --target claude-code --local
+
+# Remove everything we wrote.
+ast-outline uninstall --all
+
+# Quick visibility.
+ast-outline status
+```
+
+Supported targets: `claude-code`, `gemini`, `tabnine`, `cursor`,
+`aider`, `codex`, `copilot`. Claude Code, Gemini, and Tabnine also get
+a tool-call hook that intercepts `Read` on supported source files when
+they exceed `--min-lines` (default 200) and substitutes the outline.
+The other targets receive the prompt only.
+
+The legacy manual install via `ast-outline prompt` is still supported
+for power users:
 
 ```bash
 ast-outline prompt >> AGENTS.md
-ast-outline prompt >> .claude/CLAUDE.md
 ast-outline prompt | pbcopy   # macOS clipboard
 ```
 

--- a/README.md
+++ b/README.md
@@ -145,8 +145,7 @@ a tool-call hook that intercepts `Read` on supported source files when
 they exceed `--min-lines` (default 200) and substitutes the outline.
 The other targets receive the prompt only.
 
-The legacy manual install via `ast-outline prompt` is still supported
-for power users:
+Manual install via `ast-outline prompt` (e.g. project-level):
 
 ```bash
 ast-outline prompt >> AGENTS.md

--- a/src/hook/claude_code.rs
+++ b/src/hook/claude_code.rs
@@ -1,0 +1,107 @@
+use std::io::{self, Read, Write};
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use super::decide::{decide, DecideOpts};
+use super::event::{Decision, ToolCallEvent};
+
+#[derive(Debug, Deserialize)]
+struct InputEvent {
+    tool_name: String,
+    #[serde(default)]
+    tool_input: ToolInput,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct ToolInput {
+    #[serde(default)]
+    file_path: Option<PathBuf>,
+    #[serde(default)]
+    offset: Option<u64>,
+    #[serde(default)]
+    limit: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+struct PassThroughResponse {
+    #[serde(rename = "continue")]
+    cont: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct SubstituteResponse {
+    decision: &'static str,
+    reason: String,
+}
+
+pub fn run(opts: DecideOpts) -> i32 {
+    let mut buf = String::new();
+    if io::stdin().read_to_string(&mut buf).is_err() {
+        return emit_pass_through();
+    }
+    let event: InputEvent = match serde_json::from_str(&buf) {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("ast-outline hook: bad stdin json: {}", e);
+            return emit_pass_through();
+        }
+    };
+    let event = ToolCallEvent {
+        tool_name: event.tool_name,
+        file_path: event.tool_input.file_path,
+        has_offset_or_limit: event.tool_input.offset.is_some()
+            || event.tool_input.limit.is_some(),
+    };
+    match decide(&event, &opts) {
+        Decision::PassThrough => emit_pass_through(),
+        Decision::Substitute { content } => emit_substitute(content),
+    }
+}
+
+fn emit_pass_through() -> i32 {
+    let r = PassThroughResponse { cont: true };
+    let _ = writeln!(io::stdout(), "{}", serde_json::to_string(&r).unwrap());
+    0
+}
+
+fn emit_substitute(content: String) -> i32 {
+    let r = SubstituteResponse {
+        decision: "block",
+        reason: content,
+    };
+    let _ = writeln!(io::stdout(), "{}", serde_json::to_string(&r).unwrap());
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn pass_through_response_serializes_with_continue_true() {
+        let r = PassThroughResponse { cont: true };
+        let s = serde_json::to_string(&r).unwrap();
+        assert!(s.contains("\"continue\":true"));
+    }
+
+    #[test]
+    fn substitute_response_serializes_with_decision_block() {
+        let r = SubstituteResponse {
+            decision: "block",
+            reason: "x".into(),
+        };
+        let s = serde_json::to_string(&r).unwrap();
+        assert!(s.contains("\"decision\":\"block\""));
+        assert!(s.contains("\"reason\":\"x\""));
+    }
+
+    #[test]
+    fn input_event_parses_minimal_shape() {
+        let json = r#"{"tool_name":"Read","tool_input":{"file_path":"a.rs"}}"#;
+        let e: InputEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(e.tool_name, "Read");
+        assert_eq!(e.tool_input.file_path, Some(PathBuf::from("a.rs")));
+    }
+}

--- a/src/hook/decide.rs
+++ b/src/hook/decide.rs
@@ -1,0 +1,182 @@
+use std::path::Path;
+
+use super::event::{Decision, ToolCallEvent};
+
+#[derive(Debug, Clone)]
+pub struct DecideOpts {
+    pub min_lines: usize,
+    pub always: bool,
+}
+
+pub fn decide(event: &ToolCallEvent, opts: &DecideOpts) -> Decision {
+    if event.tool_name != "Read" {
+        return Decision::PassThrough;
+    }
+    let Some(path) = event.file_path.as_deref() else {
+        return Decision::PassThrough;
+    };
+    if event.has_offset_or_limit {
+        return Decision::PassThrough;
+    }
+    if !is_supported_extension(path) {
+        return Decision::PassThrough;
+    }
+    if !opts.always {
+        match line_count_at_least(path, opts.min_lines) {
+            Ok(true) => {}
+            _ => return Decision::PassThrough,
+        }
+    }
+    match render_outline_for(path) {
+        Some(content) => Decision::Substitute {
+            content: format!(
+                "{}\n# ast-outline substituted full file. Re-read with offset/limit, or\n# `ast-outline show <file> <symbol>` for a body.\n",
+                content
+            ),
+        },
+        None => Decision::PassThrough,
+    }
+}
+
+fn is_supported_extension(path: &Path) -> bool {
+    let ext = path
+        .extension()
+        .and_then(|o| o.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    matches!(
+        ext.as_str(),
+        "rs" | "cs"
+            | "py"
+            | "pyi"
+            | "ts"
+            | "tsx"
+            | "js"
+            | "jsx"
+            | "mjs"
+            | "cjs"
+            | "java"
+            | "kt"
+            | "kts"
+            | "scala"
+            | "sc"
+            | "go"
+            | "md"
+            | "markdown"
+            | "mdx"
+            | "mdown"
+    )
+}
+
+fn line_count_at_least(path: &Path, threshold: usize) -> std::io::Result<bool> {
+    use std::io::{BufRead, BufReader};
+    let meta = std::fs::metadata(path)?;
+    if (meta.len() as usize) < threshold {
+        return Ok(false);
+    }
+    let f = std::fs::File::open(path)?;
+    let r = BufReader::new(f);
+    let mut count = 0usize;
+    for line in r.lines() {
+        line?;
+        count += 1;
+        if count >= threshold {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn render_outline_for(path: &Path) -> Option<String> {
+    let res = crate::main_helpers::parse_file_for_hook(path)?;
+    Some(crate::core::render_outline(
+        &res,
+        &crate::core::OutlineOptions::default(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn opts() -> DecideOpts {
+        DecideOpts {
+            min_lines: 200,
+            always: false,
+        }
+    }
+
+    fn ev(tool: &str, path: Option<PathBuf>, offset: bool) -> ToolCallEvent {
+        ToolCallEvent {
+            tool_name: tool.to_string(),
+            file_path: path,
+            has_offset_or_limit: offset,
+        }
+    }
+
+    #[test]
+    fn pass_through_for_non_read_tool() {
+        let d = decide(&ev("Bash", Some(PathBuf::from("a.rs")), false), &opts());
+        assert!(matches!(d, Decision::PassThrough));
+    }
+
+    #[test]
+    fn pass_through_when_offset_or_limit_set() {
+        let d = decide(&ev("Read", Some(PathBuf::from("a.rs")), true), &opts());
+        assert!(matches!(d, Decision::PassThrough));
+    }
+
+    #[test]
+    fn pass_through_for_unsupported_extension() {
+        let d = decide(
+            &ev("Read", Some(PathBuf::from("img.png")), false),
+            &opts(),
+        );
+        assert!(matches!(d, Decision::PassThrough));
+    }
+
+    #[test]
+    fn pass_through_when_below_threshold() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("small.rs");
+        std::fs::write(&p, "fn main() {}\n").unwrap();
+        let d = decide(&ev("Read", Some(p), false), &opts());
+        assert!(matches!(d, Decision::PassThrough));
+    }
+
+    #[test]
+    fn substitutes_when_above_threshold() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("big.rs");
+        let mut s = String::new();
+        for i in 0..300 {
+            s.push_str(&format!("fn f{}() {{}}\n", i));
+        }
+        std::fs::write(&p, &s).unwrap();
+        let d = decide(&ev("Read", Some(p), false), &opts());
+        match d {
+            Decision::Substitute { content } => {
+                assert!(content.contains("# ast-outline substituted"));
+                assert!(content.contains("fn f"));
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn always_flag_substitutes_below_threshold() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("small.rs");
+        std::fs::write(&p, "fn main() {}\n").unwrap();
+        let d = decide(
+            &ev("Read", Some(p), false),
+            &DecideOpts {
+                min_lines: 200,
+                always: true,
+            },
+        );
+        assert!(matches!(d, Decision::Substitute { .. }));
+    }
+}

--- a/src/hook/event.rs
+++ b/src/hook/event.rs
@@ -1,0 +1,14 @@
+use std::path::PathBuf;
+
+#[derive(Debug, Clone)]
+pub struct ToolCallEvent {
+    pub tool_name: String,
+    pub file_path: Option<PathBuf>,
+    pub has_offset_or_limit: bool,
+}
+
+#[derive(Debug, Clone)]
+pub enum Decision {
+    PassThrough,
+    Substitute { content: String },
+}

--- a/src/hook/gemini.rs
+++ b/src/hook/gemini.rs
@@ -1,0 +1,108 @@
+//! Gemini CLI hook protocol shim.
+//!
+//! Gemini's BeforeTool event JSON shape per the official docs:
+//!   { "tool_name": "read_file",
+//!     "tool_input": { "absolute_path": "...", "offset": ..., "limit": ... } }
+//!
+//! Response shape matches Claude Code's:
+//!   pass-through: { "continue": true }
+//!   substitute:   { "decision": "block", "reason": "<content>" }
+
+use std::io::{self, Read, Write};
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use super::decide::{decide, DecideOpts};
+use super::event::{Decision, ToolCallEvent};
+
+#[derive(Debug, Deserialize)]
+struct InputEvent {
+    tool_name: String,
+    #[serde(default)]
+    tool_input: ToolInput,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct ToolInput {
+    #[serde(default)]
+    absolute_path: Option<PathBuf>,
+    #[serde(default)]
+    offset: Option<u64>,
+    #[serde(default)]
+    limit: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+struct PassThroughResponse {
+    #[serde(rename = "continue")]
+    cont: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct SubstituteResponse {
+    decision: &'static str,
+    reason: String,
+}
+
+pub fn run(opts: DecideOpts) -> i32 {
+    let mut buf = String::new();
+    if io::stdin().read_to_string(&mut buf).is_err() {
+        return emit_pass_through();
+    }
+    let event: InputEvent = match serde_json::from_str(&buf) {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("ast-outline hook: bad stdin json: {}", e);
+            return emit_pass_through();
+        }
+    };
+    // decide() keys on "Read"; Gemini sends "read_file".
+    let normalized_tool = if event.tool_name == "read_file" {
+        "Read".to_string()
+    } else {
+        event.tool_name
+    };
+    let event = ToolCallEvent {
+        tool_name: normalized_tool,
+        file_path: event.tool_input.absolute_path,
+        has_offset_or_limit: event.tool_input.offset.is_some()
+            || event.tool_input.limit.is_some(),
+    };
+    match decide(&event, &opts) {
+        Decision::PassThrough => emit_pass_through(),
+        Decision::Substitute { content } => emit_substitute(content),
+    }
+}
+
+fn emit_pass_through() -> i32 {
+    let r = PassThroughResponse { cont: true };
+    let _ = writeln!(io::stdout(), "{}", serde_json::to_string(&r).unwrap());
+    0
+}
+
+fn emit_substitute(content: String) -> i32 {
+    let r = SubstituteResponse {
+        decision: "block",
+        reason: content,
+    };
+    let _ = writeln!(io::stdout(), "{}", serde_json::to_string(&r).unwrap());
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn input_event_parses_gemini_shape() {
+        let json = r#"{"tool_name":"read_file","tool_input":{"absolute_path":"/x/a.rs"}}"#;
+        let e: InputEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(e.tool_name, "read_file");
+        assert_eq!(
+            e.tool_input.absolute_path,
+            Some(PathBuf::from("/x/a.rs"))
+        );
+    }
+}

--- a/src/hook/mod.rs
+++ b/src/hook/mod.rs
@@ -1,1 +1,2 @@
 pub mod event;
+pub mod decide;

--- a/src/hook/mod.rs
+++ b/src/hook/mod.rs
@@ -1,1 +1,1 @@
-// Implemented in Task 12.
+pub mod event;

--- a/src/hook/mod.rs
+++ b/src/hook/mod.rs
@@ -1,2 +1,18 @@
 pub mod event;
 pub mod decide;
+pub mod claude_code;
+pub mod gemini;
+
+use decide::DecideOpts;
+
+pub fn run(protocol: &str, min_lines: usize, always: bool) -> i32 {
+    let opts = DecideOpts { min_lines, always };
+    match protocol {
+        "claude-code" => claude_code::run(opts),
+        "gemini" => gemini::run(opts),
+        other => {
+            eprintln!("ast-outline hook: unknown --protocol '{}'", other);
+            2
+        }
+    }
+}

--- a/src/hook/mod.rs
+++ b/src/hook/mod.rs
@@ -1,0 +1,1 @@
+// Implemented in Task 12.

--- a/src/installers/aider.rs
+++ b/src/installers/aider.rs
@@ -1,0 +1,169 @@
+use std::path::PathBuf;
+
+use serde_yaml::{Mapping, Value as Yaml};
+
+use super::io::{atomic_write, read_optional};
+use super::paths;
+use super::{common, Change, Detection, InstallOpts, Installer, Scope, Status};
+use crate::prompt::AGENT_PROMPT;
+
+pub struct Aider;
+
+impl Aider {
+    fn config_path(&self, scope: &Scope) -> Result<PathBuf, String> {
+        match scope {
+            Scope::Local(root) => Ok(root.join(".aider.conf.yml")),
+            Scope::Global => paths::under_home(".aider.conf.yml"),
+        }
+    }
+    fn conventions_path(&self, scope: &Scope) -> Result<PathBuf, String> {
+        match scope {
+            Scope::Local(root) => Ok(root.join("CONVENTIONS.md")),
+            Scope::Global => paths::under_home(".aider/CONVENTIONS.md"),
+        }
+    }
+    fn relative_conventions(&self, scope: &Scope) -> &'static str {
+        match scope {
+            Scope::Local(_) => "CONVENTIONS.md",
+            Scope::Global => "~/.aider/CONVENTIONS.md",
+        }
+    }
+}
+
+impl Installer for Aider {
+    fn name(&self) -> &'static str {
+        "aider"
+    }
+
+    fn detect(&self, scope: &Scope) -> Detection {
+        let p = match self.config_path(scope) {
+            Ok(p) => p,
+            Err(_) => {
+                return Detection {
+                    present: false,
+                    config_root: None,
+                }
+            }
+        };
+        let root = p.parent().map(|p| p.to_path_buf());
+        Detection {
+            present: root.as_ref().map(|r| r.exists()).unwrap_or(false),
+            config_root: root,
+        }
+    }
+
+    fn install_prompt(&self, scope: &Scope, opts: &InstallOpts) -> Result<Change, String> {
+        let conv_path = self.conventions_path(scope)?;
+        let change = common::install_prompt_in(&conv_path, AGENT_PROMPT, opts)?;
+
+        let cfg_path = self.config_path(scope)?;
+        let existing = read_optional(&cfg_path)?.unwrap_or_default();
+        let mut root: Yaml = if existing.trim().is_empty() {
+            Yaml::Mapping(Mapping::new())
+        } else {
+            serde_yaml::from_str(&existing)
+                .map_err(|e| format!("parse {}: {}", cfg_path.display(), e))?
+        };
+        let map = root
+            .as_mapping_mut()
+            .ok_or_else(|| format!("{}: top level must be a mapping", cfg_path.display()))?;
+        let key = Yaml::String("read".into());
+        let entry = map.entry(key).or_insert(Yaml::Sequence(Vec::new()));
+        if let Yaml::String(s) = entry.clone() {
+            *entry = Yaml::Sequence(vec![Yaml::String(s)]);
+        }
+        let target = self.relative_conventions(scope).to_string();
+        if let Yaml::Sequence(seq) = entry {
+            let already = seq.iter().any(|v| v.as_str() == Some(&target));
+            if !already {
+                seq.push(Yaml::String(target));
+                if !opts.dry_run {
+                    let yaml = serde_yaml::to_string(&root)
+                        .map_err(|e| format!("serialize yaml: {}", e))?;
+                    atomic_write(&cfg_path, &yaml)?;
+                }
+            }
+        }
+        Ok(change)
+    }
+
+    fn install_hook(&self, _scope: &Scope, _opts: &InstallOpts) -> Result<Change, String> {
+        Ok(Change::NotApplicable)
+    }
+
+    fn uninstall(&self, scope: &Scope, opts: &InstallOpts) -> Result<Vec<Change>, String> {
+        let mut changes = Vec::new();
+        if let Some(c) = common::uninstall_prompt_in(&self.conventions_path(scope)?, opts)? {
+            changes.push(c);
+        }
+
+        let cfg_path = self.config_path(scope)?;
+        if let Some(existing) = read_optional(&cfg_path)? {
+            if let Ok(mut root) = serde_yaml::from_str::<Yaml>(&existing) {
+                let target = self.relative_conventions(scope).to_string();
+                let read_key = Yaml::String("read".into());
+                let mut removed_any = false;
+                if let Some(map) = root.as_mapping_mut() {
+                    if let Some(Yaml::Sequence(seq)) = map.get_mut(&read_key) {
+                        let before = seq.len();
+                        seq.retain(|v| v.as_str() != Some(&target));
+                        removed_any = seq.len() != before;
+                        if seq.is_empty() {
+                            map.remove(&read_key);
+                        }
+                    }
+                }
+                if removed_any {
+                    if !opts.dry_run {
+                        let yaml = serde_yaml::to_string(&root)
+                            .map_err(|e| format!("serialize yaml: {}", e))?;
+                        atomic_write(&cfg_path, &yaml)?;
+                    }
+                    changes.push(Change::Removed(cfg_path));
+                }
+            }
+        }
+        Ok(changes)
+    }
+
+    fn status(&self, scope: &Scope) -> Status {
+        common::status_for_prompt_only(self.conventions_path(scope).ok().as_deref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn install_writes_conventions_and_yaml_read_entry() {
+        let dir = TempDir::new().unwrap();
+        let scope = Scope::Local(dir.path().to_path_buf());
+        Aider
+            .install_prompt(&scope, &InstallOpts::default())
+            .unwrap();
+
+        let conv = std::fs::read_to_string(dir.path().join("CONVENTIONS.md")).unwrap();
+        assert!(conv.contains("ast-outline:begin"));
+
+        let yaml = std::fs::read_to_string(dir.path().join(".aider.conf.yml")).unwrap();
+        assert!(yaml.contains("CONVENTIONS.md"));
+        assert!(yaml.contains("read:"));
+    }
+
+    #[test]
+    fn install_idempotent_does_not_duplicate_yaml_entry() {
+        let dir = TempDir::new().unwrap();
+        let scope = Scope::Local(dir.path().to_path_buf());
+        Aider
+            .install_prompt(&scope, &InstallOpts::default())
+            .unwrap();
+        Aider
+            .install_prompt(&scope, &InstallOpts::default())
+            .unwrap();
+        let yaml = std::fs::read_to_string(dir.path().join(".aider.conf.yml")).unwrap();
+        let count = yaml.matches("CONVENTIONS.md").count();
+        assert_eq!(count, 1);
+    }
+}

--- a/src/installers/aider.rs
+++ b/src/installers/aider.rs
@@ -36,19 +36,13 @@ impl Installer for Aider {
     }
 
     fn detect(&self, scope: &Scope) -> Detection {
-        let p = match self.config_path(scope) {
-            Ok(p) => p,
-            Err(_) => {
-                return Detection {
-                    present: false,
-                    config_root: None,
-                }
-            }
-        };
-        let root = p.parent().map(|p| p.to_path_buf());
+        let cfg_exists = self
+            .config_path(scope)
+            .ok()
+            .map(|p| p.exists())
+            .unwrap_or(false);
         Detection {
-            present: root.as_ref().map(|r| r.exists()).unwrap_or(false),
-            config_root: root,
+            present: cfg_exists || paths::binary_on_path("aider"),
         }
     }
 

--- a/src/installers/claude_code.rs
+++ b/src/installers/claude_code.rs
@@ -1,0 +1,231 @@
+use std::path::PathBuf;
+
+use serde_json::{json, Value};
+
+use super::json_hook::MARKER;
+use super::paths;
+use super::{common, Change, Detection, InstallOpts, Installer, Scope, Status};
+use crate::prompt::AGENT_PROMPT;
+
+pub struct ClaudeCode;
+
+const HOOK_PATH: &[&str] = &["hooks", "PreToolUse"];
+
+impl ClaudeCode {
+    fn prompt_path(&self, scope: &Scope) -> Result<PathBuf, String> {
+        match scope {
+            Scope::Local(root) => Ok(root.join("CLAUDE.md")),
+            Scope::Global => paths::under_home(".claude/CLAUDE.md"),
+        }
+    }
+    fn settings_path(&self, scope: &Scope) -> Result<PathBuf, String> {
+        match scope {
+            Scope::Local(root) => Ok(root.join(".claude/settings.json")),
+            Scope::Global => paths::under_home(".claude/settings.json"),
+        }
+    }
+    fn hook_command(&self, opts: &InstallOpts) -> String {
+        let mut cmd = format!(
+            "ast-outline hook --protocol claude-code --min-lines {}",
+            opts.min_lines
+        );
+        if opts.always {
+            cmd.push_str(" --always");
+        }
+        cmd
+    }
+    fn hook_entry(&self, opts: &InstallOpts) -> Value {
+        json!({
+            "matcher": "Read",
+            "hooks": [{ "type": "command", "command": self.hook_command(opts) }]
+        })
+    }
+}
+
+fn matches_entry(v: &Value) -> bool {
+    v.get("matcher").and_then(|m| m.as_str()) == Some("Read")
+        && v.get("hooks")
+            .and_then(|h| h.as_array())
+            .and_then(|h| h.first())
+            .and_then(|h0| h0.get("command"))
+            .and_then(|c| c.as_str())
+            .map(|c| c.starts_with(MARKER))
+            .unwrap_or(false)
+}
+
+impl Installer for ClaudeCode {
+    fn name(&self) -> &'static str {
+        "claude-code"
+    }
+
+    fn detect(&self, scope: &Scope) -> Detection {
+        let p = match self.prompt_path(scope) {
+            Ok(p) => p,
+            Err(_) => {
+                return Detection {
+                    present: false,
+                    config_root: None,
+                }
+            }
+        };
+        let root = p.parent().map(|p| p.to_path_buf());
+        Detection {
+            present: root.as_ref().map(|r| r.exists()).unwrap_or(false),
+            config_root: root,
+        }
+    }
+
+    fn install_prompt(&self, scope: &Scope, opts: &InstallOpts) -> Result<Change, String> {
+        common::install_prompt_in(&self.prompt_path(scope)?, AGENT_PROMPT, opts)
+    }
+
+    fn install_hook(&self, scope: &Scope, opts: &InstallOpts) -> Result<Change, String> {
+        common::install_json_hook_in(
+            &self.settings_path(scope)?,
+            HOOK_PATH,
+            self.hook_entry(opts),
+            matches_entry,
+            opts,
+        )
+    }
+
+    fn uninstall(&self, scope: &Scope, opts: &InstallOpts) -> Result<Vec<Change>, String> {
+        let mut changes = Vec::new();
+        if let Some(c) = common::uninstall_prompt_in(&self.prompt_path(scope)?, opts)? {
+            changes.push(c);
+        }
+        if let Some(c) =
+            common::uninstall_json_hook_in(&self.settings_path(scope)?, HOOK_PATH, matches_entry, opts)?
+        {
+            changes.push(c);
+        }
+        Ok(changes)
+    }
+
+    fn status(&self, scope: &Scope) -> Status {
+        common::status_for(
+            self.prompt_path(scope).ok().as_deref(),
+            self.settings_path(scope).ok().as_deref(),
+            HOOK_PATH,
+            matches_entry,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn local_scope(dir: &TempDir) -> Scope {
+        Scope::Local(dir.path().to_path_buf())
+    }
+
+    #[test]
+    fn install_prompt_creates_file_with_marker_block() {
+        let dir = TempDir::new().unwrap();
+        let scope = local_scope(&dir);
+        let change = ClaudeCode
+            .install_prompt(&scope, &InstallOpts::default())
+            .unwrap();
+        assert!(matches!(change, Change::Created(_)));
+        let contents = std::fs::read_to_string(dir.path().join("CLAUDE.md")).unwrap();
+        assert!(contents.contains("<!-- ast-outline:begin"));
+        assert!(contents.contains("ast-outline"));
+    }
+
+    #[test]
+    fn install_prompt_idempotent() {
+        let dir = TempDir::new().unwrap();
+        let scope = local_scope(&dir);
+        ClaudeCode
+            .install_prompt(&scope, &InstallOpts::default())
+            .unwrap();
+        let after_first = std::fs::read_to_string(dir.path().join("CLAUDE.md")).unwrap();
+        ClaudeCode
+            .install_prompt(&scope, &InstallOpts::default())
+            .unwrap();
+        let after_second = std::fs::read_to_string(dir.path().join("CLAUDE.md")).unwrap();
+        assert_eq!(after_first, after_second);
+    }
+
+    #[test]
+    fn install_hook_creates_settings_with_entry() {
+        let dir = TempDir::new().unwrap();
+        let scope = local_scope(&dir);
+        let change = ClaudeCode
+            .install_hook(&scope, &InstallOpts::default())
+            .unwrap();
+        assert!(matches!(change, Change::Created(_)));
+        let contents = std::fs::read_to_string(dir.path().join(".claude/settings.json")).unwrap();
+        assert!(contents.contains("--protocol claude-code"));
+        assert!(contents.contains("\"matcher\": \"Read\""));
+    }
+
+    #[test]
+    fn install_hook_preserves_other_hooks() {
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir_all(dir.path().join(".claude")).unwrap();
+        std::fs::write(
+            dir.path().join(".claude/settings.json"),
+            r#"{"hooks":{"PreToolUse":[{"matcher":"Edit","hooks":[{"type":"command","command":"echo hi"}]}]}}"#,
+        ).unwrap();
+        let scope = local_scope(&dir);
+        ClaudeCode
+            .install_hook(&scope, &InstallOpts::default())
+            .unwrap();
+        let contents = std::fs::read_to_string(dir.path().join(".claude/settings.json")).unwrap();
+        assert!(contents.contains("echo hi"));
+        assert!(contents.contains("--protocol claude-code"));
+    }
+
+    #[test]
+    fn uninstall_removes_block_and_hook_keeps_siblings() {
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir_all(dir.path().join(".claude")).unwrap();
+        std::fs::write(
+            dir.path().join(".claude/settings.json"),
+            r#"{"hooks":{"PreToolUse":[{"matcher":"Edit","hooks":[{"type":"command","command":"echo hi"}]}]}}"#,
+        ).unwrap();
+        let scope = local_scope(&dir);
+        let opts = InstallOpts::default();
+        ClaudeCode.install_prompt(&scope, &opts).unwrap();
+        ClaudeCode.install_hook(&scope, &opts).unwrap();
+        let removed = ClaudeCode.uninstall(&scope, &opts).unwrap();
+        assert_eq!(removed.len(), 2);
+        let prompt = std::fs::read_to_string(dir.path().join("CLAUDE.md")).unwrap();
+        assert!(!prompt.contains("ast-outline:begin"));
+        let settings = std::fs::read_to_string(dir.path().join(".claude/settings.json")).unwrap();
+        assert!(settings.contains("echo hi"));
+        assert!(!settings.contains("ast-outline hook"));
+    }
+
+    #[test]
+    fn status_reports_versions_and_flags() {
+        let dir = TempDir::new().unwrap();
+        let scope = local_scope(&dir);
+        let s0 = ClaudeCode.status(&scope);
+        assert!(!s0.prompt_installed);
+        assert!(!s0.hook_installed);
+        ClaudeCode
+            .install_prompt(&scope, &InstallOpts::default())
+            .unwrap();
+        ClaudeCode
+            .install_hook(&scope, &InstallOpts::default())
+            .unwrap();
+        let s1 = ClaudeCode.status(&scope);
+        assert!(s1.prompt_installed);
+        assert!(s1.hook_installed);
+        assert_eq!(s1.prompt_version.as_deref(), Some(env!("CARGO_PKG_VERSION")));
+    }
+
+    #[test]
+    fn dry_run_does_not_write() {
+        let dir = TempDir::new().unwrap();
+        let scope = local_scope(&dir);
+        let mut opts = InstallOpts::default();
+        opts.dry_run = true;
+        ClaudeCode.install_prompt(&scope, &opts).unwrap();
+        assert!(!dir.path().join("CLAUDE.md").exists());
+    }
+}

--- a/src/installers/claude_code.rs
+++ b/src/installers/claude_code.rs
@@ -59,19 +59,14 @@ impl Installer for ClaudeCode {
     }
 
     fn detect(&self, scope: &Scope) -> Detection {
-        let p = match self.prompt_path(scope) {
-            Ok(p) => p,
-            Err(_) => {
-                return Detection {
-                    present: false,
-                    config_root: None,
-                }
-            }
-        };
-        let root = p.parent().map(|p| p.to_path_buf());
+        let dir_exists = self
+            .prompt_path(scope)
+            .ok()
+            .and_then(|p| p.parent().map(|r| r.to_path_buf()))
+            .map(|r| r.exists())
+            .unwrap_or(false);
         Detection {
-            present: root.as_ref().map(|r| r.exists()).unwrap_or(false),
-            config_root: root,
+            present: dir_exists || paths::binary_on_path("claude"),
         }
     }
 

--- a/src/installers/codex.rs
+++ b/src/installers/codex.rs
@@ -21,19 +21,14 @@ impl Installer for Codex {
     }
 
     fn detect(&self, scope: &Scope) -> Detection {
-        let p = match self.prompt_path(scope) {
-            Ok(p) => p,
-            Err(_) => {
-                return Detection {
-                    present: false,
-                    config_root: None,
-                }
-            }
-        };
-        let root = p.parent().map(|p| p.to_path_buf());
+        let dir_exists = self
+            .prompt_path(scope)
+            .ok()
+            .and_then(|p| p.parent().map(|r| r.to_path_buf()))
+            .map(|r| r.exists())
+            .unwrap_or(false);
         Detection {
-            present: root.as_ref().map(|r| r.exists()).unwrap_or(false),
-            config_root: root,
+            present: dir_exists || paths::binary_on_path("codex"),
         }
     }
 

--- a/src/installers/codex.rs
+++ b/src/installers/codex.rs
@@ -1,0 +1,78 @@
+use std::path::PathBuf;
+
+use super::paths;
+use super::{common, Change, Detection, InstallOpts, Installer, Scope, Status};
+use crate::prompt::AGENT_PROMPT;
+
+pub struct Codex;
+
+impl Codex {
+    fn prompt_path(&self, scope: &Scope) -> Result<PathBuf, String> {
+        match scope {
+            Scope::Local(root) => Ok(root.join("AGENTS.md")),
+            Scope::Global => paths::under_home(".codex/AGENTS.md"),
+        }
+    }
+}
+
+impl Installer for Codex {
+    fn name(&self) -> &'static str {
+        "codex"
+    }
+
+    fn detect(&self, scope: &Scope) -> Detection {
+        let p = match self.prompt_path(scope) {
+            Ok(p) => p,
+            Err(_) => {
+                return Detection {
+                    present: false,
+                    config_root: None,
+                }
+            }
+        };
+        let root = p.parent().map(|p| p.to_path_buf());
+        Detection {
+            present: root.as_ref().map(|r| r.exists()).unwrap_or(false),
+            config_root: root,
+        }
+    }
+
+    fn install_prompt(&self, scope: &Scope, opts: &InstallOpts) -> Result<Change, String> {
+        common::install_prompt_in(&self.prompt_path(scope)?, AGENT_PROMPT, opts)
+    }
+
+    fn install_hook(&self, _scope: &Scope, _opts: &InstallOpts) -> Result<Change, String> {
+        Ok(Change::NotApplicable)
+    }
+
+    fn uninstall(&self, scope: &Scope, opts: &InstallOpts) -> Result<Vec<Change>, String> {
+        let mut changes = Vec::new();
+        if let Some(c) = common::uninstall_prompt_in(&self.prompt_path(scope)?, opts)? {
+            changes.push(c);
+        }
+        Ok(changes)
+    }
+
+    fn status(&self, scope: &Scope) -> Status {
+        common::status_for_prompt_only(self.prompt_path(scope).ok().as_deref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn install_writes_agents_md() {
+        let dir = TempDir::new().unwrap();
+        let scope = Scope::Local(dir.path().to_path_buf());
+        Codex
+            .install_prompt(&scope, &InstallOpts::default())
+            .unwrap();
+        let p = dir.path().join("AGENTS.md");
+        assert!(p.exists());
+        let contents = std::fs::read_to_string(&p).unwrap();
+        assert!(contents.contains("ast-outline:begin"));
+    }
+}

--- a/src/installers/common.rs
+++ b/src/installers/common.rs
@@ -1,0 +1,162 @@
+use std::path::Path;
+
+use serde_json::Value;
+
+use super::io::{atomic_write, read_optional};
+use super::json_hook;
+use super::marker_block::{self, ApplyOutcome};
+use super::{Change, InstallOpts, Status};
+
+pub fn install_prompt_in(
+    path: &Path,
+    snippet: &str,
+    opts: &InstallOpts,
+) -> Result<Change, String> {
+    let existing = read_optional(path)?.unwrap_or_default();
+    let body = snippet.trim_end_matches('\n').to_string() + "\n";
+    let (new_contents, outcome) = marker_block::apply(
+        &existing,
+        &body,
+        &body,
+        snippet,
+        env!("CARGO_PKG_VERSION"),
+        opts.force,
+    );
+    match outcome {
+        ApplyOutcome::UserEditsBlocked(diff) => Err(format!(
+            "{}: user edits inside marker block; pass --force to overwrite\n{}",
+            path.display(),
+            diff
+        )),
+        _ => {
+            if existing == new_contents {
+                return Ok(Change::Skipped {
+                    path: path.to_path_buf(),
+                    reason: "already up to date".into(),
+                });
+            }
+            if !opts.dry_run {
+                atomic_write(path, &new_contents)?;
+            }
+            Ok(if existing.is_empty() {
+                Change::Created(path.to_path_buf())
+            } else {
+                Change::Updated(path.to_path_buf())
+            })
+        }
+    }
+}
+
+pub fn install_json_hook_in<F>(
+    path: &Path,
+    hook_path: &[&str],
+    entry: Value,
+    matches: F,
+    opts: &InstallOpts,
+) -> Result<Change, String>
+where
+    F: Fn(&Value) -> bool,
+{
+    let existing = read_optional(path)?.unwrap_or_else(|| "{}".into());
+    let mut root: Value = serde_json::from_str(&existing)
+        .map_err(|e| format!("parse {}: {}", path.display(), e))?;
+    let modified = json_hook::upsert(&mut root, hook_path, entry, matches);
+    if !modified {
+        return Ok(Change::Skipped {
+            path: path.to_path_buf(),
+            reason: "already up to date".into(),
+        });
+    }
+    let new_contents = serde_json::to_string_pretty(&root).unwrap() + "\n";
+    if !opts.dry_run {
+        atomic_write(path, &new_contents)?;
+    }
+    Ok(if existing.trim() == "{}" || existing.is_empty() {
+        Change::Created(path.to_path_buf())
+    } else {
+        Change::Updated(path.to_path_buf())
+    })
+}
+
+pub fn uninstall_prompt_in(path: &Path, opts: &InstallOpts) -> Result<Option<Change>, String> {
+    let Some(existing) = read_optional(path)? else {
+        return Ok(None);
+    };
+    let (out, removed) = marker_block::remove(&existing);
+    if !removed {
+        return Ok(None);
+    }
+    if !opts.dry_run {
+        atomic_write(path, &out)?;
+    }
+    Ok(Some(Change::Removed(path.to_path_buf())))
+}
+
+pub fn uninstall_json_hook_in<F>(
+    path: &Path,
+    hook_path: &[&str],
+    matches: F,
+    opts: &InstallOpts,
+) -> Result<Option<Change>, String>
+where
+    F: Fn(&Value) -> bool,
+{
+    let Some(existing) = read_optional(path)? else {
+        return Ok(None);
+    };
+    let mut root: Value = serde_json::from_str(&existing)
+        .map_err(|e| format!("parse {}: {}", path.display(), e))?;
+    if !json_hook::remove(&mut root, hook_path, matches) {
+        return Ok(None);
+    }
+    let new_contents = serde_json::to_string_pretty(&root).unwrap() + "\n";
+    if !opts.dry_run {
+        atomic_write(path, &new_contents)?;
+    }
+    Ok(Some(Change::Removed(path.to_path_buf())))
+}
+
+pub fn status_for<F>(
+    prompt_path: Option<&Path>,
+    settings_path: Option<&Path>,
+    hook_path: &[&str],
+    matches: F,
+) -> Status
+where
+    F: Fn(&Value) -> bool,
+{
+    let mut s = Status {
+        prompt_installed: false,
+        prompt_version: None,
+        hook_installed: false,
+    };
+    if let Some(pp) = prompt_path {
+        if let Ok(Some(contents)) = read_optional(pp) {
+            s.prompt_version = marker_block::installed_version(&contents);
+            s.prompt_installed = s.prompt_version.is_some();
+        }
+    }
+    if let Some(sp) = settings_path {
+        if let Ok(Some(contents)) = read_optional(sp) {
+            if let Ok(root) = serde_json::from_str::<Value>(&contents) {
+                s.hook_installed = json_hook::is_installed(&root, hook_path, matches);
+            }
+        }
+    }
+    s
+}
+
+pub fn status_for_prompt_only(prompt_path: Option<&Path>) -> Status {
+    let mut s = Status {
+        prompt_installed: false,
+        prompt_version: None,
+        hook_installed: false,
+    };
+    if let Some(pp) = prompt_path {
+        if let Ok(Some(contents)) = read_optional(pp) {
+            s.prompt_version = marker_block::installed_version(&contents);
+            s.prompt_installed = s.prompt_version.is_some();
+        }
+    }
+    s
+}

--- a/src/installers/copilot.rs
+++ b/src/installers/copilot.rs
@@ -1,0 +1,76 @@
+use std::path::PathBuf;
+
+use super::paths;
+use super::{common, Change, Detection, InstallOpts, Installer, Scope, Status};
+use crate::prompt::AGENT_PROMPT;
+
+pub struct Copilot;
+
+impl Copilot {
+    fn prompt_path(&self, scope: &Scope) -> Result<PathBuf, String> {
+        match scope {
+            Scope::Local(root) => Ok(root.join(".github/copilot-instructions.md")),
+            Scope::Global => paths::under_home(".copilot/copilot-instructions.md"),
+        }
+    }
+}
+
+impl Installer for Copilot {
+    fn name(&self) -> &'static str {
+        "copilot"
+    }
+
+    fn detect(&self, scope: &Scope) -> Detection {
+        let p = match self.prompt_path(scope) {
+            Ok(p) => p,
+            Err(_) => {
+                return Detection {
+                    present: false,
+                    config_root: None,
+                }
+            }
+        };
+        let root = p.parent().map(|p| p.to_path_buf());
+        Detection {
+            present: root.as_ref().map(|r| r.exists()).unwrap_or(false),
+            config_root: root,
+        }
+    }
+
+    fn install_prompt(&self, scope: &Scope, opts: &InstallOpts) -> Result<Change, String> {
+        common::install_prompt_in(&self.prompt_path(scope)?, AGENT_PROMPT, opts)
+    }
+
+    fn install_hook(&self, _scope: &Scope, _opts: &InstallOpts) -> Result<Change, String> {
+        Ok(Change::NotApplicable)
+    }
+
+    fn uninstall(&self, scope: &Scope, opts: &InstallOpts) -> Result<Vec<Change>, String> {
+        let mut changes = Vec::new();
+        if let Some(c) = common::uninstall_prompt_in(&self.prompt_path(scope)?, opts)? {
+            changes.push(c);
+        }
+        Ok(changes)
+    }
+
+    fn status(&self, scope: &Scope) -> Status {
+        common::status_for_prompt_only(self.prompt_path(scope).ok().as_deref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn install_writes_copilot_instructions() {
+        let dir = TempDir::new().unwrap();
+        let scope = Scope::Local(dir.path().to_path_buf());
+        Copilot
+            .install_prompt(&scope, &InstallOpts::default())
+            .unwrap();
+        let p = dir.path().join(".github/copilot-instructions.md");
+        assert!(p.exists());
+    }
+}

--- a/src/installers/copilot.rs
+++ b/src/installers/copilot.rs
@@ -21,19 +21,14 @@ impl Installer for Copilot {
     }
 
     fn detect(&self, scope: &Scope) -> Detection {
-        let p = match self.prompt_path(scope) {
-            Ok(p) => p,
-            Err(_) => {
-                return Detection {
-                    present: false,
-                    config_root: None,
-                }
-            }
-        };
-        let root = p.parent().map(|p| p.to_path_buf());
+        let dir_exists = self
+            .prompt_path(scope)
+            .ok()
+            .and_then(|p| p.parent().map(|r| r.to_path_buf()))
+            .map(|r| r.exists())
+            .unwrap_or(false);
         Detection {
-            present: root.as_ref().map(|r| r.exists()).unwrap_or(false),
-            config_root: root,
+            present: dir_exists || paths::binary_on_path("copilot"),
         }
     }
 

--- a/src/installers/cursor.rs
+++ b/src/installers/cursor.rs
@@ -1,0 +1,88 @@
+use std::path::PathBuf;
+
+use super::paths;
+use super::{common, Change, Detection, InstallOpts, Installer, Scope, Status};
+use crate::prompt::AGENT_PROMPT;
+
+pub struct Cursor;
+
+impl Cursor {
+    fn prompt_path(&self, scope: &Scope) -> Result<PathBuf, String> {
+        match scope {
+            Scope::Local(root) => Ok(root.join(".cursor/rules/ast-outline.mdc")),
+            Scope::Global => paths::under_home(".cursor/User Rules.md"),
+        }
+    }
+}
+
+impl Installer for Cursor {
+    fn name(&self) -> &'static str {
+        "cursor"
+    }
+
+    fn detect(&self, scope: &Scope) -> Detection {
+        let p = match self.prompt_path(scope) {
+            Ok(p) => p,
+            Err(_) => {
+                return Detection {
+                    present: false,
+                    config_root: None,
+                }
+            }
+        };
+        let root = p.parent().map(|p| p.to_path_buf());
+        Detection {
+            present: root.as_ref().map(|r| r.exists()).unwrap_or(false),
+            config_root: root,
+        }
+    }
+
+    fn install_prompt(&self, scope: &Scope, opts: &InstallOpts) -> Result<Change, String> {
+        common::install_prompt_in(&self.prompt_path(scope)?, AGENT_PROMPT, opts)
+    }
+
+    fn install_hook(&self, _scope: &Scope, _opts: &InstallOpts) -> Result<Change, String> {
+        Ok(Change::NotApplicable)
+    }
+
+    fn uninstall(&self, scope: &Scope, opts: &InstallOpts) -> Result<Vec<Change>, String> {
+        let mut changes = Vec::new();
+        if let Some(c) = common::uninstall_prompt_in(&self.prompt_path(scope)?, opts)? {
+            changes.push(c);
+        }
+        Ok(changes)
+    }
+
+    fn status(&self, scope: &Scope) -> Status {
+        common::status_for_prompt_only(self.prompt_path(scope).ok().as_deref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn install_writes_to_cursor_rules() {
+        let dir = TempDir::new().unwrap();
+        let scope = Scope::Local(dir.path().to_path_buf());
+        Cursor
+            .install_prompt(&scope, &InstallOpts::default())
+            .unwrap();
+        let p = dir.path().join(".cursor/rules/ast-outline.mdc");
+        assert!(p.exists());
+        let contents = std::fs::read_to_string(&p).unwrap();
+        assert!(contents.contains("ast-outline:begin"));
+    }
+
+    #[test]
+    fn install_hook_is_not_applicable() {
+        let dir = TempDir::new().unwrap();
+        let scope = Scope::Local(dir.path().to_path_buf());
+        let change = Cursor
+            .install_hook(&scope, &InstallOpts::default())
+            .unwrap();
+        assert!(matches!(change, Change::NotApplicable));
+    }
+}

--- a/src/installers/cursor.rs
+++ b/src/installers/cursor.rs
@@ -21,19 +21,14 @@ impl Installer for Cursor {
     }
 
     fn detect(&self, scope: &Scope) -> Detection {
-        let p = match self.prompt_path(scope) {
-            Ok(p) => p,
-            Err(_) => {
-                return Detection {
-                    present: false,
-                    config_root: None,
-                }
-            }
-        };
-        let root = p.parent().map(|p| p.to_path_buf());
+        let dir_exists = self
+            .prompt_path(scope)
+            .ok()
+            .and_then(|p| p.parent().map(|r| r.to_path_buf()))
+            .map(|r| r.exists())
+            .unwrap_or(false);
         Detection {
-            present: root.as_ref().map(|r| r.exists()).unwrap_or(false),
-            config_root: root,
+            present: dir_exists || paths::binary_on_path("cursor"),
         }
     }
 

--- a/src/installers/gemini.rs
+++ b/src/installers/gemini.rs
@@ -1,0 +1,140 @@
+use std::path::PathBuf;
+
+use serde_json::{json, Value};
+
+use super::json_hook::MARKER;
+use super::paths;
+use super::{common, Change, Detection, InstallOpts, Installer, Scope, Status};
+use crate::prompt::AGENT_PROMPT;
+
+pub struct Gemini;
+
+const HOOK_PATH: &[&str] = &["hooks", "BeforeTool"];
+const HOOK_NAME: &str = "ast-outline-read-interceptor";
+
+impl Gemini {
+    pub(crate) fn prompt_path(&self, scope: &Scope) -> Result<PathBuf, String> {
+        match scope {
+            Scope::Local(root) => Ok(root.join("GEMINI.md")),
+            Scope::Global => paths::under_home(".gemini/GEMINI.md"),
+        }
+    }
+    pub(crate) fn settings_path(&self, scope: &Scope) -> Result<PathBuf, String> {
+        match scope {
+            Scope::Local(root) => Ok(root.join(".gemini/settings.json")),
+            Scope::Global => paths::under_home(".gemini/settings.json"),
+        }
+    }
+    pub(crate) fn hook_entry(&self, opts: &InstallOpts) -> Value {
+        let mut cmd = format!(
+            "ast-outline hook --protocol gemini --min-lines {}",
+            opts.min_lines
+        );
+        if opts.always {
+            cmd.push_str(" --always");
+        }
+        json!({
+            "matcher": "read_file",
+            "hooks": [{ "name": HOOK_NAME, "type": "command", "command": cmd }]
+        })
+    }
+}
+
+pub(crate) fn matches_entry(v: &Value) -> bool {
+    v.get("matcher").and_then(|m| m.as_str()) == Some("read_file")
+        && v.get("hooks")
+            .and_then(|h| h.as_array())
+            .and_then(|h| h.first())
+            .map(|h0| {
+                h0.get("name").and_then(|n| n.as_str()) == Some(HOOK_NAME)
+                    || h0
+                        .get("command")
+                        .and_then(|c| c.as_str())
+                        .map(|c| c.starts_with(MARKER))
+                        .unwrap_or(false)
+            })
+            .unwrap_or(false)
+}
+
+impl Installer for Gemini {
+    fn name(&self) -> &'static str {
+        "gemini"
+    }
+
+    fn detect(&self, scope: &Scope) -> Detection {
+        let p = match self.prompt_path(scope) {
+            Ok(p) => p,
+            Err(_) => {
+                return Detection {
+                    present: false,
+                    config_root: None,
+                }
+            }
+        };
+        let root = p.parent().map(|p| p.to_path_buf());
+        Detection {
+            present: root.as_ref().map(|r| r.exists()).unwrap_or(false),
+            config_root: root,
+        }
+    }
+
+    fn install_prompt(&self, scope: &Scope, opts: &InstallOpts) -> Result<Change, String> {
+        common::install_prompt_in(&self.prompt_path(scope)?, AGENT_PROMPT, opts)
+    }
+
+    fn install_hook(&self, scope: &Scope, opts: &InstallOpts) -> Result<Change, String> {
+        common::install_json_hook_in(
+            &self.settings_path(scope)?,
+            HOOK_PATH,
+            self.hook_entry(opts),
+            matches_entry,
+            opts,
+        )
+    }
+
+    fn uninstall(&self, scope: &Scope, opts: &InstallOpts) -> Result<Vec<Change>, String> {
+        let mut changes = Vec::new();
+        if let Some(c) = common::uninstall_prompt_in(&self.prompt_path(scope)?, opts)? {
+            changes.push(c);
+        }
+        if let Some(c) =
+            common::uninstall_json_hook_in(&self.settings_path(scope)?, HOOK_PATH, matches_entry, opts)?
+        {
+            changes.push(c);
+        }
+        Ok(changes)
+    }
+
+    fn status(&self, scope: &Scope) -> Status {
+        common::status_for(
+            self.prompt_path(scope).ok().as_deref(),
+            self.settings_path(scope).ok().as_deref(),
+            HOOK_PATH,
+            matches_entry,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn install_creates_gemini_md_and_settings() {
+        let dir = TempDir::new().unwrap();
+        let scope = Scope::Local(dir.path().to_path_buf());
+        Gemini
+            .install_prompt(&scope, &InstallOpts::default())
+            .unwrap();
+        Gemini
+            .install_hook(&scope, &InstallOpts::default())
+            .unwrap();
+        let prompt = std::fs::read_to_string(dir.path().join("GEMINI.md")).unwrap();
+        let settings = std::fs::read_to_string(dir.path().join(".gemini/settings.json")).unwrap();
+        assert!(prompt.contains("ast-outline:begin"));
+        assert!(settings.contains("--protocol gemini"));
+        assert!(settings.contains("\"matcher\": \"read_file\""));
+        assert!(settings.contains("BeforeTool"));
+    }
+}

--- a/src/installers/gemini.rs
+++ b/src/installers/gemini.rs
@@ -62,19 +62,14 @@ impl Installer for Gemini {
     }
 
     fn detect(&self, scope: &Scope) -> Detection {
-        let p = match self.prompt_path(scope) {
-            Ok(p) => p,
-            Err(_) => {
-                return Detection {
-                    present: false,
-                    config_root: None,
-                }
-            }
-        };
-        let root = p.parent().map(|p| p.to_path_buf());
+        let dir_exists = self
+            .prompt_path(scope)
+            .ok()
+            .and_then(|p| p.parent().map(|r| r.to_path_buf()))
+            .map(|r| r.exists())
+            .unwrap_or(false);
         Detection {
-            present: root.as_ref().map(|r| r.exists()).unwrap_or(false),
-            config_root: root,
+            present: dir_exists || paths::binary_on_path("gemini"),
         }
     }
 

--- a/src/installers/io.rs
+++ b/src/installers/io.rs
@@ -1,0 +1,138 @@
+//! Filesystem primitives shared by every adapter.
+
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub fn read_optional(path: &Path) -> Result<Option<String>, String> {
+    match fs::read_to_string(path) {
+        Ok(s) => Ok(Some(s)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(format!("read {}: {}", path.display(), e)),
+    }
+}
+
+pub fn atomic_write(path: &Path, contents: &str) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("create dir {}: {}", parent.display(), e))?;
+    }
+    if path.exists() && !backup_exists(path) {
+        let backup = backup_path(path);
+        fs::copy(path, &backup).map_err(|e| format!("backup {}: {}", path.display(), e))?;
+    }
+    let tmp = path.with_extension(tmp_extension(path));
+    {
+        let mut f = fs::File::create(&tmp)
+            .map_err(|e| format!("create temp {}: {}", tmp.display(), e))?;
+        f.write_all(contents.as_bytes())
+            .map_err(|e| format!("write temp {}: {}", tmp.display(), e))?;
+        f.sync_all()
+            .map_err(|e| format!("fsync temp {}: {}", tmp.display(), e))?;
+    }
+    fs::rename(&tmp, path).map_err(|e| {
+        format!(
+            "rename temp {} -> {}: {}",
+            tmp.display(),
+            path.display(),
+            e
+        )
+    })?;
+    Ok(())
+}
+
+fn tmp_extension(path: &Path) -> String {
+    let prev = path.extension().and_then(|o| o.to_str()).unwrap_or("");
+    if prev.is_empty() {
+        "ast-outline.tmp".to_string()
+    } else {
+        format!("{}.ast-outline.tmp", prev)
+    }
+}
+
+fn backup_path(path: &Path) -> std::path::PathBuf {
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let prev = path.extension().and_then(|o| o.to_str()).unwrap_or("");
+    let suffix = if prev.is_empty() {
+        format!("ast-outline.bak.{}", ts)
+    } else {
+        format!("{}.ast-outline.bak.{}", prev, ts)
+    };
+    path.with_extension(suffix)
+}
+
+fn backup_exists(path: &Path) -> bool {
+    let parent = match path.parent() {
+        Some(p) => p,
+        None => return false,
+    };
+    let stem = match path.file_name().and_then(|o| o.to_str()) {
+        Some(s) => s,
+        None => return false,
+    };
+    let prefix = format!("{}.ast-outline.bak.", stem);
+    fs::read_dir(parent)
+        .ok()
+        .into_iter()
+        .flatten()
+        .filter_map(|e| e.ok())
+        .any(|e| {
+            e.file_name()
+                .to_str()
+                .map(|n| n.starts_with(&prefix))
+                .unwrap_or(false)
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn read_optional_returns_none_when_missing() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("missing.md");
+        assert_eq!(read_optional(&p).unwrap(), None);
+    }
+
+    #[test]
+    fn atomic_write_creates_file_and_parent() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("nested/sub/file.md");
+        atomic_write(&p, "hello").unwrap();
+        assert_eq!(fs::read_to_string(&p).unwrap(), "hello");
+    }
+
+    #[test]
+    fn atomic_write_backs_up_existing_once() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("file.md");
+        fs::write(&p, "original").unwrap();
+        atomic_write(&p, "v1").unwrap();
+        atomic_write(&p, "v2").unwrap();
+        let backups: Vec<_> = fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.file_name()
+                    .to_str()
+                    .map(|n| n.contains(".ast-outline.bak."))
+                    .unwrap_or(false)
+            })
+            .collect();
+        assert_eq!(
+            backups.len(),
+            1,
+            "expected exactly one backup, got {}",
+            backups.len()
+        );
+        let backup_contents = fs::read_to_string(backups[0].path()).unwrap();
+        assert_eq!(backup_contents, "original");
+        assert_eq!(fs::read_to_string(&p).unwrap(), "v2");
+    }
+}

--- a/src/installers/json_hook.rs
+++ b/src/installers/json_hook.rs
@@ -1,0 +1,1 @@
+// Implemented in Task 5.

--- a/src/installers/json_hook.rs
+++ b/src/installers/json_hook.rs
@@ -1,1 +1,193 @@
-// Implemented in Task 5.
+//! Manages our hook entry inside a JSON settings file. Caller supplies
+//! the JSON path-into-array and a predicate that identifies our entry —
+//! sibling entries are preserved.
+
+use serde_json::{json, Map, Value};
+
+/// String prefix every adapter's hook command begins with. Adapter
+/// predicates use this to find our entry without relying on a stable
+/// `id` field (Claude Code and Gemini hook entries do not have one).
+pub const MARKER: &str = "ast-outline hook";
+
+pub fn upsert<F>(root: &mut Value, path: &[&str], entry: Value, matches: F) -> bool
+where
+    F: Fn(&Value) -> bool,
+{
+    let arr = ensure_array(root, path);
+    if let Some(pos) = arr.iter().position(|v| matches(v)) {
+        if arr[pos] == entry {
+            return false;
+        }
+        arr[pos] = entry;
+    } else {
+        arr.push(entry);
+    }
+    true
+}
+
+pub fn remove<F>(root: &mut Value, path: &[&str], matches: F) -> bool
+where
+    F: Fn(&Value) -> bool,
+{
+    let arr = match navigate_array_mut(root, path) {
+        Some(a) => a,
+        None => return false,
+    };
+    let before = arr.len();
+    arr.retain(|v| !matches(v));
+    arr.len() != before
+}
+
+pub fn is_installed<F>(root: &Value, path: &[&str], matches: F) -> bool
+where
+    F: Fn(&Value) -> bool,
+{
+    let arr = match navigate_array(root, path) {
+        Some(a) => a,
+        None => return false,
+    };
+    arr.iter().any(|v| matches(v))
+}
+
+fn ensure_array<'a>(root: &'a mut Value, path: &[&str]) -> &'a mut Vec<Value> {
+    if !root.is_object() {
+        *root = Value::Object(Map::new());
+    }
+    let mut current = root;
+    for (i, key) in path.iter().enumerate() {
+        let is_last = i + 1 == path.len();
+        let obj = current.as_object_mut().unwrap();
+        let entry = obj
+            .entry((*key).to_string())
+            .or_insert_with(|| if is_last { json!([]) } else { json!({}) });
+        if is_last {
+            if !entry.is_array() {
+                *entry = json!([]);
+            }
+        } else if !entry.is_object() {
+            *entry = json!({});
+        }
+        current = entry;
+    }
+    current.as_array_mut().expect("ensure_array invariant")
+}
+
+fn navigate_array<'a>(root: &'a Value, path: &[&str]) -> Option<&'a Vec<Value>> {
+    let mut current = root;
+    for key in path {
+        current = current.as_object()?.get(*key)?;
+    }
+    current.as_array()
+}
+
+fn navigate_array_mut<'a>(root: &'a mut Value, path: &[&str]) -> Option<&'a mut Vec<Value>> {
+    let mut current = root;
+    for key in path {
+        current = current.as_object_mut()?.get_mut(*key)?;
+    }
+    current.as_array_mut()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry() -> Value {
+        json!({
+            "matcher": "Read",
+            "hooks": [{"type": "command", "command": "ast-outline hook --protocol claude-code"}]
+        })
+    }
+
+    fn predicate(v: &Value) -> bool {
+        v.get("matcher").and_then(|m| m.as_str()) == Some("Read")
+            && v.get("hooks")
+                .and_then(|h| h.as_array())
+                .and_then(|h| h.first())
+                .and_then(|h0| h0.get("command"))
+                .and_then(|c| c.as_str())
+                .map(|c| c.starts_with(MARKER))
+                .unwrap_or(false)
+    }
+
+    #[test]
+    fn upsert_into_empty_root() {
+        let mut root = json!({});
+        let modified = upsert(&mut root, &["hooks", "PreToolUse"], entry(), predicate);
+        assert!(modified);
+        assert!(is_installed(&root, &["hooks", "PreToolUse"], predicate));
+    }
+
+    #[test]
+    fn upsert_preserves_sibling_entries() {
+        let mut root = json!({
+            "hooks": {
+                "PreToolUse": [
+                    { "matcher": "Edit", "hooks": [{"type": "command", "command": "echo hi"}] }
+                ]
+            }
+        });
+        upsert(&mut root, &["hooks", "PreToolUse"], entry(), predicate);
+        let arr = root["hooks"]["PreToolUse"].as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0]["matcher"].as_str().unwrap(), "Edit");
+        assert_eq!(arr[1]["matcher"].as_str().unwrap(), "Read");
+    }
+
+    #[test]
+    fn upsert_replaces_in_place_by_predicate() {
+        let mut root = json!({
+            "hooks": {
+                "PreToolUse": [
+                    { "matcher": "Read", "hooks": [{"type": "command", "command": "ast-outline hook OLD"}] },
+                    { "matcher": "Edit", "hooks": [{"type": "command", "command": "echo hi"}] }
+                ]
+            }
+        });
+        upsert(&mut root, &["hooks", "PreToolUse"], entry(), predicate);
+        let arr = root["hooks"]["PreToolUse"].as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(
+            arr[0]["hooks"][0]["command"].as_str().unwrap(),
+            "ast-outline hook --protocol claude-code"
+        );
+        assert_eq!(arr[1]["matcher"].as_str().unwrap(), "Edit");
+    }
+
+    #[test]
+    fn upsert_idempotent_when_entry_unchanged() {
+        let mut root = json!({});
+        upsert(&mut root, &["hooks", "PreToolUse"], entry(), predicate);
+        let modified = upsert(&mut root, &["hooks", "PreToolUse"], entry(), predicate);
+        assert!(!modified);
+    }
+
+    #[test]
+    fn remove_drops_entry_keeps_siblings() {
+        let mut root = json!({
+            "hooks": {
+                "PreToolUse": [
+                    { "matcher": "Read", "hooks": [{"type": "command", "command": "ast-outline hook X"}] },
+                    { "matcher": "Edit", "hooks": [{"type": "command", "command": "echo Y"}] }
+                ]
+            }
+        });
+        let removed = remove(&mut root, &["hooks", "PreToolUse"], predicate);
+        assert!(removed);
+        let arr = root["hooks"]["PreToolUse"].as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["matcher"].as_str().unwrap(), "Edit");
+    }
+
+    #[test]
+    fn remove_noop_when_path_absent() {
+        let mut root = json!({});
+        assert!(!remove(&mut root, &["hooks", "PreToolUse"], predicate));
+    }
+
+    #[test]
+    fn is_installed_false_when_path_missing() {
+        let root = json!({});
+        assert!(!is_installed(&root, &["hooks", "PreToolUse"], predicate));
+    }
+}

--- a/src/installers/marker_block.rs
+++ b/src/installers/marker_block.rs
@@ -1,0 +1,1 @@
+// Implemented in Task 4.

--- a/src/installers/marker_block.rs
+++ b/src/installers/marker_block.rs
@@ -1,1 +1,239 @@
-// Implemented in Task 4.
+//! Manages a `<!-- ast-outline:begin v=X.Y.Z -->...<!-- ast-outline:end -->`
+//! block inside a prose file. Pure string operations — caller does I/O.
+
+const BEGIN_PREFIX: &str = "<!-- ast-outline:begin";
+const END_MARKER: &str = "<!-- ast-outline:end -->";
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum ApplyOutcome {
+    Appended,
+    Replaced,
+    WrappedLegacy,
+    UserEditsBlocked(String),
+}
+
+pub fn apply(
+    file_contents: &str,
+    new_block_body: &str,
+    expected_block_body: &str,
+    legacy_snippet: &str,
+    version: &str,
+    force: bool,
+) -> (String, ApplyOutcome) {
+    if let Some((start, end)) = find_block(file_contents) {
+        let current_body = &file_contents[start.body_start..end.body_end];
+        if !force && current_body.trim() != expected_block_body.trim() {
+            let diff = simple_diff(current_body, new_block_body);
+            return (file_contents.to_string(), ApplyOutcome::UserEditsBlocked(diff));
+        }
+        let mut out = String::with_capacity(file_contents.len());
+        out.push_str(&file_contents[..start.line_start]);
+        out.push_str(&render_block(new_block_body, version));
+        out.push_str(&file_contents[end.line_end..]);
+        return (out, ApplyOutcome::Replaced);
+    }
+
+    if !legacy_snippet.is_empty() {
+        if let Some(idx) = file_contents.find(legacy_snippet) {
+            let mut out = String::with_capacity(file_contents.len() + 80);
+            out.push_str(&file_contents[..idx]);
+            out.push_str(&render_block(new_block_body, version));
+            out.push_str(&file_contents[idx + legacy_snippet.len()..]);
+            return (out, ApplyOutcome::WrappedLegacy);
+        }
+    }
+
+    let mut out = String::with_capacity(file_contents.len() + new_block_body.len() + 80);
+    out.push_str(file_contents);
+    if !file_contents.ends_with('\n') && !file_contents.is_empty() {
+        out.push('\n');
+    }
+    if !file_contents.is_empty() {
+        out.push('\n');
+    }
+    out.push_str(&render_block(new_block_body, version));
+    (out, ApplyOutcome::Appended)
+}
+
+pub fn remove(file_contents: &str) -> (String, bool) {
+    if let Some((start, end)) = find_block(file_contents) {
+        let mut prefix = file_contents[..start.line_start].to_string();
+        // Strip the blank-line separator that `apply` inserts before the block.
+        if prefix.ends_with("\n\n") {
+            prefix.pop();
+        }
+        let tail = file_contents[end.line_end..].to_string();
+        return (format!("{}{}", prefix, tail), true);
+    }
+    (file_contents.to_string(), false)
+}
+
+pub fn installed_version(file_contents: &str) -> Option<String> {
+    let (start, _) = find_block(file_contents)?;
+    let header = &file_contents[start.line_start..start.body_start];
+    let prefix = "v=";
+    let v_at = header.find(prefix)? + prefix.len();
+    let rest = &header[v_at..];
+    let end = rest.find(' ').or_else(|| rest.find("-->"))?;
+    Some(rest[..end].trim().to_string())
+}
+
+struct BeginPos {
+    line_start: usize,
+    body_start: usize,
+}
+struct EndPos {
+    body_end: usize,
+    line_end: usize,
+}
+
+fn find_block(contents: &str) -> Option<(BeginPos, EndPos)> {
+    let begin_offset = contents.find(BEGIN_PREFIX)?;
+    let begin_line_end = contents[begin_offset..].find('\n')? + begin_offset + 1;
+    let line_start = contents[..begin_offset]
+        .rfind('\n')
+        .map(|i| i + 1)
+        .unwrap_or(0);
+
+    let end_offset = contents[begin_line_end..].find(END_MARKER)? + begin_line_end;
+    let end_line_start = contents[..end_offset]
+        .rfind('\n')
+        .map(|i| i + 1)
+        .unwrap_or(0);
+    let end_line_end = contents[end_offset..]
+        .find('\n')
+        .map(|i| end_offset + i + 1)
+        .unwrap_or(contents.len());
+
+    Some((
+        BeginPos {
+            line_start,
+            body_start: begin_line_end,
+        },
+        EndPos {
+            body_end: end_line_start,
+            line_end: end_line_end,
+        },
+    ))
+}
+
+fn render_block(body: &str, version: &str) -> String {
+    let mut s = String::with_capacity(body.len() + 80);
+    s.push_str(&format!("<!-- ast-outline:begin v={} -->\n", version));
+    s.push_str(body.trim_end_matches('\n'));
+    s.push('\n');
+    s.push_str(END_MARKER);
+    s.push('\n');
+    s
+}
+
+fn simple_diff(old: &str, new: &str) -> String {
+    use similar::TextDiff;
+    TextDiff::from_lines(old, new)
+        .unified_diff()
+        .header("installed", "new")
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BODY: &str = "## Hello\nLine.\n";
+    const NEW_BODY: &str = "## Hello\nUpdated line.\n";
+
+    #[test]
+    fn appends_to_empty_file() {
+        let (out, outcome) = apply("", BODY, BODY, "", "1.0.0", false);
+        assert_eq!(outcome, ApplyOutcome::Appended);
+        assert!(out.contains("<!-- ast-outline:begin v=1.0.0 -->"));
+        assert!(out.contains("<!-- ast-outline:end -->"));
+        assert!(out.contains("Line."));
+    }
+
+    #[test]
+    fn appends_with_blank_line_after_existing_content() {
+        let (out, outcome) = apply("Existing.\n", BODY, BODY, "", "1.0.0", false);
+        assert_eq!(outcome, ApplyOutcome::Appended);
+        assert!(out.starts_with("Existing.\n\n<!-- ast-outline:begin"));
+    }
+
+    #[test]
+    fn replaces_existing_block_in_place() {
+        let initial = format!(
+            "Top.\n\n<!-- ast-outline:begin v=1.0.0 -->\n{}<!-- ast-outline:end -->\nBottom.\n",
+            BODY
+        );
+        let (out, outcome) = apply(&initial, NEW_BODY, BODY, "", "2.0.0", false);
+        assert_eq!(outcome, ApplyOutcome::Replaced);
+        assert!(out.contains("v=2.0.0"));
+        assert!(out.contains("Updated line."));
+        assert!(out.starts_with("Top.\n\n"));
+        assert!(out.ends_with("Bottom.\n"));
+    }
+
+    #[test]
+    fn refuses_when_user_edited_block_without_force() {
+        let initial =
+            "<!-- ast-outline:begin v=1.0.0 -->\n## Hello\nUSER EDITED.\n<!-- ast-outline:end -->\n"
+                .to_string();
+        let (out, outcome) = apply(&initial, NEW_BODY, BODY, "", "2.0.0", false);
+        assert_eq!(out, initial);
+        match outcome {
+            ApplyOutcome::UserEditsBlocked(diff) => {
+                assert!(diff.contains("USER EDITED"));
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn force_overrides_user_edits() {
+        let initial =
+            "<!-- ast-outline:begin v=1.0.0 -->\n## Hello\nUSER EDITED.\n<!-- ast-outline:end -->\n"
+                .to_string();
+        let (out, outcome) = apply(&initial, NEW_BODY, BODY, "", "2.0.0", true);
+        assert_eq!(outcome, ApplyOutcome::Replaced);
+        assert!(out.contains("Updated line."));
+        assert!(!out.contains("USER EDITED"));
+    }
+
+    #[test]
+    fn wraps_legacy_snippet_in_place() {
+        let legacy = "## Code exploration\nUse ast-outline.\n";
+        let initial = format!("Top.\n\n{}\nBottom.\n", legacy);
+        let (out, outcome) = apply(&initial, NEW_BODY, BODY, legacy, "1.0.0", false);
+        assert_eq!(outcome, ApplyOutcome::WrappedLegacy);
+        assert!(out.contains("<!-- ast-outline:begin v=1.0.0 -->"));
+        assert!(!out.contains("## Code exploration\nUse ast-outline."));
+    }
+
+    #[test]
+    fn idempotent_when_block_matches() {
+        let (out1, _) = apply("", BODY, BODY, "", "1.0.0", false);
+        let (out2, outcome) = apply(&out1, BODY, BODY, "", "1.0.0", false);
+        assert_eq!(out1, out2);
+        assert_eq!(outcome, ApplyOutcome::Replaced);
+    }
+
+    #[test]
+    fn remove_strips_block_and_trailing_blank() {
+        let (with_block, _) = apply("Top.\n", BODY, BODY, "", "1.0.0", false);
+        let (out, removed) = remove(&with_block);
+        assert!(removed);
+        assert_eq!(out, "Top.\n");
+    }
+
+    #[test]
+    fn remove_noop_when_absent() {
+        let (out, removed) = remove("Just text.\n");
+        assert!(!removed);
+        assert_eq!(out, "Just text.\n");
+    }
+
+    #[test]
+    fn installed_version_extracts_v_tag() {
+        let (with_block, _) = apply("", BODY, BODY, "", "1.2.3", false);
+        assert_eq!(installed_version(&with_block), Some("1.2.3".to_string()));
+    }
+}

--- a/src/installers/mod.rs
+++ b/src/installers/mod.rs
@@ -7,6 +7,7 @@ pub mod claude_code;
 pub mod gemini;
 pub mod tabnine;
 pub mod cursor;
+pub mod aider;
 
 use std::path::PathBuf;
 
@@ -72,5 +73,6 @@ pub fn registry() -> Vec<Box<dyn Installer>> {
         Box::new(gemini::Gemini),
         Box::new(tabnine::Tabnine),
         Box::new(cursor::Cursor),
+        Box::new(aider::Aider),
     ]
 }

--- a/src/installers/mod.rs
+++ b/src/installers/mod.rs
@@ -1,4 +1,5 @@
 pub mod paths;
+pub mod io;
 pub mod marker_block;
 pub mod json_hook;
 

--- a/src/installers/mod.rs
+++ b/src/installers/mod.rs
@@ -2,6 +2,9 @@ pub mod paths;
 pub mod io;
 pub mod marker_block;
 pub mod json_hook;
+pub mod common;
+pub mod claude_code;
+pub mod gemini;
 
 use std::path::PathBuf;
 
@@ -62,5 +65,8 @@ pub trait Installer: Sync + Send {
 }
 
 pub fn registry() -> Vec<Box<dyn Installer>> {
-    Vec::new()
+    vec![
+        Box::new(claude_code::ClaudeCode),
+        Box::new(gemini::Gemini),
+    ]
 }

--- a/src/installers/mod.rs
+++ b/src/installers/mod.rs
@@ -6,6 +6,7 @@ pub mod common;
 pub mod claude_code;
 pub mod gemini;
 pub mod tabnine;
+pub mod cursor;
 
 use std::path::PathBuf;
 
@@ -70,5 +71,6 @@ pub fn registry() -> Vec<Box<dyn Installer>> {
         Box::new(claude_code::ClaudeCode),
         Box::new(gemini::Gemini),
         Box::new(tabnine::Tabnine),
+        Box::new(cursor::Cursor),
     ]
 }

--- a/src/installers/mod.rs
+++ b/src/installers/mod.rs
@@ -5,6 +5,7 @@ pub mod json_hook;
 pub mod common;
 pub mod claude_code;
 pub mod gemini;
+pub mod tabnine;
 
 use std::path::PathBuf;
 
@@ -68,5 +69,6 @@ pub fn registry() -> Vec<Box<dyn Installer>> {
     vec![
         Box::new(claude_code::ClaudeCode),
         Box::new(gemini::Gemini),
+        Box::new(tabnine::Tabnine),
     ]
 }

--- a/src/installers/mod.rs
+++ b/src/installers/mod.rs
@@ -8,6 +8,8 @@ pub mod gemini;
 pub mod tabnine;
 pub mod cursor;
 pub mod aider;
+pub mod codex;
+pub mod copilot;
 
 use std::path::PathBuf;
 
@@ -74,5 +76,7 @@ pub fn registry() -> Vec<Box<dyn Installer>> {
         Box::new(tabnine::Tabnine),
         Box::new(cursor::Cursor),
         Box::new(aider::Aider),
+        Box::new(codex::Codex),
+        Box::new(copilot::Copilot),
     ]
 }

--- a/src/installers/mod.rs
+++ b/src/installers/mod.rs
@@ -50,7 +50,6 @@ pub enum Change {
 #[derive(Debug, Clone)]
 pub struct Detection {
     pub present: bool,
-    pub config_root: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/installers/mod.rs
+++ b/src/installers/mod.rs
@@ -1,0 +1,65 @@
+pub mod paths;
+pub mod marker_block;
+pub mod json_hook;
+
+use std::path::PathBuf;
+
+#[derive(Debug, Clone)]
+pub enum Scope {
+    Local(PathBuf),
+    Global,
+}
+
+#[derive(Debug, Clone)]
+pub struct InstallOpts {
+    pub min_lines: usize,
+    pub always: bool,
+    pub dry_run: bool,
+    pub force: bool,
+}
+
+impl Default for InstallOpts {
+    fn default() -> Self {
+        Self {
+            min_lines: 200,
+            always: false,
+            dry_run: false,
+            force: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum Change {
+    Created(PathBuf),
+    Updated(PathBuf),
+    Removed(PathBuf),
+    Skipped { path: PathBuf, reason: String },
+    NotApplicable,
+}
+
+#[derive(Debug, Clone)]
+pub struct Detection {
+    pub present: bool,
+    pub config_root: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Status {
+    pub prompt_installed: bool,
+    pub prompt_version: Option<String>,
+    pub hook_installed: bool,
+}
+
+pub trait Installer: Sync + Send {
+    fn name(&self) -> &'static str;
+    fn detect(&self, scope: &Scope) -> Detection;
+    fn install_prompt(&self, scope: &Scope, opts: &InstallOpts) -> Result<Change, String>;
+    fn install_hook(&self, scope: &Scope, opts: &InstallOpts) -> Result<Change, String>;
+    fn uninstall(&self, scope: &Scope, opts: &InstallOpts) -> Result<Vec<Change>, String>;
+    fn status(&self, scope: &Scope) -> Status;
+}
+
+pub fn registry() -> Vec<Box<dyn Installer>> {
+    Vec::new()
+}

--- a/src/installers/paths.rs
+++ b/src/installers/paths.rs
@@ -1,0 +1,21 @@
+use std::path::{Path, PathBuf};
+
+pub fn home() -> Result<PathBuf, String> {
+    dirs::home_dir().ok_or_else(|| "cannot resolve user home directory".to_string())
+}
+
+pub fn under_home(relative: impl AsRef<Path>) -> Result<PathBuf, String> {
+    Ok(home()?.join(relative))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn under_home_joins_relative() {
+        let p = under_home(".claude/CLAUDE.md").unwrap();
+        assert!(p.ends_with(".claude/CLAUDE.md"));
+        assert!(p.is_absolute());
+    }
+}

--- a/src/installers/paths.rs
+++ b/src/installers/paths.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 
 pub fn home() -> Result<PathBuf, String> {
     dirs::home_dir().ok_or_else(|| "cannot resolve user home directory".to_string())
@@ -6,6 +7,19 @@ pub fn home() -> Result<PathBuf, String> {
 
 pub fn under_home(relative: impl AsRef<Path>) -> Result<PathBuf, String> {
     Ok(home()?.join(relative))
+}
+
+/// True if `name` resolves to an executable on the user's $PATH. Used
+/// by adapters' `detect()` so `--all` can skip CLIs the user doesn't
+/// actually have installed.
+pub fn binary_on_path(name: &str) -> bool {
+    Command::new("which")
+        .arg(name)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
 }
 
 #[cfg(test)]

--- a/src/installers/tabnine.rs
+++ b/src/installers/tabnine.rs
@@ -1,0 +1,140 @@
+use std::path::PathBuf;
+
+use serde_json::{json, Value};
+
+use super::json_hook::MARKER;
+use super::paths;
+use super::{common, Change, Detection, InstallOpts, Installer, Scope, Status};
+use crate::prompt::AGENT_PROMPT;
+
+pub struct Tabnine;
+
+const HOOK_PATH: &[&str] = &["hooks", "BeforeTool"];
+const HOOK_NAME: &str = "ast-outline-read-interceptor";
+
+impl Tabnine {
+    fn prompt_path(&self, scope: &Scope) -> Result<PathBuf, String> {
+        match scope {
+            Scope::Local(root) => Ok(root.join(".tabnine/guidelines/ast-outline.md")),
+            Scope::Global => paths::under_home(".tabnine/guidelines/ast-outline.md"),
+        }
+    }
+    fn settings_path(&self, scope: &Scope) -> Result<PathBuf, String> {
+        match scope {
+            Scope::Local(root) => Ok(root.join(".tabnine/agent/settings.json")),
+            Scope::Global => paths::under_home(".tabnine/agent/settings.json"),
+        }
+    }
+    fn hook_entry(&self, opts: &InstallOpts) -> Value {
+        let mut cmd = format!(
+            "ast-outline hook --protocol gemini --min-lines {}",
+            opts.min_lines
+        );
+        if opts.always {
+            cmd.push_str(" --always");
+        }
+        json!({
+            "matcher": "read_file",
+            "hooks": [{ "name": HOOK_NAME, "type": "command", "command": cmd }]
+        })
+    }
+}
+
+fn matches_entry(v: &Value) -> bool {
+    v.get("matcher").and_then(|m| m.as_str()) == Some("read_file")
+        && v.get("hooks")
+            .and_then(|h| h.as_array())
+            .and_then(|h| h.first())
+            .map(|h0| {
+                h0.get("name").and_then(|n| n.as_str()) == Some(HOOK_NAME)
+                    || h0
+                        .get("command")
+                        .and_then(|c| c.as_str())
+                        .map(|c| c.starts_with(MARKER))
+                        .unwrap_or(false)
+            })
+            .unwrap_or(false)
+}
+
+impl Installer for Tabnine {
+    fn name(&self) -> &'static str {
+        "tabnine"
+    }
+
+    fn detect(&self, scope: &Scope) -> Detection {
+        let p = match self.prompt_path(scope) {
+            Ok(p) => p,
+            Err(_) => {
+                return Detection {
+                    present: false,
+                    config_root: None,
+                }
+            }
+        };
+        let root = p.parent().map(|p| p.to_path_buf());
+        Detection {
+            present: root.as_ref().map(|r| r.exists()).unwrap_or(false),
+            config_root: root,
+        }
+    }
+
+    fn install_prompt(&self, scope: &Scope, opts: &InstallOpts) -> Result<Change, String> {
+        common::install_prompt_in(&self.prompt_path(scope)?, AGENT_PROMPT, opts)
+    }
+
+    fn install_hook(&self, scope: &Scope, opts: &InstallOpts) -> Result<Change, String> {
+        common::install_json_hook_in(
+            &self.settings_path(scope)?,
+            HOOK_PATH,
+            self.hook_entry(opts),
+            matches_entry,
+            opts,
+        )
+    }
+
+    fn uninstall(&self, scope: &Scope, opts: &InstallOpts) -> Result<Vec<Change>, String> {
+        let mut changes = Vec::new();
+        if let Some(c) = common::uninstall_prompt_in(&self.prompt_path(scope)?, opts)? {
+            changes.push(c);
+        }
+        if let Some(c) =
+            common::uninstall_json_hook_in(&self.settings_path(scope)?, HOOK_PATH, matches_entry, opts)?
+        {
+            changes.push(c);
+        }
+        Ok(changes)
+    }
+
+    fn status(&self, scope: &Scope) -> Status {
+        common::status_for(
+            self.prompt_path(scope).ok().as_deref(),
+            self.settings_path(scope).ok().as_deref(),
+            HOOK_PATH,
+            matches_entry,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn install_creates_tabnine_files() {
+        let dir = TempDir::new().unwrap();
+        let scope = Scope::Local(dir.path().to_path_buf());
+        Tabnine
+            .install_prompt(&scope, &InstallOpts::default())
+            .unwrap();
+        Tabnine
+            .install_hook(&scope, &InstallOpts::default())
+            .unwrap();
+        let prompt =
+            std::fs::read_to_string(dir.path().join(".tabnine/guidelines/ast-outline.md")).unwrap();
+        let settings =
+            std::fs::read_to_string(dir.path().join(".tabnine/agent/settings.json")).unwrap();
+        assert!(prompt.contains("ast-outline:begin"));
+        assert!(settings.contains("--protocol gemini"));
+    }
+}

--- a/src/installers/tabnine.rs
+++ b/src/installers/tabnine.rs
@@ -62,19 +62,14 @@ impl Installer for Tabnine {
     }
 
     fn detect(&self, scope: &Scope) -> Detection {
-        let p = match self.prompt_path(scope) {
-            Ok(p) => p,
-            Err(_) => {
-                return Detection {
-                    present: false,
-                    config_root: None,
-                }
-            }
-        };
-        let root = p.parent().map(|p| p.to_path_buf());
+        let dir_exists = self
+            .prompt_path(scope)
+            .ok()
+            .and_then(|p| p.parent().map(|r| r.to_path_buf()))
+            .map(|r| r.exists())
+            .unwrap_or(false);
         Detection {
-            present: root.as_ref().map(|r| r.exists()).unwrap_or(false),
-            config_root: root,
+            present: dir_exists || paths::binary_on_path("tabnine"),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,19 +7,9 @@ mod core;
 mod prompt;
 mod installers;
 mod hook;
+mod main_helpers;
 
-use crate::adapters::base::LanguageAdapter;
-use crate::adapters::csharp::CSharpAdapter;
-use crate::adapters::go::GoAdapter;
-use crate::adapters::java::JavaAdapter;
-use crate::adapters::kotlin::KotlinAdapter;
-use crate::adapters::python::PythonAdapter;
-use crate::adapters::rust::RustAdapter;
-use crate::adapters::scala::ScalaAdapter;
-use crate::adapters::typescript::TypeScriptAdapter;
 use crate::core::{DigestOptions, OutlineOptions, ParseResult};
-use ast_grep_core::Language;
-use ast_grep_language::{LanguageExt, SupportLang};
 
 #[derive(Parser)]
 #[command(name = "ast-outline")]
@@ -82,55 +72,7 @@ enum Commands {
 }
 
 fn parse_file(path: &Path) -> Option<ParseResult> {
-    let lang = SupportLang::from_path(path);
-    let source = std::fs::read_to_string(path).ok()?;
-
-    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
-
-    if ext == "md" || ext == "markdown" || ext == "mdx" {
-        return Some(crate::adapters::markdown::parse_markdown(
-            path,
-            source.as_bytes(),
-        ));
-    }
-
-    let lang = lang?;
-
-    match lang {
-        SupportLang::Rust => {
-            let ast_grep = lang.ast_grep(source.clone());
-            Some(RustAdapter.parse(path, source.as_bytes(), ast_grep.root()))
-        }
-        SupportLang::Python => {
-            let ast_grep = lang.ast_grep(source.clone());
-            Some(PythonAdapter.parse(path, source.as_bytes(), ast_grep.root()))
-        }
-        SupportLang::TypeScript | SupportLang::Tsx | SupportLang::JavaScript => {
-            let ast_grep = lang.ast_grep(source.clone());
-            Some(TypeScriptAdapter.parse(path, source.as_bytes(), ast_grep.root()))
-        }
-        SupportLang::CSharp => {
-            let ast_grep = lang.ast_grep(source.clone());
-            Some(CSharpAdapter.parse(path, source.as_bytes(), ast_grep.root()))
-        }
-        SupportLang::Go => {
-            let ast_grep = lang.ast_grep(source.clone());
-            Some(GoAdapter.parse(path, source.as_bytes(), ast_grep.root()))
-        }
-        SupportLang::Java => {
-            let ast_grep = lang.ast_grep(source.clone());
-            Some(JavaAdapter.parse(path, source.as_bytes(), ast_grep.root()))
-        }
-        SupportLang::Kotlin => {
-            let ast_grep = lang.ast_grep(source.clone());
-            Some(KotlinAdapter.parse(path, source.as_bytes(), ast_grep.root()))
-        }
-        SupportLang::Scala => {
-            let ast_grep = lang.ast_grep(source.clone());
-            Some(ScalaAdapter.parse(path, source.as_bytes(), ast_grep.root()))
-        }
-        _ => None,
-    }
+    crate::main_helpers::parse_file_for_hook(path)
 }
 
 fn walk_and_parse(paths: &[PathBuf], glob_str: Option<&str>) -> Vec<ParseResult> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,15 @@ enum Commands {
     },
     /// Print the agent prompt snippet
     Prompt,
+    /// Internal: read a tool-call event from stdin and respond
+    Hook {
+        #[arg(long)]
+        protocol: String,
+        #[arg(long, default_value_t = 200)]
+        min_lines: usize,
+        #[arg(long)]
+        always: bool,
+    },
 }
 
 fn parse_file(path: &Path) -> Option<ParseResult> {
@@ -194,6 +203,14 @@ fn main() {
             }
             Commands::Prompt => {
                 println!("{}", crate::prompt::AGENT_PROMPT);
+            }
+            Commands::Hook {
+                protocol,
+                min_lines,
+                always,
+            } => {
+                let exit = hook::run(protocol, *min_lines, *always);
+                std::process::exit(exit);
             }
         }
     } else if !cli.paths.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -326,7 +326,7 @@ fn run_install(
 ) -> i32 {
     let registry = installers::registry();
     let chosen: Vec<&Box<dyn installers::Installer>> = if all {
-        registry.iter().collect()
+        select_all(&registry, scope)
     } else if let Some(name) = target {
         match registry.iter().find(|i| i.name() == name) {
             Some(i) => vec![i],
@@ -400,7 +400,7 @@ fn run_uninstall(
 ) -> i32 {
     let registry = installers::registry();
     let chosen: Vec<&Box<dyn installers::Installer>> = if all {
-        registry.iter().collect()
+        select_all(&registry, scope)
     } else if let Some(name) = target {
         match registry.iter().find(|i| i.name() == name) {
             Some(i) => vec![i],
@@ -461,6 +461,30 @@ fn names(registry: &[Box<dyn installers::Installer>]) -> String {
         .map(|i| i.name())
         .collect::<Vec<_>>()
         .join(", ")
+}
+
+/// Picks the adapters to act on for `--all`. For `Scope::Global`, we
+/// skip targets whose `detect()` reports the CLI is absent (and print a
+/// note). For `Scope::Local`, the user explicitly opted into this repo
+/// so detection is bypassed.
+fn select_all<'a>(
+    registry: &'a [Box<dyn installers::Installer>],
+    scope: &installers::Scope,
+) -> Vec<&'a Box<dyn installers::Installer>> {
+    let bypass_detection = matches!(scope, installers::Scope::Local(_));
+    registry
+        .iter()
+        .filter(|inst| {
+            if bypass_detection {
+                return true;
+            }
+            let d = inst.detect(scope);
+            if !d.present {
+                println!("{:<14} {:<10} skipped  (not detected on this system)", inst.name(), "detect");
+            }
+            d.present
+        })
+        .collect()
 }
 
 fn print_change(target: &str, phase: &str, change: &installers::Change) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,45 @@ enum Commands {
     },
     /// Print the agent prompt snippet
     Prompt,
+    /// Install ast-outline into a coding-agent CLI
+    Install {
+        #[arg(long, conflicts_with = "all")]
+        target: Option<String>,
+        #[arg(long, conflicts_with = "target")]
+        all: bool,
+        #[arg(long)]
+        local: bool,
+        #[arg(long, conflicts_with = "local")]
+        global: bool,
+        #[arg(long)]
+        always: bool,
+        #[arg(long, default_value_t = 200)]
+        min_lines: usize,
+        #[arg(long)]
+        dry_run: bool,
+        #[arg(long)]
+        force: bool,
+    },
+    /// Remove ast-outline from a coding-agent CLI
+    Uninstall {
+        #[arg(long, conflicts_with = "all")]
+        target: Option<String>,
+        #[arg(long, conflicts_with = "target")]
+        all: bool,
+        #[arg(long)]
+        local: bool,
+        #[arg(long, conflicts_with = "local")]
+        global: bool,
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Report what's installed where
+    Status {
+        #[arg(long)]
+        local: bool,
+        #[arg(long, conflicts_with = "local")]
+        global: bool,
+    },
     /// Internal: read a tool-call event from stdin and respond
     Hook {
         #[arg(long)]
@@ -204,6 +243,45 @@ fn main() {
             Commands::Prompt => {
                 println!("{}", crate::prompt::AGENT_PROMPT);
             }
+            Commands::Install {
+                target,
+                all,
+                local,
+                global,
+                always,
+                min_lines,
+                dry_run,
+                force,
+            } => {
+                let scope = resolve_scope(*local, *global);
+                let opts = installers::InstallOpts {
+                    min_lines: *min_lines,
+                    always: *always,
+                    dry_run: *dry_run,
+                    force: *force,
+                };
+                let exit = run_install(target.as_deref(), *all, &scope, &opts);
+                std::process::exit(exit);
+            }
+            Commands::Uninstall {
+                target,
+                all,
+                local,
+                global,
+                dry_run,
+            } => {
+                let scope = resolve_scope(*local, *global);
+                let opts = installers::InstallOpts {
+                    dry_run: *dry_run,
+                    ..installers::InstallOpts::default()
+                };
+                let exit = run_uninstall(target.as_deref(), *all, &scope, &opts);
+                std::process::exit(exit);
+            }
+            Commands::Status { local, global } => {
+                let scope = resolve_scope(*local, *global);
+                run_status(&scope);
+            }
             Commands::Hook {
                 protocol,
                 min_lines,
@@ -229,5 +307,177 @@ fn main() {
         }
     } else {
         println!("Please provide a path or command.");
+    }
+}
+
+fn resolve_scope(local: bool, _global: bool) -> installers::Scope {
+    if local {
+        installers::Scope::Local(std::env::current_dir().expect("cwd"))
+    } else {
+        installers::Scope::Global
+    }
+}
+
+fn run_install(
+    target: Option<&str>,
+    all: bool,
+    scope: &installers::Scope,
+    opts: &installers::InstallOpts,
+) -> i32 {
+    let registry = installers::registry();
+    let chosen: Vec<&Box<dyn installers::Installer>> = if all {
+        registry.iter().collect()
+    } else if let Some(name) = target {
+        match registry.iter().find(|i| i.name() == name) {
+            Some(i) => vec![i],
+            None => {
+                eprintln!(
+                    "unknown --target '{}'. Known: {}",
+                    name,
+                    names(&registry)
+                );
+                return 2;
+            }
+        }
+    } else {
+        eprintln!(
+            "must pass --target <name> or --all. Known: {}",
+            names(&registry)
+        );
+        return 2;
+    };
+
+    let mut any_installed = false;
+    let mut any_failed = false;
+    for inst in chosen {
+        let label = inst.name();
+        match inst.install_prompt(scope, opts) {
+            Ok(c) => {
+                print_change(label, "prompt", &c);
+                if !matches!(
+                    c,
+                    installers::Change::Skipped { .. } | installers::Change::NotApplicable
+                ) {
+                    any_installed = true;
+                }
+            }
+            Err(e) => {
+                eprintln!("{}: prompt: {}", label, e);
+                any_failed = true;
+            }
+        }
+        match inst.install_hook(scope, opts) {
+            Ok(c) => {
+                print_change(label, "hook", &c);
+                if !matches!(
+                    c,
+                    installers::Change::Skipped { .. } | installers::Change::NotApplicable
+                ) {
+                    any_installed = true;
+                }
+            }
+            Err(e) => {
+                eprintln!("{}: hook: {}", label, e);
+                any_failed = true;
+            }
+        }
+    }
+
+    if any_failed && any_installed {
+        1
+    } else if any_failed {
+        2
+    } else {
+        0
+    }
+}
+
+fn run_uninstall(
+    target: Option<&str>,
+    all: bool,
+    scope: &installers::Scope,
+    opts: &installers::InstallOpts,
+) -> i32 {
+    let registry = installers::registry();
+    let chosen: Vec<&Box<dyn installers::Installer>> = if all {
+        registry.iter().collect()
+    } else if let Some(name) = target {
+        match registry.iter().find(|i| i.name() == name) {
+            Some(i) => vec![i],
+            None => {
+                eprintln!(
+                    "unknown --target '{}'. Known: {}",
+                    name,
+                    names(&registry)
+                );
+                return 2;
+            }
+        }
+    } else {
+        eprintln!(
+            "must pass --target <name> or --all. Known: {}",
+            names(&registry)
+        );
+        return 2;
+    };
+
+    let mut any_failed = false;
+    for inst in chosen {
+        match inst.uninstall(scope, opts) {
+            Ok(changes) => {
+                for c in changes {
+                    print_change(inst.name(), "uninstall", &c);
+                }
+            }
+            Err(e) => {
+                eprintln!("{}: {}", inst.name(), e);
+                any_failed = true;
+            }
+        }
+    }
+    if any_failed {
+        1
+    } else {
+        0
+    }
+}
+
+fn run_status(scope: &installers::Scope) {
+    for inst in installers::registry() {
+        let s = inst.status(scope);
+        let prompt = if s.prompt_installed {
+            format!("prompt {}", s.prompt_version.unwrap_or_else(|| "?".into()))
+        } else {
+            "prompt -".to_string()
+        };
+        let hook = if s.hook_installed { "hook ✓" } else { "hook -" };
+        println!("{:<14} {:<14} {}", inst.name(), prompt, hook);
+    }
+}
+
+fn names(registry: &[Box<dyn installers::Installer>]) -> String {
+    registry
+        .iter()
+        .map(|i| i.name())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn print_change(target: &str, phase: &str, change: &installers::Change) {
+    use installers::Change::*;
+    match change {
+        Created(p) => println!("{:<14} {:<10} created  {}", target, phase, p.display()),
+        Updated(p) => println!("{:<14} {:<10} updated  {}", target, phase, p.display()),
+        Removed(p) => println!("{:<14} {:<10} removed  {}", target, phase, p.display()),
+        Skipped { path, reason } => {
+            println!(
+                "{:<14} {:<10} skipped  {} ({})",
+                target,
+                phase,
+                path.display(),
+                reason
+            )
+        }
+        NotApplicable => println!("{:<14} {:<10} n/a", target, phase),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,8 @@ use std::path::{Path, PathBuf};
 mod adapters;
 mod core;
 mod prompt;
+mod installers;
+mod hook;
 
 use crate::adapters::base::LanguageAdapter;
 use crate::adapters::csharp::CSharpAdapter;

--- a/src/main_helpers.rs
+++ b/src/main_helpers.rs
@@ -1,0 +1,69 @@
+use std::path::Path;
+
+use ast_grep_core::Language;
+use ast_grep_language::{LanguageExt, SupportLang};
+
+use crate::adapters::base::LanguageAdapter;
+use crate::adapters::csharp::CSharpAdapter;
+use crate::adapters::go::GoAdapter;
+use crate::adapters::java::JavaAdapter;
+use crate::adapters::kotlin::KotlinAdapter;
+use crate::adapters::python::PythonAdapter;
+use crate::adapters::rust::RustAdapter;
+use crate::adapters::scala::ScalaAdapter;
+use crate::adapters::typescript::TypeScriptAdapter;
+use crate::core::ParseResult;
+
+pub fn parse_file_for_hook(path: &Path) -> Option<ParseResult> {
+    let lang = SupportLang::from_path(path);
+    let source = std::fs::read_to_string(path).ok()?;
+    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+    if matches!(ext, "md" | "markdown" | "mdx" | "mdown") {
+        return Some(crate::adapters::markdown::parse_markdown(
+            path,
+            source.as_bytes(),
+        ));
+    }
+    let lang = lang?;
+    match lang {
+        SupportLang::Rust => Some(RustAdapter.parse(
+            path,
+            source.as_bytes(),
+            lang.ast_grep(source.clone()).root(),
+        )),
+        SupportLang::Python => Some(PythonAdapter.parse(
+            path,
+            source.as_bytes(),
+            lang.ast_grep(source.clone()).root(),
+        )),
+        SupportLang::TypeScript | SupportLang::Tsx | SupportLang::JavaScript => Some(
+            TypeScriptAdapter.parse(path, source.as_bytes(), lang.ast_grep(source.clone()).root()),
+        ),
+        SupportLang::CSharp => Some(CSharpAdapter.parse(
+            path,
+            source.as_bytes(),
+            lang.ast_grep(source.clone()).root(),
+        )),
+        SupportLang::Go => Some(GoAdapter.parse(
+            path,
+            source.as_bytes(),
+            lang.ast_grep(source.clone()).root(),
+        )),
+        SupportLang::Java => Some(JavaAdapter.parse(
+            path,
+            source.as_bytes(),
+            lang.ast_grep(source.clone()).root(),
+        )),
+        SupportLang::Kotlin => Some(KotlinAdapter.parse(
+            path,
+            source.as_bytes(),
+            lang.ast_grep(source.clone()).root(),
+        )),
+        SupportLang::Scala => Some(ScalaAdapter.parse(
+            path,
+            source.as_bytes(),
+            lang.ast_grep(source.clone()).root(),
+        )),
+        _ => None,
+    }
+}

--- a/tests/hook_e2e.rs
+++ b/tests/hook_e2e.rs
@@ -1,0 +1,124 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+use tempfile::TempDir;
+
+fn binary() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_ast-outline"))
+}
+
+fn run_hook(protocol: &str, stdin: &str, args: &[&str]) -> (String, String, i32) {
+    let mut cmd = Command::new(binary());
+    cmd.arg("hook")
+        .arg("--protocol")
+        .arg(protocol)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = cmd.spawn().expect("spawn ast-outline");
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(stdin.as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+    (
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+#[test]
+fn claude_code_pass_through_for_small_file() {
+    let dir = TempDir::new().unwrap();
+    let p = dir.path().join("small.rs");
+    std::fs::write(&p, "fn main() {}\n").unwrap();
+    let stdin = format!(
+        r#"{{"tool_name":"Read","tool_input":{{"file_path":"{}"}}}}"#,
+        p.display()
+    );
+    let (stdout, _, code) = run_hook("claude-code", &stdin, &["--min-lines", "200"]);
+    assert_eq!(code, 0);
+    assert!(stdout.contains("\"continue\":true"), "stdout: {}", stdout);
+}
+
+#[test]
+fn claude_code_substitutes_for_big_file() {
+    let dir = TempDir::new().unwrap();
+    let p = dir.path().join("big.rs");
+    let mut s = String::new();
+    for i in 0..300 {
+        s.push_str(&format!("fn f{}() {{}}\n", i));
+    }
+    std::fs::write(&p, &s).unwrap();
+    let stdin = format!(
+        r#"{{"tool_name":"Read","tool_input":{{"file_path":"{}"}}}}"#,
+        p.display()
+    );
+    let (stdout, _, code) = run_hook("claude-code", &stdin, &["--min-lines", "200"]);
+    assert_eq!(code, 0);
+    assert!(stdout.contains("\"decision\":\"block\""));
+    assert!(stdout.contains("ast-outline substituted"));
+}
+
+#[test]
+fn claude_code_pass_through_for_png() {
+    let stdin = r#"{"tool_name":"Read","tool_input":{"file_path":"image.png"}}"#;
+    let (stdout, _, code) = run_hook("claude-code", stdin, &["--min-lines", "200"]);
+    assert_eq!(code, 0);
+    assert!(stdout.contains("\"continue\":true"));
+}
+
+#[test]
+fn claude_code_pass_through_when_offset_set() {
+    let dir = TempDir::new().unwrap();
+    let p = dir.path().join("big.rs");
+    let mut s = String::new();
+    for i in 0..300 {
+        s.push_str(&format!("fn f{}() {{}}\n", i));
+    }
+    std::fs::write(&p, &s).unwrap();
+    let stdin = format!(
+        r#"{{"tool_name":"Read","tool_input":{{"file_path":"{}","offset":10,"limit":20}}}}"#,
+        p.display()
+    );
+    let (stdout, _, code) = run_hook("claude-code", &stdin, &["--min-lines", "200"]);
+    assert_eq!(code, 0);
+    assert!(stdout.contains("\"continue\":true"));
+}
+
+#[test]
+fn gemini_substitutes_for_big_file() {
+    let dir = TempDir::new().unwrap();
+    let p = dir.path().join("big.rs");
+    let mut s = String::new();
+    for i in 0..300 {
+        s.push_str(&format!("fn f{}() {{}}\n", i));
+    }
+    std::fs::write(&p, &s).unwrap();
+    let stdin = format!(
+        r#"{{"tool_name":"read_file","tool_input":{{"absolute_path":"{}"}}}}"#,
+        p.display()
+    );
+    let (stdout, _, code) = run_hook("gemini", &stdin, &["--min-lines", "200"]);
+    assert_eq!(code, 0);
+    assert!(stdout.contains("\"decision\":\"block\""));
+}
+
+#[test]
+fn bad_stdin_json_pass_through_with_warning() {
+    let (stdout, stderr, code) = run_hook("claude-code", "not json", &["--min-lines", "200"]);
+    assert_eq!(code, 0);
+    assert!(stdout.contains("\"continue\":true"));
+    assert!(stderr.contains("bad stdin json"));
+}
+
+#[test]
+fn unknown_protocol_exits_nonzero() {
+    let (_, stderr, code) = run_hook("zzz-not-real", "{}", &[]);
+    assert_eq!(code, 2);
+    assert!(stderr.contains("unknown --protocol"));
+}


### PR DESCRIPTION
## Summary
- New `install` / `uninstall` / `status` subcommands wire the agent prompt snippet into seven coding-agent CLIs: claude-code, gemini, tabnine, cursor, aider, codex, copilot. `--all` filters by detection (binary on PATH or config dir present); `--local` bypasses detection for explicit per-repo opt-in.
- New `hook` subcommand acts as a `Read`-interceptor for Claude Code (`hooks.PreToolUse`) and Gemini/Tabnine (`hooks.BeforeTool`) — substitutes the outline when a file exceeds `--min-lines` (default 200), pass-through otherwise. Cursor / aider / codex / copilot get the prompt only (no public tool-call hook API).
- 53 tests passing (46 unit + 7 end-to-end stdin/stdout fixtures). Atomic writes, one-time backups, marker-block idempotency for prose files (`<!-- ast-outline:begin v=X.Y.Z -->...<!-- ast-outline:end -->`), predicate-based upsert for nested hook configs (sibling hooks preserved), `--dry-run` on every write.

## Test plan
- [ ] `cargo test` — should be green (locally: 53/53)
- [ ] `cargo build --release` — clean (0 warnings)
- [ ] `ast-outline install --target claude-code --local --dry-run` shows expected files, writes nothing
- [ ] `ast-outline install --all --local` creates files for all seven targets in a temp repo
- [ ] `ast-outline install --all --global` on a system where only some CLIs are present skips the absent ones with a one-line note
- [ ] `ast-outline status --local` after install reports `prompt 0.1.1` for all seven and `hook ✓` for claude-code / gemini / tabnine
- [ ] `ast-outline uninstall --all --local` removes the marker block + hook entry and leaves sibling content / hooks intact
- [ ] `ast-outline prompt` still emits the legacy snippet unchanged

## Notes for review
- Tabnine paths (`~/.tabnine/guidelines/ast-outline.md`, `~/.tabnine/agent/settings.json`) follow Tabnine's docs but the assumption that its hook JSON shape mirrors Gemini's is inferred — please verify against your installed Tabnine CLI version.
- Gemini hook event schema is taken from the official `google-gemini/gemini-cli` docs (`tool_name` + `tool_input.absolute_path`, response = `{"continue": true}` or `{"decision": "block", "reason": "..."}`).
- The hook never breaks `Read`: any internal failure (parser error, malformed stdin, unreadable file) emits pass-through with a one-line stderr warning. Verified by `bad_stdin_json_pass_through_with_warning`.

Generated with [Claude Code](https://claude.com/claude-code).