### PR TITLE
Some more (gentle) clean ups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,7 @@
 /result
 .DS_Store
 
+/.direnv
+.envrc
+
 **/*.rs.bk

--- a/flake.lock
+++ b/flake.lock
@@ -15,21 +15,21 @@
         "type": "github"
       }
     },
-    "flake-utils": {
+    "flake-parts": {
       "inputs": {
-        "systems": "systems"
+        "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
         "type": "github"
       }
     },
@@ -49,26 +49,26 @@
         "type": "github"
       }
     },
-    "root": {
-      "inputs": {
-        "crane": "crane",
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
+    "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "lastModified": 1774748309,
+        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
         "type": "github"
       },
       "original": {
-        "owner": "nix-systems",
-        "repo": "default",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
         "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -6,40 +6,61 @@
 
     crane.url = "github:ipetkov/crane";
 
-    flake-utils.url = "github:numtide/flake-utils";
-
+    flake-parts.url = "github:hercules-ci/flake-parts";
   };
-
-  outputs =
-    {
-      self,
-      nixpkgs,
-      crane,
-      flake-utils,
-      ...
-    }:
-    flake-utils.lib.eachDefaultSystem (
-      system:
-      let
-        pkgs = nixpkgs.legacyPackages.${system};
-
-        inherit (pkgs) lib;
-
+  outputs = {
+    flake-parts,
+    crane,
+    ...
+  } @ inputs:
+    flake-parts.lib.mkFlake {inherit inputs;} {
+      # Allows definition of system-specific attributes
+      # without needing to declare the system explicitly!
+      #
+      # Quick rundown of the provided arguments:
+      # - config is a reference to the full configuration, lazily evaluated
+      # - self' is the outputs as provided here, without system. (self'.packages.default)
+      # - inputs' is the input without needing to specify system (inputs'.foo.packages.bar)
+      # - pkgs is an instance of nixpkgs for your specific system
+      # - system is the system this configuration is for
+      perSystem = {
+        config,
+        self',
+        inputs',
+        pkgs,
+        system,
+        lib,
+        ...
+      }: let
         craneLib = crane.mkLib pkgs;
         src = craneLib.cleanCargoSource ./.;
 
-        # Common arguments can be set here to avoid repeating them later
+        # Read package metadata from Cargo.toml so we don't have to
+        # duplicate it here.
+        cargoToml = fromTOML (builtins.readFile ./Cargo.toml);
+        crateName = craneLib.crateNameFromCargoToml {cargoToml = ./Cargo.toml;};
+
+        # Cargo defaults the binary name to the package name when the crate
+        # exposes a single `src/main.rs` and no explicit `[[bin]]` targets
+        # override it. Honour any `[[bin]]` entry if one is added later.
+        mainProgram =
+          if (cargoToml ? bin) && (builtins.length cargoToml.bin > 0)
+          then (builtins.head cargoToml.bin).name
+          else crateName.pname;
+
         commonArgs = {
           inherit src;
+          inherit (crateName) pname version;
           strictDeps = true;
 
-          buildInputs = [
-            # Add additional build inputs here
-          ]
-          ++ lib.optionals pkgs.stdenv.isDarwin [
-            # Additional darwin specific inputs can be set here
-            pkgs.libiconv
-          ];
+          buildInputs =
+            [
+              # Add additional build inputs here
+            ]
+            ++ lib.optionals pkgs.stdenv.isDarwin [
+              # Additional darwin specific inputs can be set here
+              pkgs.libiconv
+            ];
 
           # Additional environment variables can be set directly
           # MY_CUSTOM_VAR = "some value";
@@ -51,17 +72,23 @@
 
         # Build the actual crate itself, reusing the dependency
         # artifacts from above.
-        ast-outline = craneLib.buildPackage (
+        astOutline = craneLib.buildPackage (
           commonArgs
           // {
             inherit cargoArtifacts;
+            doCheck = false;
+            meta = {
+              inherit (cargoToml.package) description;
+              homepage = cargoToml.package.repository;
+              license = lib.getLicenseFromSpdxId cargoToml.package.license;
+              inherit mainProgram;
+            };
           }
         );
-      in
-      {
+      in {
         checks = {
           # Build the crate as part of `nix flake check` for convenience
-          inherit ast-outline;
+          inherit astOutline;
 
           # Run clippy (and deny all warnings) on the crate source,
           # again, reusing the dependency artifacts from above.
@@ -69,7 +96,7 @@
           # Note that this is done as a separate derivation so that
           # we can block the CI if there are issues here, but not
           # prevent downstream consumers from building our crate by itself.
-          my-crate-clippy = craneLib.cargoClippy (
+          astOutlineClippy = craneLib.cargoClippy (
             commonArgs
             // {
               inherit cargoArtifacts;
@@ -77,7 +104,7 @@
             }
           );
 
-          my-crate-doc = craneLib.cargoDoc (
+          astOutlineDoc = craneLib.cargoDoc (
             commonArgs
             // {
               inherit cargoArtifacts;
@@ -87,21 +114,10 @@
             }
           );
 
-          # Check formatting
-          my-crate-fmt = craneLib.cargoFmt {
-            inherit src;
-          };
-
-          my-crate-toml-fmt = craneLib.taploFmt {
-            src = pkgs.lib.sources.sourceFilesBySuffices src [ ".toml" ];
-            # taplo arguments can be further customized below as needed
-            # taploExtraArgs = "--config ./taplo.toml";
-          };
-
           # Run tests with cargo-nextest
-          # Consider setting `doCheck = false` on `ast-outline` if you do not want
+          # Consider setting `doCheck = false` on `astOutline` if you do not want
           # the tests to run twice
-          my-crate-nextest = craneLib.cargoNextest (
+          astOutlineNextest = craneLib.cargoNextest (
             commonArgs
             // {
               inherit cargoArtifacts;
@@ -112,17 +128,20 @@
           );
         };
 
+        # This is equivalent to packages.<system>.default
         packages = {
-          default = ast-outline;
+          default = astOutline;
         };
 
-        apps.default = flake-utils.lib.mkApp {
-          drv = ast-outline;
+        apps.default = {
+          type = "app";
+          program = lib.getExe astOutline;
+          inherit (astOutline) meta;
         };
 
         devShells.default = craneLib.devShell {
           # Inherit inputs from checks.
-          checks = self.checks.${system};
+          checks = self'.checks;
 
           # Additional dev-shell environment variables can be set directly
           # MY_CUSTOM_DEVELOPMENT_VAR = "something else";
@@ -132,6 +151,14 @@
             # pkgs.ripgrep
           ];
         };
-      }
-    );
+      };
+
+      flake = {
+        # The usual flake attributes can be defined here, including
+        # system-agnostic and/or arbitrary outputs.
+      };
+
+      # Declared systems that your flake supports. These will be enumerated in perSystem
+      systems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
+    };
 }

--- a/src/adapters/go.rs
+++ b/src/adapters/go.rs
@@ -106,8 +106,8 @@ fn _walk_top<'a, D: Doc>(node: &Node<'a, D>, src: &[u8], out: &mut Vec<Declarati
     // Attach methods
     for (recv, method) in pending_methods {
         if let Some(&idx) = type_index.get(&recv) {
-            let target = if package_ns.is_some() {
-                &mut package_ns.as_mut().unwrap().children[idx]
+            let target = if let Some(ref mut inner) = package_ns {
+                &mut inner.children[idx]
             } else {
                 &mut out[idx]
             };
@@ -596,13 +596,17 @@ fn _spec_to_field<'a, D: Doc>(
     let name = name_node.text().into_owned();
 
     let mut docs = _go_docs(node);
-    if docs.is_empty() && outer_doc_anchor.is_some() {
-        docs = _go_docs(outer_doc_anchor.as_ref().unwrap());
+    if docs.is_empty() {
+        if let Some(ref inner) = outer_doc_anchor {
+            docs = _go_docs(inner);
+        }
     }
 
     let mut doc_start = _leading_doc_start_byte(node);
-    if doc_start.is_none() && outer_doc_anchor.is_some() {
-        doc_start = _leading_doc_start_byte(outer_doc_anchor.as_ref().unwrap());
+    if doc_start.is_none() {
+        if let Some(ref inner) = outer_doc_anchor {
+            doc_start = _leading_doc_start_byte(inner);
+        }
     }
     let doc_start = doc_start.unwrap_or(node.range().start);
 

--- a/src/adapters/markdown.rs
+++ b/src/adapters/markdown.rs
@@ -196,12 +196,8 @@ fn _end_line_ts(node: tree_sitter::Node) -> usize {
 
 fn _find_heading_ts(section: tree_sitter::Node) -> Option<tree_sitter::Node> {
     let mut cursor = section.walk();
-    for c in section.named_children(&mut cursor) {
-        if c.kind() == "atx_heading" || c.kind() == "setext_heading" {
-            return Some(c);
-        }
-    }
-    None
+    let ret = section.named_children(&mut cursor).find(|&c| c.kind() == "atx_heading" || c.kind() == "setext_heading");
+    ret
 }
 
 fn _heading_level_and_title_ts(heading: tree_sitter::Node, src: &[u8]) -> (usize, String) {

--- a/src/adapters/python.rs
+++ b/src/adapters/python.rs
@@ -129,9 +129,9 @@ fn _class_to_decl<'a, D: Doc>(node: &Node<'a, D>, src: &[u8]) -> Declaration {
 
     let mut sig = format!("class {}", name);
     if !bases.is_empty() {
-        sig.push_str("(");
+        sig.push('(');
         sig.push_str(&bases.join(", "));
-        sig.push_str(")");
+        sig.push(')');
     }
 
     let range = node.range();

--- a/src/adapters/typescript.rs
+++ b/src/adapters/typescript.rs
@@ -38,8 +38,8 @@ fn _walk_module<'a, D: Doc>(node: &Node<'a, D>, src: &[u8], out: &mut Vec<Declar
 fn _node_to_decl<'a, D: Doc>(
     node: &Node<'a, D>,
     src: &[u8],
-    inside_class: bool,
-    inside_interface: bool,
+    _inside_class: bool,
+    _inside_interface: bool,
 ) -> Option<Declaration> {
     let kind = node.kind();
 
@@ -55,7 +55,7 @@ fn _node_to_decl<'a, D: Doc>(
                 continue;
             }
             if _is_handled_top_level(inner.kind().as_ref()) {
-                if let Some(mut decl) = _node_to_decl(&inner, src, inside_class, inside_interface) {
+                if let Some(mut decl) = _node_to_decl(&inner, src, _inside_class, _inside_interface) {
                     decl.start_byte = node.range().start;
                     decl.start_line = node.start_pos().line() + 1;
                     let ds_byte = _leading_doc_start_byte(node).unwrap_or(node.range().start);

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,6 +1,6 @@
 use colored::Colorize;
 use serde::{Serialize, Serializer};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 // Stable JSON schema identifiers — bump on breaking changes.
 pub const JSON_SCHEMA_OUTLINE: &str = "ast-outline.outline.v1";
@@ -766,7 +766,7 @@ fn _digest_markdown(
     out
 }
 
-fn _serialize_path<S: Serializer>(p: &PathBuf, ser: S) -> Result<S::Ok, S::Error> {
+fn _serialize_path<S: Serializer>(p: &Path, ser: S) -> Result<S::Ok, S::Error> {
     ser.serialize_str(&p.to_string_lossy())
 }
 

--- a/src/hook/gemini.rs
+++ b/src/hook/gemini.rs
@@ -6,7 +6,7 @@
 //!
 //! Response shape matches Claude Code's:
 //!   pass-through: { "continue": true }
-//!   substitute:   { "decision": "block", "reason": "<content>" }
+//!   substitute:   { "decision": "block", "reason": "\<content\>" }
 
 use std::io::{self, Read, Write};
 use std::path::PathBuf;

--- a/src/installers/claude_code.rs
+++ b/src/installers/claude_code.rs
@@ -218,8 +218,7 @@ mod tests {
     fn dry_run_does_not_write() {
         let dir = TempDir::new().unwrap();
         let scope = local_scope(&dir);
-        let mut opts = InstallOpts::default();
-        opts.dry_run = true;
+        let opts = InstallOpts { dry_run: true, ..Default::default() };
         ClaudeCode.install_prompt(&scope, &opts).unwrap();
         assert!(!dir.path().join("CLAUDE.md").exists());
     }

--- a/src/installers/json_hook.rs
+++ b/src/installers/json_hook.rs
@@ -14,7 +14,7 @@ where
     F: Fn(&Value) -> bool,
 {
     let arr = ensure_array(root, path);
-    if let Some(pos) = arr.iter().position(|v| matches(v)) {
+    if let Some(pos) = arr.iter().position(matches) {
         if arr[pos] == entry {
             return false;
         }
@@ -46,7 +46,7 @@ where
         Some(a) => a,
         None => return false,
     };
-    arr.iter().any(|v| matches(v))
+    arr.iter().any(matches)
 }
 
 fn ensure_array<'a>(root: &'a mut Value, path: &[&str]) -> &'a mut Vec<Value> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -175,7 +175,7 @@ fn walk_and_parse(paths: &[PathBuf], glob_str: Option<&str>) -> Vec<ParseResult>
         let tx = tx.clone();
         Box::new(move |result| {
             if let Ok(entry) = result {
-                if entry.file_type().map_or(false, |ft| ft.is_file()) {
+                if entry.file_type().is_some_and(|ft| ft.is_file()) {
                     if let Some(parsed) = parse_file(entry.path()) {
                         let _ = tx.send(parsed);
                     }
@@ -375,7 +375,7 @@ fn main() {
         } else {
             for res in results {
                 println!("{}", crate::core::render_outline(&res, &opts));
-                println!("");
+                println!();
             }
         }
     } else {
@@ -540,6 +540,7 @@ fn names(registry: &[Box<dyn installers::Installer>]) -> String {
 /// skip targets whose `detect()` reports the CLI is absent (and print a
 /// note). For `Scope::Local`, the user explicitly opted into this repo
 /// so detection is bypassed.
+#[allow(clippy::borrowed_box)]
 fn select_all<'a>(
     registry: &'a [Box<dyn installers::Installer>],
     scope: &installers::Scope,


### PR DESCRIPTION
* fixed all clippy warnings, `nix flake check` doesn't show errors anymore
* reorganized the flake
    * moved from flake-utils to flake parts
    * removed cargo-fmt and toml-fmt checks -> don't want to incur on formatting
    * metadata now comes from Cargo.toml

