### PR TITLE
Fix Homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ Want to see exactly what ast-outline walks? Compare `ast-outline digest some/dir
 ### Homebrew (macOS)
 
 ```bash
-brew install aeroxy/ast-outline/ast-outline
+brew tap aeroxy/ast-outline https://github.com/aeroxy/ast-outline
+brew install ast-outline
 ```
 
 ### Cargo


### PR DESCRIPTION
Previous command didn't work for me:

```
> brew install aeroxy/ast-outline/ast-outline

 ==> Tapping aeroxy/ast-outline
 Cloning into '/opt/homebrew/Library/Taps/aeroxy/homebrew-ast-outline'...
 ERROR: Repository not found.
 fatal: Could not read from remote repository.

 Please make sure you have the correct access rights
 and the repository exists.
 Error: Failure while executing; `git clone https://github.com/aeroxy/homebrew-ast-outline /opt/homebrew/Library/Taps/aeroxy/homebrew-ast-outline --origin=origin --template= --config
 core.fsmonitor=false` exited with 128.
```