### PR TITLE
fix: trim extra white space in comments for `ast-bro map`

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -667,6 +667,16 @@ fn _collect_counts(decls: &[Declaration]) -> std::collections::HashMap<&'static 
 fn _render_decl(decl: &Declaration, opts: &MapOptions, indent: usize, out: &mut Vec<String>) {
     use DeclarationKind::*;
 
+    let push_docs = |prefix: &str, lines_out: &mut Vec<String>| {
+        for d in _clip_docs(&decl.docs, opts.max_doc_lines) {
+            lines_out.push(format!(
+                "{}{}",
+                prefix,
+                d.trim_end_matches(&['\r', '\n'][..])
+            ));
+        }
+    };
+
     let is_field = matches!(decl.kind, Field | Property | Event | Indexer);
     if is_field && !opts.include_fields {
         return;
@@ -678,9 +688,7 @@ fn _render_decl(decl: &Declaration, opts: &MapOptions, indent: usize, out: &mut 
     let prefix = "    ".repeat(indent);
 
     if opts.include_docs && !decl.docs.is_empty() && !decl.docs_inside {
-        for d in _clip_docs(&decl.docs, opts.max_doc_lines) {
-            out.push(format!("{}{}", prefix, d));
-        }
+        push_docs(&prefix, out);
     }
 
     let attrs_prefix = if opts.include_attributes && !decl.attrs.is_empty() {
@@ -710,9 +718,7 @@ fn _render_decl(decl: &Declaration, opts: &MapOptions, indent: usize, out: &mut 
 
     if opts.include_docs && !decl.docs.is_empty() && decl.docs_inside {
         let inner_prefix = "    ".repeat(indent + 1);
-        for d in _clip_docs(&decl.docs, opts.max_doc_lines) {
-            out.push(format!("{}{}", inner_prefix, d));
-        }
+        push_docs(&inner_prefix, out);
     }
 
     for child in &decl.children {


### PR DESCRIPTION
before:

```
❌130 ❯ ast-outline map src/surface/module_graph.rs
# src/surface/module_graph.rs ([tiny], 44 lines, 1528 chars, 1 methods)
/// Returns the resolved file path for a `mod foo;` reference declared in

/// `containing_file`, or `None` if no candidate exists on disk.

pub fn resolve_mod_file(containing_file: &Path, m: &ModRef) -> Option<PathBuf>  L22-43
```

after:

```
❯ nix run . -- map src/surface/module_graph.rs
# src/surface/module_graph.rs ([tiny], 44 lines, 1528 chars, 1 methods)
/// Returns the resolved file path for a `mod foo;` reference declared in
/// `containing_file`, or `None` if no candidate exists on disk.
pub fn resolve_mod_file(containing_file: &Path, m: &ModRef) -> Option<PathBuf>  L22-43
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Documentation output now trims trailing carriage returns/newlines from each line, producing cleaner, more consistent displayed docs.
  * No changes to rendering flow or visible behavior beyond the trimmed line endings; overall formatting of documentation shown in the UI is improved with no other regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aeroxy/ast-bro/pull/17?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->