### PR TITLE
feat: add squeeze cmd

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,6 @@ The architecture page links to six deeper wiki files — read them on-demand whe
 - [wiki/deps.md](wiki/deps.md) — dependency-graph internals (deps / reverse-deps / cycles / graph)
 - [wiki/calls.md](wiki/calls.md) — call-graph internals (callers / callees, three-pass resolver, unified graph cache, per-language extraction)
 - [wiki/search.md](wiki/search.md) — semantic search internals (BM25 + dense, chunking, on-disk format)
-- [wiki/squeeze.md](wiki/squeeze.md) — log/text token compression (squeeze): ported `logs-tokenizer` pipeline, reversible legend, degenerate fallback
+- [wiki/squeeze.md](wiki/squeeze.md) — log/text token compression (squeeze): multi-stage pipeline, reversible legend, degenerate fallback
 - [wiki/network-security.md](wiki/network-security.md) — model download, TLS policy, mirror fallback
 - [wiki/file-filtering.md](wiki/file-filtering.md) — what gets walked, ignore layers, escape hatches

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,10 +8,11 @@
 
 @wiki/architecture.md
 
-The architecture page links to five deeper wiki files — read them on-demand when your work touches that subsystem:
+The architecture page links to six deeper wiki files — read them on-demand when your work touches that subsystem:
 
 - [wiki/deps.md](wiki/deps.md) — dependency-graph internals (deps / reverse-deps / cycles / graph)
 - [wiki/calls.md](wiki/calls.md) — call-graph internals (callers / callees, three-pass resolver, unified graph cache, per-language extraction)
 - [wiki/search.md](wiki/search.md) — semantic search internals (BM25 + dense, chunking, on-disk format)
+- [wiki/squeeze.md](wiki/squeeze.md) — log/text token compression (squeeze): ported `logs-tokenizer` pipeline, reversible legend, degenerate fallback
 - [wiki/network-security.md](wiki/network-security.md) — model download, TLS policy, mirror fallback
 - [wiki/file-filtering.md](wiki/file-filtering.md) — what gets walked, ignore layers, escape hatches

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ast-bro
 
-Fast, AST-based **code-navigation toolkit** for source files — surface the *shape* of a file (signatures with line numbers, no method bodies), the *true public API* of a package, the *dependency graph* between files, the *call graph* between symbols, and search the repo by *symbol* or *behaviour*. Fourteen subcommands, one binary, built for LLM coding agents and humans who’d rather not waste tokens reading every file just to understand a codebase.
+Fast, AST-based **code-navigation toolkit** for source files — surface the *shape* of a file (signatures with line numbers, no method bodies), the *true public API* of a package, the *dependency graph* between files, the *call graph* between symbols, search the repo by *symbol* or *behaviour*, and *squeeze* repetitive logs into a smaller, reversible form. Fifteen subcommands, one binary, built for LLM coding agents and humans who’d rather not waste tokens reading every file just to understand a codebase.
 
 [ast-bro](https://github.com/aeroxy/ast-bro) is written in Rust and uses [ast-grep](https://github.com/ast-grep/ast-grep)’s incredibly fast [tree-sitter](https://github.com/tree-sitter/tree-sitter) bindings. Thanks to [rayon](https://github.com/rayon-rs/rayon), it parses your entire workspace concurrently—often in milliseconds. For Google- or ByteDance-scale monorepos, [ast-bro](https://github.com/aeroxy/ast-bro) benefits from the additional abstraction layer provided by [repolayer](https://github.com/zhousiyao03-cyber/repolayer).
 
@@ -30,7 +30,8 @@ Modern agentic coding tools explore codebases by reading files directly. That's 
 3. **Dependency graph for free.** `deps` / `reverse-deps` / `cycles` / `graph` build a file-level import graph (Rust, Python, TS/JS, Java, C#, Kotlin, Scala, Go) cached at `.ast-bro/graph/`. Use `reverse-deps` before refactoring to know the blast radius. `cycles` exits non-zero — wire it into a CI gate. `graph` emits the full dependency graph (text by default, `--json` for JSON).
 4. **Symbol-level call graph.** `callers` / `callees` answer "who calls X" and "what does X call" with AST accuracy across all 14 languages — no `grep` false positives on overloaded names, comments, or string literals. Both are kind-aware: ask for a function and you get call-sites; ask for a type and you get implementors / constructions / ancestors. A three-pass resolver (same-file → global symbol table → dep-graph disambiguation) tags every edge `Exact` / `Inferred` / `Ambiguous` so you can filter by precision. Same on-disk cache as the dep graph.
 5. **Hybrid semantic search.** `search` runs BM25 + dense embeddings via [`potion-code-16M`](https://huggingface.co/minishlab/potion-code-16M) (a static, no-inference model — ~64 MB, runs on CPU in microseconds). `find-related` returns chunks structurally similar to one you already have, with a dep-graph-aware boost when a graph cache exists.
-6. **Fourteen native MCP tools.** Every CLI command is also exposed as an MCP tool — `ast-bro install --mcp <agent>` wires it into Claude Code, Cursor, Gemini, Codex, or VS Code Copilot in one line.
+6. **Squeeze logs, not just code.** `squeeze` compresses a repetitive log/text file into a smaller, reversible form (a legend plus short tags) so a noisy log costs far fewer tokens to hand to an agent — and falls back to the raw text when squeezing wouldn't help. This is for *logs/text*, not code (for code, `map` / `digest` / `show` are the token win).
+7. **Fifteen native MCP tools.** Every CLI command is also exposed as an MCP tool — `ast-bro install --mcp <agent>` wires it into Claude Code, Cursor, Gemini, Codex, or VS Code Copilot in one line.
 
 ### The workflow
 
@@ -213,6 +214,12 @@ ast-bro find-related src/auth/login.rs:42
 ast-bro index            # build or refresh
 ast-bro index --stats    # show chunk count, model, etc.
 ast-bro index --rebuild  # drop cache and rebuild
+
+# Squeeze a repetitive log/text file into a smaller, reversible form (logs, not code)
+ast-bro squeeze app.log                 # compress; falls back to raw if it wouldn't help
+ast-bro squeeze app.log 1000:2000       # only a line range
+ast-bro squeeze app.log --raw           # skip compression (raw + header, for diffing)
+ast-bro squeeze app.log --json          # ast-bro.squeeze.v1 (legend + body + sizes)
 
 # Output a prompt snippet to steer LLM agents
 ast-bro prompt >> AGENTS.md
@@ -404,6 +411,7 @@ changes, so downstream tooling can guard on it:
 | `ast-bro.search.v1` | `search --json` |
 | `ast-bro.related.v1` | `find-related --json` |
 | `ast-bro.index-stats.v1` | `index --stats --json` |
+| `ast-bro.squeeze.v1` | `squeeze --json` |
 
 ---
 
@@ -417,7 +425,7 @@ as native tools — no shell parsing required:
 ast-bro mcp
 ```
 
-The server speaks line-delimited JSON-RPC 2.0 on stdin/stdout and exposes fourteen
+The server speaks line-delimited JSON-RPC 2.0 on stdin/stdout and exposes fifteen
 tools that map 1:1 to the CLI commands:
 
 | Tool | Equivalent CLI | Returns |
@@ -436,6 +444,7 @@ tools that map 1:1 to the CLI commands:
 | `search`       | `ast-bro search "<query>"`           | text, or `ast-bro.search.v1` with `json: true` |
 | `find_related` | `ast-bro find-related <file>:<line>` | text, or `ast-bro.related.v1` with `json: true` |
 | `index`        | `ast-bro index`                      | text, or `ast-bro.index-stats.v1` with `json: true` |
+| `squeeze`      | `ast-bro squeeze <file>`             | text, or `ast-bro.squeeze.v1` with `json: true` |
 
 Wire it into a client by pointing at the binary:
 

--- a/skills/ast-bro/SKILL.md
+++ b/skills/ast-bro/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ast-bro
-description: AST-based code-navigation toolkit for source files. Surface the shape of a file (signatures with line numbers, no method bodies), the true public API of a package, the dependency graph between files, the call graph between symbols, and search the repo by symbol or behaviour.
+description: AST-based code-navigation toolkit for source files. Surface the shape of a file (signatures with line numbers, no method bodies), the true public API of a package, the dependency graph between files, the call graph between symbols, search the repo by symbol or behaviour, and squeeze repetitive logs/text into a smaller, reversible form.
 user-invocable: true
 ---
 
@@ -30,6 +30,7 @@ Commands:
   callees       What does this symbol call? — AST-accurate forward call traversal
   index         Build, refresh, or inspect the per-repo search index
   run           AST-aware search and rewrite using pattern matching with metavariables
+  squeeze       Compress repetitive log/text with a reversible legend
 
 Each command has `--json` for stable schemas and `--compact` for single-line JSON. Pass an unknown flag or no command and the help text prints automatically — there's no "default" command, every operation is explicit.
 
@@ -64,8 +65,11 @@ Stop at the step that answers the question:
 
 10. Find or rewrite by AST pattern — `sb run -p '<pattern>'`: structural search with metavariables (`$VAR`, `$$$` for splats). Add `-r '<rewrite>'` for a dry-run diff, or `-r '<rewrite>' --write` to apply in-place. Pass `--lang <lang>` to pre-compile the pattern (faster across many files; also fails fast on an invalid pattern). Use when you need a structural shape (`foo($$$)` regardless of args) rather than a text match.
 
+11. Compress a repetitive **log/text** file — `sb squeeze <file> [from:to]`: replaces repeated timestamps, tags, and token runs with short tags and prints a reversible legend, so a noisy log costs far fewer tokens to paste. This is for **logs/text, not code** — for code use `map` / `digest` / `show`. Auto-falls back to the raw text when squeezing would be larger. `--raw` skips compression; `--json` emits `ast-bro.squeeze.v1`.
+
 Path / argument expectations:
 - `deps`, `reverse-deps` → expect a file path
 - `graph`, `cycles` → expect a directory (repo root)
 - `callers`, `callees` → expect a symbol name (function or type), not a path
 - `run` → expects a `-p <pattern>` flag, optionally `-r <rewrite>` and `--write`
+- `squeeze` → expects a file path, optionally a `from:to` line range

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -741,8 +741,12 @@ pub fn run() {
                 }
                 let text = match std::fs::read_to_string(path) {
                     Ok(t) => t,
-                    Err(_) => {
-                        println!("# note: not valid UTF-8: {}", path.display());
+                    Err(e) => {
+                        if path.is_dir() {
+                            println!("# note: path is a directory: {}", path.display());
+                        } else {
+                            println!("# note: could not read {}: {}", path.display(), e);
+                        }
                         return;
                     }
                 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ mod mcp;
 mod project_root;
 mod search;
 mod run;
+mod squeeze;
 mod surface;
 
 use crate::core::{DigestOptions, MapOptions, ParseResult};
@@ -62,6 +63,28 @@ enum Commands {
         symbol: String,
         #[arg(num_args = 0..)]
         others: Vec<String>,
+        /// Emit output as JSON instead of text
+        #[arg(long)]
+        json: bool,
+        /// With --json: emit compact (single-line) JSON
+        #[arg(long)]
+        compact: bool,
+    },
+    /// Compress repetitive log/text into a smaller, reversible form with a legend.
+    ///
+    /// For **logs and text**, not code — for code use `map` / `digest` / `show`.
+    /// Shrinks repeated lines, tags, timestamps and token sequences; prints a legend
+    /// so the original is recoverable. Falls back to the raw input when squeezing
+    /// would make it larger.
+    Squeeze {
+        /// Path to the log/text file to read.
+        path: PathBuf,
+        /// Optional 1-indexed inclusive line range: `N`, `A:B`, `A:`, or `:B`.
+        #[arg(value_parser = parse_line_range)]
+        range: Option<LineRange>,
+        /// Skip compression — emit the raw text with a header (for diffing/inspecting).
+        #[arg(long)]
+        raw: bool,
         /// Emit output as JSON instead of text
         #[arg(long)]
         json: bool,
@@ -412,6 +435,61 @@ pub(crate) fn parse_file(path: &Path) -> Option<ParseResult> {
     crate::main_helpers::parse_file_for_hook(path)
 }
 
+/// A 1-indexed, inclusive line range for `squeeze`. Either bound may be open:
+/// `start` defaults to line 1, `end` defaults to EOF. Maps cleanly to the
+/// `Option<(usize, usize)>` the squeeze renderer expects via [`LineRange::resolve`].
+#[derive(Clone, Debug)]
+pub struct LineRange {
+    pub start: Option<usize>,
+    pub end: Option<usize>,
+}
+
+impl LineRange {
+    /// Collapse to the `(start, end)` pair the report uses, filling open bounds
+    /// with line 1 / `usize::MAX` (the slicer clamps `end` to the real EOF).
+    fn resolve(&self) -> (usize, usize) {
+        (self.start.unwrap_or(1), self.end.unwrap_or(usize::MAX))
+    }
+}
+
+/// Clap value parser for `squeeze`'s optional range argument. Accepts:
+/// `N` (single line), `A:B` (inclusive), `A:` (A to EOF), `:B` (start to B).
+/// All bounds are 1-indexed; `0` and `A > B` are rejected. Clamping to the
+/// file's real line count happens later in the slicer.
+fn parse_line_range(s: &str) -> Result<LineRange, String> {
+    let parse_bound = |part: &str| -> Result<Option<usize>, String> {
+        if part.is_empty() {
+            return Ok(None);
+        }
+        match part.parse::<usize>() {
+            Ok(0) => Err("line numbers are 1-indexed (got 0)".to_string()),
+            Ok(n) => Ok(Some(n)),
+            Err(_) => Err(format!("invalid line number: {part:?}")),
+        }
+    };
+
+    let range = match s.split_once(':') {
+        // `A:B`, `A:`, `:B`, or `:`
+        Some((a, b)) => LineRange {
+            start: parse_bound(a)?,
+            end: parse_bound(b)?,
+        },
+        // `N` — single line, both bounds equal
+        None => {
+            let n = parse_bound(s)?;
+            LineRange { start: n, end: n }
+        }
+    };
+
+    if let (Some(start), Some(end)) = (range.start, range.end) {
+        if start > end {
+            return Err(format!("range start {start} is after end {end}"));
+        }
+    }
+
+    Ok(range)
+}
+
 /// Parse `<FILE>:<LINE>` into the two parts. Returns `None` if there's no
 /// colon or the suffix doesn't parse as a u32. Used by `find-related`.
 fn parse_file_line(s: &str) -> Option<(String, u32)> {
@@ -648,6 +726,39 @@ pub fn run() {
                         "# note: unsupported file type for `show`: {}",
                         path.display()
                     );
+                }
+            }
+            Commands::Squeeze {
+                path,
+                range,
+                raw,
+                json,
+                compact,
+            } => {
+                if !path.exists() {
+                    println!("# note: path not found: {}", path.display());
+                    return;
+                }
+                let text = match std::fs::read_to_string(path) {
+                    Ok(t) => t,
+                    Err(_) => {
+                        println!("# note: not valid UTF-8: {}", path.display());
+                        return;
+                    }
+                };
+                let resolved: Option<(usize, usize)> = range.as_ref().map(LineRange::resolve);
+                let sliced = crate::squeeze::render::slice_lines(&text, resolved);
+                let path_str = path.display().to_string();
+                let report = crate::squeeze::render::SqueezeReport {
+                    path: &path_str,
+                    range: resolved,
+                    raw: &sliced,
+                    raw_requested: *raw,
+                };
+                if *json {
+                    println!("{}", crate::squeeze::render::render_json(&report, !(*compact)));
+                } else {
+                    println!("{}", crate::squeeze::render::render_text(&report));
                 }
             }
             Commands::Digest {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -446,10 +446,21 @@ pub struct LineRange {
 
 impl LineRange {
     /// Collapse to the `(start, end)` pair the report uses, filling open bounds
-    /// with line 1 / `usize::MAX` (the slicer clamps `end` to the real EOF).
-    fn resolve(&self) -> (usize, usize) {
-        (self.start.unwrap_or(1), self.end.unwrap_or(usize::MAX))
+    /// with line 1 / EOF and clamping `end` to the real line count so JSON
+    /// consumers never see an out-of-range sentinel like `usize::MAX`.
+    fn resolve(&self, line_count: usize) -> (usize, usize) {
+        clamp_line_range(self.start.unwrap_or(1), self.end, line_count)
     }
+}
+
+/// Clamp a 1-indexed inclusive line range to a file's real line count.
+pub(crate) fn clamp_line_range(
+    start: usize,
+    end: Option<usize>,
+    line_count: usize,
+) -> (usize, usize) {
+    let end = end.unwrap_or(line_count).min(line_count).max(start);
+    (start, end)
 }
 
 /// Clap value parser for `squeeze`'s optional range argument. Accepts:
@@ -750,7 +761,9 @@ pub fn run() {
                         return;
                     }
                 };
-                let resolved: Option<(usize, usize)> = range.as_ref().map(LineRange::resolve);
+                let line_count = text.lines().count();
+                let resolved: Option<(usize, usize)> =
+                    range.as_ref().map(|r| r.resolve(line_count));
                 let sliced = crate::squeeze::render::slice_lines(&text, resolved);
                 let path_str = path.display().to_string();
                 let report = crate::squeeze::render::SqueezeReport {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -257,6 +257,21 @@ pub fn list() -> Value {
                     },
                     "required": ["pattern"]
                 }
+            },
+            {
+                "name": "squeeze",
+                "description": "Compress repetitive log/text with a reversible legend (logs, not code).",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "path":  { "type": "string",  "description": "Path to the log/text file to read." },
+                        "start": { "type": "integer", "description": "1-indexed inclusive start line of the slice.", "minimum": 1 },
+                        "end":   { "type": "integer", "description": "1-indexed inclusive end line of the slice.", "minimum": 1 },
+                        "raw":   { "type": "boolean", "description": "Skip compression and emit the raw text." },
+                        "json":  { "type": "boolean", "description": "Return JSON (schema `ast-bro.squeeze.v1`) instead of text." }
+                    },
+                    "required": ["path"]
+                }
             }
         ]
     })
@@ -286,6 +301,7 @@ pub fn call(name: &str, args: Value) -> CallResult {
         "callers"      => run_callers(args),
         "callees"      => run_callees(args),
         "run"          => run_run(args),
+        "squeeze"      => run_squeeze(args),
         other => CallResult::Error(format!("unknown tool: {}", other)),
     }
 }
@@ -1094,5 +1110,57 @@ fn run_run(args: Value) -> CallResult {
             output.push_str(&format!("\n# warning: reached safety cap of {} matches; remaining files were not processed.", MCP_SEARCH_MAX_MATCHES));
         }
         CallResult::Text(output)
+    }
+}
+
+// ---- squeeze (log/text compression with a reversible legend) ----
+
+#[derive(Deserialize)]
+struct SqueezeArgs {
+    path: PathBuf,
+    #[serde(default)] start: Option<usize>,
+    #[serde(default)] end: Option<usize>,
+    #[serde(default)] raw: bool,
+    #[serde(default)] json: bool,
+}
+
+fn run_squeeze(args: Value) -> CallResult {
+    let a: SqueezeArgs = match serde_json::from_value(args) {
+        Ok(v) => v,
+        Err(e) => return CallResult::Error(format!("invalid arguments: {}", e)),
+    };
+    // Explicit single file → read directly, no walk / no file_filter.
+    // Non-UTF8 (read_to_string err) surfaces as a tool error rather than
+    // squeezing raw bytes.
+    let text = match std::fs::read_to_string(&a.path) {
+        Ok(s) => s,
+        Err(e) => return CallResult::Error(format!("could not read {}: {}", a.path.display(), e)),
+    };
+    // Build the 1-indexed inclusive range. Both bounds absent → None (whole
+    // file). A partial bound defaults the other end to the file's natural
+    // extent (start→1, end→usize::MAX), letting slice_lines clamp.
+    let range: Option<(usize, usize)> = match (a.start, a.end) {
+        (None, None) => None,
+        (s, e) => Some((s.unwrap_or(1), e.unwrap_or(usize::MAX))),
+    };
+    // Match the CLI's `parse_line_range` validation so both front-ends agree on
+    // what an invalid range is (rather than silently returning an empty slice).
+    if let (Some(s), Some(e)) = (a.start, a.end) {
+        if s > e {
+            return CallResult::Error(format!("range start {} is after end {}", s, e));
+        }
+    }
+    let sliced = crate::squeeze::render::slice_lines(&text, range);
+    let path_str = a.path.to_string_lossy();
+    let report = crate::squeeze::render::SqueezeReport {
+        path: &path_str,
+        range,
+        raw: &sliced,
+        raw_requested: a.raw,
+    };
+    if a.json {
+        CallResult::Text(crate::squeeze::render::render_json(&report, true))
+    } else {
+        CallResult::Text(crate::squeeze::render::render_text(&report))
     }
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1129,6 +1129,11 @@ fn run_squeeze(args: Value) -> CallResult {
         Ok(v) => v,
         Err(e) => return CallResult::Error(format!("invalid arguments: {}", e)),
     };
+    // Match the CLI's 1-indexed line-number validation even if an MCP client
+    // bypasses the JSON schema's `minimum: 1` constraint.
+    if a.start == Some(0) || a.end == Some(0) {
+        return CallResult::Error("line numbers are 1-indexed (got 0)".to_string());
+    }
     // Explicit single file → read directly, no walk / no file_filter.
     // Non-UTF8 (read_to_string err) surfaces as a tool error rather than
     // squeezing raw bytes.

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1141,12 +1141,13 @@ fn run_squeeze(args: Value) -> CallResult {
         Ok(s) => s,
         Err(e) => return CallResult::Error(format!("could not read {}: {}", a.path.display(), e)),
     };
+    let line_count = text.lines().count();
     // Build the 1-indexed inclusive range. Both bounds absent → None (whole
     // file). A partial bound defaults the other end to the file's natural
-    // extent (start→1, end→usize::MAX), letting slice_lines clamp.
+    // extent (start→1, end→EOF), clamped before we serialize the report.
     let range: Option<(usize, usize)> = match (a.start, a.end) {
         (None, None) => None,
-        (s, e) => Some((s.unwrap_or(1), e.unwrap_or(usize::MAX))),
+        (s, e) => Some(crate::clamp_line_range(s.unwrap_or(1), e, line_count)),
     };
     // Match the CLI's `parse_line_range` validation so both front-ends agree on
     // what an invalid range is (rather than silently returning an empty slice).

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -21,6 +21,7 @@ Commands:
   search        Hybrid BM25 + dense semantic search over the repo
   find-related  Find chunks semantically similar to a given file:line
   surface       True public API surface — resolves `pub use` / `__all__` re-exports
+  squeeze       Compress repetitive log/text with a reversible legend
   deps          Forward import-graph traversal: what does this file import (transitively)?
   reverse-deps  Reverse import-graph: who imports this file (transitively)?
   cycles        Find import cycles via Tarjan SCC

--- a/src/squeeze/mod.rs
+++ b/src/squeeze/mod.rs
@@ -62,7 +62,7 @@ static RE_TS: LazyLock<Regex> =
 static RE_COMP: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\[[A-Za-z0-9_-]+\]").unwrap());
 static RE_KEYS: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\b[A-Za-z0-9_]+={1,2}").unwrap());
 static RE_NO_TIME: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^#T#\d{2}\.\d{3}\s*").unwrap());
+    LazyLock::new(|| Regex::new(r"^#T#\d{2}(?:\.\d+)?\s*").unwrap());
 
 /// Result of compressing a chunk of log/text.
 pub struct Squeezed {

--- a/src/squeeze/mod.rs
+++ b/src/squeeze/mod.rs
@@ -34,6 +34,7 @@
 pub mod render;
 
 use regex::Regex;
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
@@ -316,11 +317,27 @@ impl Compressor {
         // (the upstream left ties to HashMap order, which is non-deterministic).
         sorted.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
 
-        for (pat, _) in sorted {
+        let mut replacements: HashMap<String, String> = HashMap::with_capacity(sorted.len());
+        for (pat, _) in &sorted {
             let token = self.get_var_token();
-            *text = text.replace(&pat, &token);
             self.legend.push(format!("{} = {}", token, pat));
+            replacements.insert(pat.clone(), token);
         }
+
+        let mut rewritten = String::with_capacity(text.len());
+        let mut last_end = 0;
+        for mat in re.find_iter(text) {
+            rewritten.push_str(&text[last_end..mat.start()]);
+            let matched = mat.as_str();
+            if let Some(token) = replacements.get(matched) {
+                rewritten.push_str(token);
+            } else {
+                rewritten.push_str(matched);
+            }
+            last_end = mat.end();
+        }
+        rewritten.push_str(&text[last_end..]);
+        *text = rewritten;
     }
 
     fn run_bpe<S: BpeStrategy>(&mut self, text: String, max_iter: usize, strategy: S) -> String {
@@ -395,8 +412,8 @@ impl Compressor {
             // so equal-savings ties depended on hash order. We instead resolve
             // ties by the candidate's rendered phrase (lexicographic), which is
             // stable across runs.
-            let (mut best_slice, mut best_savings): (&[u32], i32) = (&[][..], 0);
-            let mut best_phrase: Option<String> = None;
+            let mut best_slice: &[u32] = &[];
+            let mut best_savings = 0;
             for (slice, &count) in &counts {
                 if count > 1 {
                     let phrase_len: usize =
@@ -408,18 +425,10 @@ impl Compressor {
                     if savings > best_savings {
                         best_savings = savings;
                         best_slice = *slice;
-                        best_phrase = None; // recomputed lazily on tie below
                     } else if savings == best_savings && savings >= BPE_MIN_SAVINGS {
-                        let cand: String =
-                            slice.iter().map(|&id| id_to_str[id as usize].as_str()).collect();
-                        let cur = best_phrase.get_or_insert_with(|| {
-                            best_slice
-                                .iter()
-                                .map(|&id| id_to_str[id as usize].as_str())
-                                .collect()
-                        });
-                        if &cand < cur {
-                            *cur = cand;
+                        let cand_bytes = slice.iter().flat_map(|&id| id_to_str[id as usize].as_bytes());
+                        let best_bytes = best_slice.iter().flat_map(|&id| id_to_str[id as usize].as_bytes());
+                        if cand_bytes.cmp(best_bytes) == std::cmp::Ordering::Less {
                             best_slice = *slice;
                         }
                     }
@@ -604,13 +613,14 @@ impl Compressor {
     }
 
     fn deduplicate_lines(&self, text: &str) -> Vec<String> {
-        let (mut final_lines, mut dup_count, mut last_line) = (Vec::new(), 0, String::new());
+        let (mut final_lines, mut dup_count) = (Vec::new(), 0);
+        let mut last_line: Cow<'_, str> = Cow::Borrowed("");
         for line in text.lines() {
             if line.trim().is_empty() {
                 continue;
             }
 
-            let line_no_time = RE_NO_TIME.replace(line, "").into_owned();
+            let line_no_time = RE_NO_TIME.replace(line, "");
             if line_no_time == last_line && !line_no_time.is_empty() {
                 dup_count += 1;
                 continue;
@@ -785,5 +795,23 @@ mod tests {
         let (tag, val) = split_legend_entry("#0# = a = b".to_string());
         assert_eq!(tag, "#0#");
         assert_eq!(val, "a = b");
+    }
+
+    #[test]
+    fn replace_frequent_does_not_corrupt_substring_patterns() {
+        let input = "\
+[WinFocus] changed
+[WinFocusMonitor] changed
+[WinFocus] changed
+[WinFocusMonitor] changed";
+        let mut text = input.to_string();
+        let mut c = Compressor::new();
+
+        c.replace_frequent(&mut text, &RE_COMP);
+
+        let legend: Vec<_> = c.legend.into_iter().map(split_legend_entry).collect();
+        let restored = expand(&text, &legend);
+        assert_eq!(restored, input);
+        assert_eq!(legend.len(), 2, "both component names should be replaced");
     }
 }

--- a/src/squeeze/mod.rs
+++ b/src/squeeze/mod.rs
@@ -119,8 +119,7 @@ fn to_base62(mut n: usize) -> String {
         n /= RADIX;
     }
     res.reverse();
-    // SAFETY: BASE62 is ASCII, so every pushed byte is valid UTF-8.
-    unsafe { String::from_utf8_unchecked(res) }
+    String::from_utf8(res).expect("BASE62 is valid ASCII")
 }
 
 #[inline]
@@ -426,8 +425,9 @@ impl Compressor {
                         best_savings = savings;
                         best_slice = *slice;
                     } else if savings == best_savings && savings >= BPE_MIN_SAVINGS {
-                        let cand_bytes = slice.iter().flat_map(|&id| id_to_str[id as usize].as_bytes());
-                        let best_bytes = best_slice.iter().flat_map(|&id| id_to_str[id as usize].as_bytes());
+                        let to_bytes = |&id: &u32| id_to_str[id as usize].as_bytes();
+                        let cand_bytes = slice.iter().flat_map(to_bytes);
+                        let best_bytes = best_slice.iter().flat_map(to_bytes);
                         if cand_bytes.cmp(best_bytes) == std::cmp::Ordering::Less {
                             best_slice = *slice;
                         }

--- a/src/squeeze/mod.rs
+++ b/src/squeeze/mod.rs
@@ -1,9 +1,9 @@
 //! Log/text token compressor — the pure engine behind `sb squeeze`.
 //!
-//! Ported from `../logs-tokenizer/src/core/mod.rs` (a clipboard tool). The
-//! algorithm is unchanged; this module just exposes it as a dependency-light,
-//! I/O-free function and returns the legend as structured `(tag, value)` pairs
-//! instead of a pre-rendered string blob.
+//! A dependency-light, I/O-free function that collapses the repetitive structure
+//! of logs (timestamps, component tags, repeated token and tag runs) into short
+//! tags, returning the legend as structured `(tag, value)` pairs so the output
+//! round-trips back to the original.
 //!
 //! Pipeline (all stages kept — the input is logs, where most content is real):
 //! ```text
@@ -14,19 +14,18 @@
 //!   5a. BPE (normal)              repeated token runs       -> #n#
 //!   5b. BPE (meta)                repeated runs *of tags*   -> !n!
 //!   6. Macro templating           lines differing by 1 tag  -> &n + &n:val
-//!   7. Tag-sequence macros        repeated multi-tag runs   -> &n  (inert*)
 //!   dedup                         identical lines collapse  -> ... xN (lossy)
 //! ```
-//! \* Stage 7 never fires: its matcher relies on a `\1` backreference, which the
-//! `regex` crate rejects — upstream has the identical dead branch. Kept for port
-//! fidelity (see `run_tag_sequence_macro_templating`).
+//! (An earlier design had a 7th "tag-sequence macro" stage, but its matcher
+//! needs a `\1` backreference the `regex` crate rejects, so it never fired and
+//! was dropped rather than carried as dead code.)
 //!
-//! `regex` is the only external crate (already a dependency of this repo). The
-//! upstream tool used `once_cell::Lazy`; here we use `std::sync::LazyLock`.
+//! `regex` is the only external crate (already a dependency of this repo);
+//! `std::sync::LazyLock` holds the one-off compiled patterns.
 //!
 //! ## Determinism
 //! Tag assignment is fully deterministic so output is stable and testable.
-//! Wherever the upstream relied on `HashMap` iteration order to break ties
+//! Anywhere a tie could otherwise fall to `HashMap` iteration order
 //! (frequent-pattern ordering, BPE best-phrase selection, template ordering)
 //! we add an explicit, content-derived tie-breaker. Equal-savings candidates
 //! are resolved by their text (lexicographic), never by hash seed or clock.
@@ -41,7 +40,7 @@ use std::sync::LazyLock;
 const BASE62: &[u8] = b"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 const RADIX: usize = 62;
 
-// Tuning parameters for compression (ported verbatim).
+// Tuning parameters for compression.
 const BPE_MAX_ITERATIONS: usize = 100;
 const BPE_MIN_SAVINGS: i32 = 5;
 const MACRO_MIN_COUNT: usize = 4;
@@ -313,7 +312,7 @@ impl Compressor {
 
         let mut sorted: Vec<_> = counts.into_iter().filter(|&(_, c)| c > 1).collect();
         // Deterministic: most-frequent first, ties broken by the pattern text
-        // (the upstream left ties to HashMap order, which is non-deterministic).
+        // (a plain HashMap-order pick would be non-deterministic).
         sorted.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
 
         let mut replacements: HashMap<String, String> = HashMap::with_capacity(sorted.len());
@@ -406,9 +405,9 @@ impl Compressor {
                 }
             }
 
-            // Pick the highest-savings candidate. Determinism: the upstream
-            // iterated `counts` (a HashMap) and kept the first strict maximum,
-            // so equal-savings ties depended on hash order. We instead resolve
+            // Pick the highest-savings candidate. Determinism: iterating `counts`
+            // (a HashMap) and keeping the first strict maximum would make
+            // equal-savings ties depend on hash order, so we instead resolve
             // ties by the candidate's rendered phrase (lexicographic), which is
             // stable across runs.
             let mut best_slice: &[u32] = &[];
@@ -504,7 +503,7 @@ impl Compressor {
             .collect();
 
         // Deterministic: longest template first, then most matches, then the
-        // template text (final tie-break the upstream lacked).
+        // template text (a final, fully-deterministic tie-break).
         scores.sort_by(|a, b| {
             b.0.len()
                 .cmp(&a.0.len())
@@ -553,65 +552,6 @@ impl Compressor {
         lines.join("\n")
     }
 
-    /// NOTE: this stage is currently **inert** — faithfully so, matching upstream.
-    /// The per-template matcher (`re_str` below) uses a `\1` backreference, which
-    /// the standard `regex` crate does not support, so `Regex::new` returns `Err`
-    /// and the `if let Ok(re)` swallows it: no `&n` macro is ever emitted here.
-    /// `../logs-tokenizer` has the identical dead branch. Kept for port fidelity;
-    /// making it fire would require a backreference-free rewrite of `re_str`.
-    fn run_tag_sequence_macro_templating(&mut self, mut text: String) -> String {
-        let re_seq =
-            Regex::new(r"(?:(?:#(?:T|[0-9a-zA-Z]+)#|![0-9a-zA-Z]+!)[ \t]*){2,}").unwrap();
-        let mut templates: HashMap<String, usize> = HashMap::new();
-
-        for mat in re_seq.find_iter(&text) {
-            let seq = mat.as_str().trim_end();
-            for tag_mat in RE_TAGS.find_iter(seq) {
-                let mut template = seq.to_string();
-                template.replace_range(tag_mat.start()..tag_mat.end(), "@");
-                *templates.entry(template).or_insert(0) += 1;
-            }
-        }
-
-        let mut scores: Vec<_> = templates
-            .iter()
-            .map(|(t, &c)| (t.clone(), c, calc_savings(c, t.len())))
-            .filter(|&(_, count, sav)| sav > 0 || count >= MACRO_MIN_COUNT)
-            .collect();
-
-        // Deterministic: longest template, then count, then text.
-        scores.sort_by(|a, b| {
-            b.0.len()
-                .cmp(&a.0.len())
-                .then(b.1.cmp(&a.1))
-                .then_with(|| a.0.cmp(&b.0))
-        });
-
-        for (template, _, _) in scores {
-            let parts: Vec<&str> = template.split('@').collect();
-            if parts.len() != 2 {
-                continue;
-            }
-
-            let re_str = format!(
-                r"{}([#!])([0-9a-zA-Z]+)\1{}",
-                regex::escape(parts[0]),
-                regex::escape(parts[1])
-            );
-            if let Ok(re) = Regex::new(&re_str) {
-                let count = re.find_iter(&text).count();
-                if calc_savings(count, template.len()) > 0 || count >= MACRO_MIN_COUNT {
-                    let macro_tag = self.get_macro_token();
-                    self.legend.push(format!("{} = {}", macro_tag, template));
-                    text = re
-                        .replace_all(&text, format!("{}:$1$2$1", macro_tag).as_str())
-                        .into_owned();
-                }
-            }
-        }
-        text
-    }
-
     fn deduplicate_lines(&self, text: &str) -> Vec<String> {
         let (mut final_lines, mut dup_count) = (Vec::new(), 0);
         let mut last_line: Cow<'_, str> = Cow::Borrowed("");
@@ -641,7 +581,7 @@ impl Compressor {
 
     /// Run the full pipeline. Returns the compressed *body* only — the legend is
     /// accumulated on `self.legend` and exposed separately by `squeeze()`.
-    /// (The upstream prepended a `--- LEGEND ---` / `--- LOGS ---` block; here
+    /// (Rather than prepending a `--- LEGEND ---` / `--- LOGS ---` text block,
     /// the caller decides how to present the legend.)
     fn compress(&mut self, mut text: String) -> String {
         if text.trim().is_empty() {
@@ -654,8 +594,8 @@ impl Compressor {
         text = RE_ZEROS_4.replace_all(&text, "${1}${2}").into_owned();
 
         // Most-frequent ISO8601 prefix -> #T#. Determinism: when two prefixes
-        // tie on frequency, prefer the lexicographically smaller (the upstream
-        // `max_by_key` kept an arbitrary one).
+        // tie on frequency, prefer the lexicographically smaller (a bare
+        // `max_by_key` would keep an arbitrary one).
         if let Some(best_ts) = RE_TS
             .find_iter(&text)
             .fold(HashMap::new(), |mut acc, m| {
@@ -676,7 +616,6 @@ impl Compressor {
         text = self.run_bpe(text, BPE_MAX_ITERATIONS, NormalBpe);
         text = self.run_bpe(text, BPE_MAX_ITERATIONS, MetaBpe);
         text = self.run_macro_templating(text);
-        text = self.run_tag_sequence_macro_templating(text);
 
         self.deduplicate_lines(&text).join("\n")
     }
@@ -692,7 +631,7 @@ mod tests {
     /// entries are template-based (`@` placeholder + `&n:val` reference); all
     /// others are plain string substitutions.
     ///
-    /// This reverses stages 2-7. It cannot recover the two intentionally lossy
+    /// This reverses stages 2-6. It cannot recover the two intentionally lossy
     /// stages (leading-zero trim, line dedup), so the round-trip samples below
     /// are constructed to avoid triggering those.
     fn expand(body: &str, legend: &[(String, String)]) -> String {
@@ -700,11 +639,10 @@ mod tests {
         for (tag, value) in legend.iter().rev() {
             if tag.starts_with('&') {
                 // Macro: `&n:CAPTURE` -> `value` with `@` substituted by CAPTURE.
-                // Both macro stages emit a single tag as the capture
-                // (`process_templates` replaces the whole line with `&n:<tag>`;
-                // the tag-sequence stage emits `&n:#X#` inline). So CAPTURE is
-                // exactly one `#…#` or `!…!` token. We match the macro tag plus
-                // its colon plus that one token.
+                // The macro-templating stage (`process_templates`) replaces a
+                // whole line with `&n:<tag>`, so CAPTURE is exactly one `#…#` or
+                // `!…!` token. We match the macro tag plus its colon plus that
+                // one token.
                 let re = Regex::new(&format!(
                     r"{}:(#(?:T|[0-9a-zA-Z]+)#|![0-9a-zA-Z]+!)",
                     regex::escape(tag)

--- a/src/squeeze/mod.rs
+++ b/src/squeeze/mod.rs
@@ -1,0 +1,789 @@
+//! Log/text token compressor — the pure engine behind `sb squeeze`.
+//!
+//! Ported from `../logs-tokenizer/src/core/mod.rs` (a clipboard tool). The
+//! algorithm is unchanged; this module just exposes it as a dependency-light,
+//! I/O-free function and returns the legend as structured `(tag, value)` pairs
+//! instead of a pre-rendered string blob.
+//!
+//! Pipeline (all stages kept — the input is logs, where most content is real):
+//! ```text
+//!   1. Leading-zero trim          0x0001 -> 0x1               (lossy, no legend)
+//!   2. Timestamp dictionary       most-frequent ISO8601 -> #T#
+//!   3. Component / key extraction frequent [Tag] / key= -> #0#
+//!   4. Base62 tag names           #10# packs as #a# to keep tags narrow
+//!   5a. BPE (normal)              repeated token runs       -> #n#
+//!   5b. BPE (meta)                repeated runs *of tags*   -> !n!
+//!   6. Macro templating           lines differing by 1 tag  -> &n + &n:val
+//!   7. Tag-sequence macros        repeated multi-tag runs   -> &n  (inert*)
+//!   dedup                         identical lines collapse  -> ... xN (lossy)
+//! ```
+//! \* Stage 7 never fires: its matcher relies on a `\1` backreference, which the
+//! `regex` crate rejects — upstream has the identical dead branch. Kept for port
+//! fidelity (see `run_tag_sequence_macro_templating`).
+//!
+//! `regex` is the only external crate (already a dependency of this repo). The
+//! upstream tool used `once_cell::Lazy`; here we use `std::sync::LazyLock`.
+//!
+//! ## Determinism
+//! Tag assignment is fully deterministic so output is stable and testable.
+//! Wherever the upstream relied on `HashMap` iteration order to break ties
+//! (frequent-pattern ordering, BPE best-phrase selection, template ordering)
+//! we add an explicit, content-derived tie-breaker. Equal-savings candidates
+//! are resolved by their text (lexicographic), never by hash seed or clock.
+
+pub mod render;
+
+use regex::Regex;
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+const BASE62: &[u8] = b"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+const RADIX: usize = 62;
+
+// Tuning parameters for compression (ported verbatim).
+const BPE_MAX_ITERATIONS: usize = 100;
+const BPE_MIN_SAVINGS: i32 = 5;
+const MACRO_MIN_COUNT: usize = 4;
+const MACRO_MIN_TEMPLATE_LEN: usize = 5;
+const MACRO_OVERHEAD_MULT: i32 = 4;
+const MACRO_OVERHEAD_CONST: i32 = 5;
+
+// Pre-compiled static regexes for one-off passes.
+static RE_TAGS: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(#(?:T|[0-9a-zA-Z]+)#|![0-9a-zA-Z]+!)").unwrap());
+static RE_ZEROS_1: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\b0{3,}([1-9A-Fa-f][0-9A-Fa-f]*\b)").unwrap());
+static RE_ZEROS_2: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\b0{3,}(0\b)").unwrap());
+static RE_ZEROS_3: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(\b0x)0{3,}([1-9A-Fa-f][0-9A-Fa-f]*\b)").unwrap());
+static RE_ZEROS_4: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(\b0x)0{3,}(0\b)").unwrap());
+static RE_TS: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:").unwrap());
+static RE_COMP: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\[[A-Za-z0-9_-]+\]").unwrap());
+static RE_KEYS: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\b[A-Za-z0-9_]+={1,2}").unwrap());
+static RE_NO_TIME: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^#T#\d{2}\.\d{3}\s*").unwrap());
+
+/// Result of compressing a chunk of log/text.
+pub struct Squeezed {
+    /// Compressed text (the deduplicated body — no legend prepended).
+    pub body: String,
+    /// `(tag, original)` pairs in display / assignment order. Reversing these
+    /// from last to first re-expands the body. The legend is reversible; the
+    /// only lossy stages (leading-zero trim, line dedup) leave no entry.
+    pub legend: Vec<(String, String)>,
+}
+
+/// Compress `input`. Pure, no I/O. Empty / whitespace-only input round-trips
+/// unchanged with an empty legend.
+pub fn squeeze(input: &str) -> Squeezed {
+    let mut c = Compressor::new();
+    let body = c.compress(input.to_string());
+    Squeezed {
+        body,
+        legend: c.legend.into_iter().map(split_legend_entry).collect(),
+    }
+}
+
+/// Split a `"tag = value"` legend line into `(tag, value)` on the *first*
+/// " = " — tags never contain " = ", so a value that does is preserved intact.
+fn split_legend_entry(entry: String) -> (String, String) {
+    match entry.find(" = ") {
+        Some(idx) => (entry[..idx].to_string(), entry[idx + 3..].to_string()),
+        None => (entry, String::new()),
+    }
+}
+
+#[inline]
+fn advance_while(bytes: &[u8], mut i: usize, cond: impl Fn(u8) -> bool) -> usize {
+    while i < bytes.len() && cond(bytes[i]) {
+        i += 1;
+    }
+    i
+}
+
+#[inline]
+fn calc_savings(count: usize, len: usize) -> i32 {
+    (count as i32 - 1) * (len as i32) - MACRO_OVERHEAD_MULT * (count as i32) - MACRO_OVERHEAD_CONST
+}
+
+#[inline]
+fn to_base62(mut n: usize) -> String {
+    if n == 0 {
+        return "0".to_string();
+    }
+    let mut res = Vec::new();
+    while n > 0 {
+        res.push(BASE62[n % RADIX]);
+        n /= RADIX;
+    }
+    res.reverse();
+    // SAFETY: BASE62 is ASCII, so every pushed byte is valid UTF-8.
+    unsafe { String::from_utf8_unchecked(res) }
+}
+
+#[inline]
+fn base62_len(mut n: usize) -> usize {
+    if n == 0 {
+        return 1;
+    }
+    let mut len = 0;
+    while n > 0 {
+        len += 1;
+        n /= RADIX;
+    }
+    len
+}
+
+struct Compressor {
+    var_idx: usize,
+    meta_idx: usize,
+    macro_idx: usize,
+    legend: Vec<String>,
+}
+
+trait BpeStrategy {
+    fn tokenize<'a>(&self, text: &'a str) -> Vec<&'a str>;
+    fn split_text_with_separators<'a>(&self, text: &'a str) -> (Vec<&'a str>, Vec<&'a str>);
+    fn max_n(&self) -> usize;
+    fn min_trim_len(&self) -> usize;
+    fn requires_hash(&self) -> bool;
+    fn tag_len(&self, comp: &Compressor) -> usize;
+    fn next_token(&self, comp: &mut Compressor) -> String;
+}
+
+struct NormalBpe;
+impl BpeStrategy for NormalBpe {
+    fn tokenize<'a>(&self, text: &'a str) -> Vec<&'a str> {
+        let (mut tokens, bytes, mut i) = (Vec::new(), text.as_bytes(), 0);
+        while i < bytes.len() {
+            let is_alnum = bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_';
+            let j = advance_while(bytes, i + 1, |b| {
+                (b.is_ascii_alphanumeric() || b == b'_') == is_alnum
+            });
+            tokens.push(&text[i..j]);
+            i = j;
+        }
+        tokens
+    }
+
+    fn split_text_with_separators<'a>(&self, text: &'a str) -> (Vec<&'a str>, Vec<&'a str>) {
+        let (mut parts, mut seps, bytes) = (Vec::new(), Vec::new(), text.as_bytes());
+        let (mut i, mut last_end) = (0, 0);
+        while i < bytes.len() {
+            if bytes[i] == b'#' {
+                let mut j = i + 1;
+                if j < bytes.len() && bytes[j] == b'T' {
+                    j += 1;
+                } else {
+                    j = advance_while(bytes, j, |b| b.is_ascii_alphanumeric());
+                }
+
+                if j < bytes.len() && bytes[j] == b'#' && j > i + 1 {
+                    parts.push(&text[last_end..i]);
+                    seps.push(&text[i..=j]);
+                    last_end = j + 1;
+                    i = j + 1;
+                    continue;
+                }
+            }
+            i += 1;
+        }
+        parts.push(&text[last_end..]);
+        (parts, seps)
+    }
+
+    fn max_n(&self) -> usize {
+        20
+    }
+    fn min_trim_len(&self) -> usize {
+        4
+    }
+    fn requires_hash(&self) -> bool {
+        false
+    }
+    fn tag_len(&self, comp: &Compressor) -> usize {
+        base62_len(comp.var_idx) + 2
+    }
+    fn next_token(&self, comp: &mut Compressor) -> String {
+        comp.get_var_token()
+    }
+}
+
+struct MetaBpe;
+impl BpeStrategy for MetaBpe {
+    fn tokenize<'a>(&self, text: &'a str) -> Vec<&'a str> {
+        let (mut tokens, bytes, mut i) = (Vec::new(), text.as_bytes(), 0);
+        while i < bytes.len() {
+            let b = bytes[i];
+            if b == b'#' {
+                let j = advance_while(bytes, i + 1, |c| c.is_ascii_alphanumeric());
+                if j < bytes.len() && bytes[j] == b'#' {
+                    tokens.push(&text[i..=j]);
+                    i = j + 1;
+                    continue;
+                }
+            } else if b == b'!' {
+                let j = advance_while(bytes, i + 1, |c| c.is_ascii_alphanumeric());
+                if j < bytes.len() && bytes[j] == b'!' {
+                    tokens.push(&text[i..=j]);
+                    i = j + 1;
+                    continue;
+                }
+            }
+
+            let is_alnum = b.is_ascii_alphanumeric() || b == b'_';
+            let j = advance_while(bytes, i + 1, |c| {
+                if is_alnum {
+                    c.is_ascii_alphanumeric() || c == b'_'
+                } else {
+                    !c.is_ascii_alphanumeric() && c != b'_' && c != b'#' && c != b'!'
+                }
+            });
+            tokens.push(&text[i..j]);
+            i = j;
+        }
+        tokens
+    }
+
+    fn split_text_with_separators<'a>(&self, text: &'a str) -> (Vec<&'a str>, Vec<&'a str>) {
+        let (mut parts, mut seps, bytes) = (Vec::new(), Vec::new(), text.as_bytes());
+        let mut last_end = 0;
+        for i in 0..bytes.len() {
+            if bytes[i] == b'\n' {
+                parts.push(&text[last_end..i]);
+                seps.push("\n");
+                last_end = i + 1;
+            }
+        }
+        parts.push(&text[last_end..]);
+        (parts, seps)
+    }
+
+    fn max_n(&self) -> usize {
+        15
+    }
+    fn min_trim_len(&self) -> usize {
+        5
+    }
+    fn requires_hash(&self) -> bool {
+        true
+    }
+    fn tag_len(&self, comp: &Compressor) -> usize {
+        base62_len(comp.meta_idx) + 2
+    }
+    fn next_token(&self, comp: &mut Compressor) -> String {
+        comp.get_meta_token()
+    }
+}
+
+impl Compressor {
+    fn new() -> Self {
+        Self {
+            var_idx: 0,
+            meta_idx: 1,
+            macro_idx: 1,
+            legend: Vec::new(),
+        }
+    }
+
+    fn get_var_token(&mut self) -> String {
+        let t = format!("#{}#", to_base62(self.var_idx));
+        self.var_idx += 1;
+        t
+    }
+
+    fn get_meta_token(&mut self) -> String {
+        let t = format!("!{}!", to_base62(self.meta_idx));
+        self.meta_idx += 1;
+        t
+    }
+
+    fn get_macro_token(&mut self) -> String {
+        let t = format!("&{}", to_base62(self.macro_idx));
+        self.macro_idx += 1;
+        t
+    }
+
+    fn replace_frequent(&mut self, text: &mut String, re: &Regex) {
+        let mut counts: HashMap<String, usize> = HashMap::new();
+        for mat in re.find_iter(text) {
+            *counts.entry(mat.as_str().to_string()).or_insert(0) += 1;
+        }
+
+        let mut sorted: Vec<_> = counts.into_iter().filter(|&(_, c)| c > 1).collect();
+        // Deterministic: most-frequent first, ties broken by the pattern text
+        // (the upstream left ties to HashMap order, which is non-deterministic).
+        sorted.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+
+        for (pat, _) in sorted {
+            let token = self.get_var_token();
+            *text = text.replace(&pat, &token);
+            self.legend.push(format!("{} = {}", token, pat));
+        }
+    }
+
+    fn run_bpe<S: BpeStrategy>(&mut self, text: String, max_iter: usize, strategy: S) -> String {
+        let mut id_to_str: Vec<String> = Vec::new();
+        let mut str_to_id: HashMap<String, u32> = HashMap::new();
+
+        let mut get_or_add = |s: &str| -> u32 {
+            *str_to_id.entry(s.to_string()).or_insert_with(|| {
+                id_to_str.push(s.to_string());
+                (id_to_str.len() - 1) as u32
+            })
+        };
+
+        let (part_strs, seps) = strategy.split_text_with_separators(&text);
+        let mut parts: Vec<Vec<u32>> = part_strs
+            .into_iter()
+            .map(|p| {
+                if p.is_empty() {
+                    vec![]
+                } else {
+                    strategy.tokenize(p).into_iter().map(&mut get_or_add).collect()
+                }
+            })
+            .collect();
+
+        for _ in 0..max_iter {
+            let mut counts: HashMap<&[u32], usize> = HashMap::new();
+            let max_n = strategy.max_n();
+
+            for part in &parts {
+                let len = part.len();
+                if len < 2 {
+                    continue;
+                }
+
+                for n in 2..=std::cmp::min(max_n, len) {
+                    for i in 0..=(len - n) {
+                        let slice = &part[i..(i + n)];
+                        let (mut has_hash, mut total_len, mut valid) = (false, 0, true);
+
+                        for &id in slice {
+                            let s = &id_to_str[id as usize];
+                            if s.contains('\n') || s.contains('\r') {
+                                valid = false;
+                                break;
+                            }
+                            if strategy.requires_hash() && s.contains('#') {
+                                has_hash = true;
+                            }
+                            total_len += s.len();
+                        }
+
+                        if !valid || (strategy.requires_hash() && !has_hash) {
+                            continue;
+                        }
+
+                        let first_s = &id_to_str[slice[0] as usize];
+                        let last_s = &id_to_str[slice[slice.len() - 1] as usize];
+                        let trim_len = total_len
+                            - (first_s.len() - first_s.trim_start().len())
+                            - (last_s.len() - last_s.trim_end().len());
+
+                        if trim_len >= strategy.min_trim_len() {
+                            *counts.entry(slice).or_insert(0) += 1;
+                        }
+                    }
+                }
+            }
+
+            // Pick the highest-savings candidate. Determinism: the upstream
+            // iterated `counts` (a HashMap) and kept the first strict maximum,
+            // so equal-savings ties depended on hash order. We instead resolve
+            // ties by the candidate's rendered phrase (lexicographic), which is
+            // stable across runs.
+            let (mut best_slice, mut best_savings): (&[u32], i32) = (&[][..], 0);
+            let mut best_phrase: Option<String> = None;
+            for (slice, &count) in &counts {
+                if count > 1 {
+                    let phrase_len: usize =
+                        slice.iter().map(|&id| id_to_str[id as usize].len()).sum();
+                    let tag_len = strategy.tag_len(self);
+                    let savings = (count as i32) * (phrase_len as i32 - tag_len as i32)
+                        - (tag_len as i32 + 3 + phrase_len as i32);
+
+                    if savings > best_savings {
+                        best_savings = savings;
+                        best_slice = *slice;
+                        best_phrase = None; // recomputed lazily on tie below
+                    } else if savings == best_savings && savings >= BPE_MIN_SAVINGS {
+                        let cand: String =
+                            slice.iter().map(|&id| id_to_str[id as usize].as_str()).collect();
+                        let cur = best_phrase.get_or_insert_with(|| {
+                            best_slice
+                                .iter()
+                                .map(|&id| id_to_str[id as usize].as_str())
+                                .collect()
+                        });
+                        if &cand < cur {
+                            *cur = cand;
+                            best_slice = *slice;
+                        }
+                    }
+                }
+            }
+
+            if best_savings < BPE_MIN_SAVINGS {
+                break;
+            }
+
+            let best_vec = best_slice.to_vec();
+            let best_str: String = best_vec
+                .iter()
+                .map(|&id| id_to_str[id as usize].as_str())
+                .collect();
+            let token = strategy.next_token(self);
+
+            let new_id = id_to_str.len() as u32;
+            id_to_str.push(token.clone());
+            str_to_id.insert(token.clone(), new_id);
+
+            for part in &mut parts {
+                if part.len() < best_vec.len() {
+                    continue;
+                }
+                let (mut new_part, mut i) = (Vec::with_capacity(part.len()), 0);
+                while i <= part.len() - best_vec.len() {
+                    if &part[i..i + best_vec.len()] == best_vec.as_slice() {
+                        new_part.push(new_id);
+                        i += best_vec.len();
+                    } else {
+                        new_part.push(part[i]);
+                        i += 1;
+                    }
+                }
+                new_part.extend_from_slice(&part[i..]);
+                *part = new_part;
+            }
+
+            let display = if best_str.starts_with(' ') || best_str.ends_with(' ') {
+                format!("'{}'", best_str)
+            } else {
+                best_str
+            };
+            self.legend.push(format!("{} = {}", token, display));
+        }
+
+        parts
+            .iter()
+            .enumerate()
+            .map(|(i, part)| {
+                let mut s = part
+                    .iter()
+                    .map(|&id| id_to_str[id as usize].as_str())
+                    .collect::<String>();
+                if i < seps.len() {
+                    s.push_str(seps[i]);
+                }
+                s
+            })
+            .collect()
+    }
+
+    fn process_templates(
+        &mut self,
+        templates: &HashMap<String, Vec<(usize, String)>>,
+        lines: &mut [String],
+    ) {
+        let mut scores: Vec<_> = templates
+            .iter()
+            .map(|(t, m)| (t.clone(), m.len(), calc_savings(m.len(), t.len())))
+            .filter(|&(_, count, sav)| sav > 0 || count >= MACRO_MIN_COUNT)
+            .collect();
+
+        // Deterministic: longest template first, then most matches, then the
+        // template text (final tie-break the upstream lacked).
+        scores.sort_by(|a, b| {
+            b.0.len()
+                .cmp(&a.0.len())
+                .then(b.1.cmp(&a.1))
+                .then_with(|| a.0.cmp(&b.0))
+        });
+        let mut templated = vec![false; lines.len()];
+
+        for (template, _, _) in scores {
+            if let Some(matches) = templates.get(&template) {
+                let valid: Vec<_> = matches.iter().filter(|(i, _)| !templated[*i]).collect();
+                if valid.len() > 1 {
+                    let macro_tag = self.get_macro_token();
+                    self.legend.push(format!("{} = {}", macro_tag, template));
+
+                    for (i, var) in valid {
+                        lines[*i] = format!("{}:{}", macro_tag, var);
+                        templated[*i] = true;
+                    }
+                }
+            }
+        }
+    }
+
+    fn run_macro_templating(&mut self, text: String) -> String {
+        let mut lines: Vec<String> = text.lines().map(|l| l.trim_end().to_string()).collect();
+        let mut templates: HashMap<String, Vec<(usize, String)>> = HashMap::new();
+
+        for (i, line) in lines.iter().enumerate() {
+            if line.trim().is_empty() {
+                continue;
+            }
+            for mat in RE_TAGS.find_iter(line) {
+                let mut template = line.clone();
+                template.replace_range(mat.start()..mat.end(), "@");
+                if template.len() >= MACRO_MIN_TEMPLATE_LEN {
+                    templates
+                        .entry(template)
+                        .or_default()
+                        .push((i, mat.as_str().to_string()));
+                }
+            }
+        }
+
+        self.process_templates(&templates, &mut lines);
+        lines.join("\n")
+    }
+
+    /// NOTE: this stage is currently **inert** — faithfully so, matching upstream.
+    /// The per-template matcher (`re_str` below) uses a `\1` backreference, which
+    /// the standard `regex` crate does not support, so `Regex::new` returns `Err`
+    /// and the `if let Ok(re)` swallows it: no `&n` macro is ever emitted here.
+    /// `../logs-tokenizer` has the identical dead branch. Kept for port fidelity;
+    /// making it fire would require a backreference-free rewrite of `re_str`.
+    fn run_tag_sequence_macro_templating(&mut self, mut text: String) -> String {
+        let re_seq =
+            Regex::new(r"(?:(?:#(?:T|[0-9a-zA-Z]+)#|![0-9a-zA-Z]+!)[ \t]*){2,}").unwrap();
+        let mut templates: HashMap<String, usize> = HashMap::new();
+
+        for mat in re_seq.find_iter(&text) {
+            let seq = mat.as_str().trim_end();
+            for tag_mat in RE_TAGS.find_iter(seq) {
+                let mut template = seq.to_string();
+                template.replace_range(tag_mat.start()..tag_mat.end(), "@");
+                *templates.entry(template).or_insert(0) += 1;
+            }
+        }
+
+        let mut scores: Vec<_> = templates
+            .iter()
+            .map(|(t, &c)| (t.clone(), c, calc_savings(c, t.len())))
+            .filter(|&(_, count, sav)| sav > 0 || count >= MACRO_MIN_COUNT)
+            .collect();
+
+        // Deterministic: longest template, then count, then text.
+        scores.sort_by(|a, b| {
+            b.0.len()
+                .cmp(&a.0.len())
+                .then(b.1.cmp(&a.1))
+                .then_with(|| a.0.cmp(&b.0))
+        });
+
+        for (template, _, _) in scores {
+            let parts: Vec<&str> = template.split('@').collect();
+            if parts.len() != 2 {
+                continue;
+            }
+
+            let re_str = format!(
+                r"{}([#!])([0-9a-zA-Z]+)\1{}",
+                regex::escape(parts[0]),
+                regex::escape(parts[1])
+            );
+            if let Ok(re) = Regex::new(&re_str) {
+                let count = re.find_iter(&text).count();
+                if calc_savings(count, template.len()) > 0 || count >= MACRO_MIN_COUNT {
+                    let macro_tag = self.get_macro_token();
+                    self.legend.push(format!("{} = {}", macro_tag, template));
+                    text = re
+                        .replace_all(&text, format!("{}:$1$2$1", macro_tag).as_str())
+                        .into_owned();
+                }
+            }
+        }
+        text
+    }
+
+    fn deduplicate_lines(&self, text: &str) -> Vec<String> {
+        let (mut final_lines, mut dup_count, mut last_line) = (Vec::new(), 0, String::new());
+        for line in text.lines() {
+            if line.trim().is_empty() {
+                continue;
+            }
+
+            let line_no_time = RE_NO_TIME.replace(line, "").into_owned();
+            if line_no_time == last_line && !line_no_time.is_empty() {
+                dup_count += 1;
+                continue;
+            }
+
+            if dup_count > 0 {
+                final_lines.push(format!("    ... x{}", dup_count + 1));
+                dup_count = 0;
+            }
+            final_lines.push(line.to_string());
+            last_line = line_no_time;
+        }
+        if dup_count > 0 {
+            final_lines.push(format!("    ... x{}", dup_count + 1));
+        }
+        final_lines
+    }
+
+    /// Run the full pipeline. Returns the compressed *body* only — the legend is
+    /// accumulated on `self.legend` and exposed separately by `squeeze()`.
+    /// (The upstream prepended a `--- LEGEND ---` / `--- LOGS ---` block; here
+    /// the caller decides how to present the legend.)
+    fn compress(&mut self, mut text: String) -> String {
+        if text.trim().is_empty() {
+            return text;
+        }
+
+        text = RE_ZEROS_1.replace_all(&text, "$1").into_owned();
+        text = RE_ZEROS_2.replace_all(&text, "$1").into_owned();
+        text = RE_ZEROS_3.replace_all(&text, "${1}${2}").into_owned();
+        text = RE_ZEROS_4.replace_all(&text, "${1}${2}").into_owned();
+
+        // Most-frequent ISO8601 prefix -> #T#. Determinism: when two prefixes
+        // tie on frequency, prefer the lexicographically smaller (the upstream
+        // `max_by_key` kept an arbitrary one).
+        if let Some(best_ts) = RE_TS
+            .find_iter(&text)
+            .fold(HashMap::new(), |mut acc, m| {
+                *acc.entry(m.as_str()).or_insert(0) += 1;
+                acc
+            })
+            .into_iter()
+            .max_by(|a, b| a.1.cmp(&b.1).then_with(|| b.0.cmp(a.0)))
+            .map(|(ts, _)| ts.to_string())
+        {
+            text = text.replace(&best_ts, "#T#");
+            self.legend.push(format!("#T# = {}", best_ts));
+        }
+
+        self.replace_frequent(&mut text, &RE_COMP);
+        self.replace_frequent(&mut text, &RE_KEYS);
+
+        text = self.run_bpe(text, BPE_MAX_ITERATIONS, NormalBpe);
+        text = self.run_bpe(text, BPE_MAX_ITERATIONS, MetaBpe);
+        text = self.run_macro_templating(text);
+        text = self.run_tag_sequence_macro_templating(text);
+
+        self.deduplicate_lines(&text).join("\n")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Re-expand a squeezed body using its legend, reversing every *reversible*
+    /// stage. Applied last-assigned-first (reverse legend order) so nested tags
+    /// unfold correctly (meta `!n!` -> exposes `#n#` -> expands). Macro `&n`
+    /// entries are template-based (`@` placeholder + `&n:val` reference); all
+    /// others are plain string substitutions.
+    ///
+    /// This reverses stages 2-7. It cannot recover the two intentionally lossy
+    /// stages (leading-zero trim, line dedup), so the round-trip samples below
+    /// are constructed to avoid triggering those.
+    fn expand(body: &str, legend: &[(String, String)]) -> String {
+        let mut text = body.to_string();
+        for (tag, value) in legend.iter().rev() {
+            if tag.starts_with('&') {
+                // Macro: `&n:CAPTURE` -> `value` with `@` substituted by CAPTURE.
+                // Both macro stages emit a single tag as the capture
+                // (`process_templates` replaces the whole line with `&n:<tag>`;
+                // the tag-sequence stage emits `&n:#X#` inline). So CAPTURE is
+                // exactly one `#…#` or `!…!` token. We match the macro tag plus
+                // its colon plus that one token.
+                let re = Regex::new(&format!(
+                    r"{}:(#(?:T|[0-9a-zA-Z]+)#|![0-9a-zA-Z]+!)",
+                    regex::escape(tag)
+                ))
+                .unwrap();
+                text = re
+                    .replace_all(&text, |caps: &regex::Captures| {
+                        value.replacen('@', &caps[1], 1)
+                    })
+                    .into_owned();
+            } else {
+                // Plain tag. The display value may be quoted if it had leading/
+                // trailing spaces (`'...'`); unwrap that for the real substitution.
+                let real = if value.starts_with('\'') && value.ends_with('\'') && value.len() >= 2 {
+                    &value[1..value.len() - 1]
+                } else {
+                    value.as_str()
+                };
+                text = text.replace(tag, real);
+            }
+        }
+        text
+    }
+
+    #[test]
+    fn empty_input_is_empty() {
+        let s = squeeze("");
+        assert_eq!(s.body, "");
+        assert!(s.legend.is_empty());
+
+        let s2 = squeeze("   \n\t\n  ");
+        assert!(s2.legend.is_empty());
+        // whitespace-only short-circuits and returns the input untouched
+        assert_eq!(s2.body, "   \n\t\n  ");
+    }
+
+    #[test]
+    fn tiny_nonrepetitive_input() {
+        // A single unique line: nothing repeats, so no legend and the body is
+        // just the (trimmed/deduplicated) line. Reconstruct it exactly.
+        let input = "the quick brown fox jumps";
+        let s = squeeze(input);
+        assert!(s.legend.is_empty(), "no repetition -> no legend");
+        assert_eq!(s.body, input);
+        assert_eq!(expand(&s.body, &s.legend), input);
+    }
+
+    #[test]
+    fn repetitive_log_shrinks_and_round_trips() {
+        // Repetitive ISO8601-timestamped component logs. No leading-zero
+        // sequences, no exact duplicate lines (each carries a distinct hwnd),
+        // no trailing whitespace, no blank lines — so only the *reversible*
+        // stages fire and the round-trip is exact.
+        let input = "\
+2026-05-30T11:54:19.557 [WinFocusMonitor] focus changed hwnd=11 title=alpha
+2026-05-30T11:54:19.602 [WinFocusMonitor] focus changed hwnd=12 title=bravo
+2026-05-30T11:54:19.640 [WinFocusMonitor] focus changed hwnd=13 title=charlie
+2026-05-30T11:54:19.688 [WinFocusMonitor] focus changed hwnd=14 title=delta
+2026-05-30T11:54:19.701 [WinFocusMonitor] focus changed hwnd=15 title=echo
+2026-05-30T11:54:19.744 [WinFocusMonitor] focus changed hwnd=16 title=foxtrot
+2026-05-30T11:54:19.780 [WinFocusMonitor] focus changed hwnd=17 title=golf
+2026-05-30T11:54:19.822 [WinFocusMonitor] focus changed hwnd=18 title=hotel";
+
+        let s = squeeze(input);
+
+        assert!(
+            !s.legend.is_empty(),
+            "a repetitive log must produce legend entries"
+        );
+        assert!(
+            s.body.len() < input.len(),
+            "compressed body ({}) should be smaller than input ({})",
+            s.body.len(),
+            input.len()
+        );
+
+        let restored = expand(&s.body, &s.legend);
+        assert_eq!(
+            restored, input,
+            "legend round-trip must reconstruct the input exactly"
+        );
+    }
+
+    #[test]
+    fn legend_entries_split_cleanly() {
+        // A value that itself contains " = " must be preserved on the value
+        // side (split only on the first separator).
+        let (tag, val) = split_legend_entry("#0# = a = b".to_string());
+        assert_eq!(tag, "#0#");
+        assert_eq!(val, "a = b");
+    }
+}

--- a/src/squeeze/render.rs
+++ b/src/squeeze/render.rs
@@ -1,0 +1,421 @@
+//! Renderers + emit-decision for `sb squeeze`.
+//!
+//! This module is the single source of truth for the squeeze emit decision and
+//! output formatting. Both `render_text` and `render_json` run the same pipeline:
+//!
+//! 1. Call [`crate::squeeze::squeeze`] on the (already line-sliced) `raw` text.
+//! 2. Assemble the squeezed output as `legend block + body` and measure it in bytes.
+//! 3. Apply the **degenerate floor** (§7 of the plan): if `--raw` was requested, OR
+//!    the squeezed total (legend block **and** its `# legend:` marker **included**)
+//!    is `>=` the raw byte length, emit the raw input instead. Every squeezed-only
+//!    byte MUST be counted or the floor lies about being smaller.
+//! 4. Format as text (§4) or JSON (§5).
+
+use colored::Colorize;
+use serde::Serialize;
+
+use crate::squeeze::{squeeze, Squeezed};
+
+/// Stable JSON schema identifier — bump on breaking changes.
+pub const JSON_SCHEMA_SQUEEZE: &str = "ast-bro.squeeze.v1";
+
+/// Everything the renderers need. `raw` is already line-sliced by the caller
+/// (CLI / MCP) via [`slice_lines`]; the renderers operate on it directly.
+pub struct SqueezeReport<'a> {
+    pub path: &'a str,
+    /// 1-indexed inclusive range, as resolved. `None` => whole file.
+    pub range: Option<(usize, usize)>,
+    /// Raw text, ALREADY line-sliced.
+    pub raw: &'a str,
+    /// `--raw` => never compress (escape hatch).
+    pub raw_requested: bool,
+}
+
+/// What the decision logic resolved to. Internal to this module.
+struct Emit {
+    /// `true` if the squeezed form won and is being emitted.
+    squeezed: bool,
+    /// The body to print (squeezed body, or the raw text on fallback).
+    body: String,
+    /// Legend pairs (tag, original) — empty when emitting raw.
+    legend: Vec<(String, String)>,
+    /// Byte length of the raw input.
+    raw_bytes: usize,
+    /// Byte length of what we actually emit (legend block + body when squeezed;
+    /// raw length when not).
+    emitted_bytes: usize,
+}
+
+/// The marker line printed immediately before the legend in text output. It is
+/// emitted ONLY on the squeezed branch, so it must be counted in the
+/// degenerate-floor size comparison (see [`decide`]) and in `emitted_bytes`.
+const LEGEND_MARKER: &str = "# legend:\n";
+
+/// Render the legend lines exactly as they appear in the text output (each
+/// line `#   <tag> = <value>` plus a trailing newline). Used both for display
+/// and — critically — for the byte accounting that drives the degenerate floor.
+fn legend_block(legend: &[(String, String)]) -> String {
+    let mut s = String::new();
+    for (tag, value) in legend {
+        s.push_str("#   ");
+        s.push_str(tag);
+        s.push_str(" = ");
+        s.push_str(value);
+        s.push('\n');
+    }
+    s
+}
+
+/// The core emit decision. Single source of truth shared by text + JSON.
+fn decide(r: &SqueezeReport) -> Emit {
+    let raw_bytes = r.raw.len();
+
+    // --raw escape hatch: never compress.
+    if r.raw_requested {
+        return Emit {
+            squeezed: false,
+            body: r.raw.to_string(),
+            legend: Vec::new(),
+            raw_bytes,
+            emitted_bytes: raw_bytes,
+        };
+    }
+
+    let Squeezed { body, legend } = squeeze(r.raw);
+
+    // Degenerate floor: the squeezed *total* must include every byte that the
+    // squeezed branch emits beyond the raw branch — that's the legend block AND
+    // its `# legend:` marker line (the `---` separator is common to both branches
+    // so it cancels). Omitting the marker lets a sub-marker-sized gain report a
+    // "win" while the emitted payload is actually larger than raw.
+    let legend_bytes = LEGEND_MARKER.len() + legend_block(&legend).len();
+    let squeezed_total_bytes = legend_bytes + body.len();
+
+    // An empty legend means nothing was actually substituted — any apparent
+    // "savings" comes only from the pipeline's lossy whitespace/dedup trimming,
+    // not a real reversible compression. Emitting that as a win would be both
+    // misleading and lossy (a dropped trailing newline can read as "smaller"),
+    // so treat it as the degenerate case and fall back to raw.
+    if legend.is_empty() || squeezed_total_bytes >= raw_bytes {
+        Emit {
+            squeezed: false,
+            body: r.raw.to_string(),
+            legend: Vec::new(),
+            raw_bytes,
+            emitted_bytes: raw_bytes,
+        }
+    } else {
+        Emit {
+            squeezed: true,
+            body,
+            legend,
+            raw_bytes,
+            emitted_bytes: squeezed_total_bytes,
+        }
+    }
+}
+
+/// Human-readable byte size: `412B`, `45.0KB`, `1.2MB`. Decimal (1000) units,
+/// matching the plan's examples (`45.0KB → 10.2KB`).
+fn fmt_bytes(n: usize) -> String {
+    const KB: f64 = 1000.0;
+    const MB: f64 = 1000.0 * 1000.0;
+    let f = n as f64;
+    if f < KB {
+        format!("{}B", n)
+    } else if f < MB {
+        format!("{:.1}KB", f / KB)
+    } else {
+        format!("{:.1}MB", f / MB)
+    }
+}
+
+/// Percentage saved going from `raw` to `emitted`, e.g. `77.3`. Positive means
+/// smaller. Guards against div-by-zero on empty input.
+fn savings_pct(raw_bytes: usize, emitted_bytes: usize) -> f64 {
+    if raw_bytes == 0 {
+        return 0.0;
+    }
+    (1.0 - (emitted_bytes as f64 / raw_bytes as f64)) * 100.0
+}
+
+/// Slice `text` by an optional 1-indexed inclusive line range, clamped to
+/// bounds. `None` => the whole text. Shared by CLI + MCP so the slice they hand
+/// to a [`SqueezeReport`] is identical to what the renderers assume.
+///
+/// Out-of-bounds is clamped; a `start` past EOF yields an empty string. The
+/// returned slice preserves the original line terminators where present (a
+/// trailing newline on the last selected line is kept iff it existed in the
+/// source), so round-tripping a full-file slice is byte-identical to the input.
+pub fn slice_lines(text: &str, range: Option<(usize, usize)>) -> String {
+    let (start, end) = match range {
+        None => return text.to_string(),
+        Some(r) => r,
+    };
+    // Normalize: clamp start to >= 1; ensure start <= end.
+    let start = start.max(1);
+    if end < start {
+        return String::new();
+    }
+
+    let total = text.len();
+    let mut out = String::new();
+    let mut line_no = 0usize;
+    let mut idx = 0usize;
+
+    // Walk the byte offsets of each line (content + its '\n' if present).
+    while idx < total {
+        line_no += 1;
+        let rel = text[idx..].find('\n');
+        let line_end = match rel {
+            Some(off) => idx + off + 1, // include the '\n'
+            None => total,              // last line, no trailing newline
+        };
+        if line_no >= start && line_no <= end {
+            out.push_str(&text[idx..line_end]);
+        }
+        if line_no > end {
+            break;
+        }
+        idx = line_end;
+    }
+    out
+}
+
+/// Text rendering (§4): muted-truecolor header, then the comment-prefixed
+/// legend, then a `---` separator, then the body.
+pub fn render_text(r: &SqueezeReport) -> String {
+    let e = decide(r);
+
+    // Header line. Colored exactly like map/show line suffixes (truecolor 150).
+    let header_plain = if e.squeezed {
+        let pct = savings_pct(e.raw_bytes, e.emitted_bytes);
+        format!(
+            "# {}  [squeezed {} -> {}, {:.1}%]",
+            r.path,
+            fmt_bytes(e.raw_bytes),
+            fmt_bytes(e.emitted_bytes),
+            -pct, // print as a negative delta, e.g. -77.3%
+        )
+    } else if r.raw_requested {
+        // --raw escape hatch.
+        format!("# {}  [raw {}]", r.path, fmt_bytes(e.raw_bytes))
+    } else {
+        // Degenerate fallback: squeeze would have been larger.
+        format!(
+            "# {}  [raw {}; squeeze would be larger, emitting original]",
+            r.path,
+            fmt_bytes(e.raw_bytes),
+        )
+    };
+    let header = header_plain.truecolor(150, 150, 150).to_string();
+
+    let mut out = String::new();
+    out.push_str(&header);
+    out.push('\n');
+
+    // Legend block (only when squeezed and non-empty). Uncolored so it copies
+    // cleanly. Prefixed with the `# legend:` marker.
+    if e.squeezed && !e.legend.is_empty() {
+        out.push_str(LEGEND_MARKER);
+        out.push_str(&legend_block(&e.legend));
+    }
+
+    // Separator + body. The body already carries its own line terminators; a
+    // single newline before it keeps the `---` on its own line.
+    out.push_str("---\n");
+    out.push_str(&e.body);
+    out
+}
+
+/// JSON document for `ast-bro.squeeze.v1` (§5).
+#[derive(Serialize)]
+struct JsonSqueezeDoc<'a> {
+    schema: &'static str,
+    path: &'a str,
+    range: Option<JsonRange>,
+    raw_bytes: usize,
+    squeezed_bytes: usize,
+    savings_pct: f64,
+    emitted: &'static str,
+    legend: Vec<JsonLegendEntry<'a>>,
+    body: &'a str,
+}
+
+#[derive(Serialize)]
+struct JsonRange {
+    start: usize,
+    end: usize,
+}
+
+#[derive(Serialize)]
+struct JsonLegendEntry<'a> {
+    tag: &'a str,
+    value: &'a str,
+}
+
+/// JSON rendering (§5). `pretty = !compact`. Legend always present (empty when
+/// emitting raw). `savings_pct` rounded to one decimal to match the text line.
+pub fn render_json(r: &SqueezeReport, pretty: bool) -> String {
+    let e = decide(r);
+    let pct = (savings_pct(e.raw_bytes, e.emitted_bytes) * 10.0).round() / 10.0;
+
+    let doc = JsonSqueezeDoc {
+        schema: JSON_SCHEMA_SQUEEZE,
+        path: r.path,
+        range: r.range.map(|(start, end)| JsonRange { start, end }),
+        raw_bytes: e.raw_bytes,
+        squeezed_bytes: e.emitted_bytes,
+        savings_pct: pct,
+        emitted: if e.squeezed { "squeezed" } else { "raw" },
+        legend: e
+            .legend
+            .iter()
+            .map(|(tag, value)| JsonLegendEntry { tag, value })
+            .collect(),
+        body: &e.body,
+    };
+
+    let res = if pretty {
+        serde_json::to_string_pretty(&doc)
+    } else {
+        serde_json::to_string(&doc)
+    };
+    res.unwrap_or_else(|err| format!("{{\"error\":\"{}\"}}", err))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A tiny / non-repetitive input has no compressible structure, so the
+    /// legend overhead guarantees the squeezed total is >= raw: must fall back.
+    #[test]
+    fn tiny_input_falls_back_to_raw() {
+        let raw = "hi\n";
+        let r = SqueezeReport {
+            path: "tiny.log",
+            range: None,
+            raw,
+            raw_requested: false,
+        };
+        let txt = render_text(&r);
+        assert!(
+            txt.contains("squeeze would be larger") || txt.contains("[raw "),
+            "tiny input should report raw fallback, got:\n{txt}"
+        );
+        // The body is the original text, byte-for-byte.
+        assert!(txt.ends_with("---\nhi\n"));
+    }
+
+    /// Regression: an input whose true compression gain is smaller than the
+    /// squeezed-only `# legend:` marker must NOT be reported as a win. Before the
+    /// marker was counted, this reported `[squeezed 39B -> 37B]` while the real
+    /// emitted payload was larger than the 39-byte input.
+    #[test]
+    fn marginal_gain_does_not_falsely_claim_squeezed() {
+        let raw = "xy12 xy12 zz\n".repeat(3);
+        let r = SqueezeReport {
+            path: "marginal.log",
+            range: None,
+            raw: &raw,
+            raw_requested: false,
+        };
+        let json = render_json(&r, false);
+        assert!(
+            !json.contains("\"emitted\":\"squeezed\""),
+            "marginal input falsely claimed a squeeze win: {json}"
+        );
+    }
+
+    /// `--raw` always emits the original with no legend, regardless of content.
+    #[test]
+    fn raw_requested_skips_compression() {
+        let raw = "ab\n".repeat(500);
+        let r = SqueezeReport {
+            path: "forced.log",
+            range: None,
+            raw: &raw,
+            raw_requested: true,
+        };
+        let json = render_json(&r, false);
+        assert!(json.contains("\"emitted\":\"raw\""));
+        assert!(json.contains("\"legend\":[]"));
+        let txt = render_text(&r);
+        assert!(txt.contains("[raw "));
+        assert!(!txt.contains("# legend:"));
+    }
+
+    /// A highly repetitive input must compress: emitted=="squeezed" and the
+    /// emitted body is shorter than the raw input.
+    #[test]
+    fn repetitive_input_emits_squeezed() {
+        // Many identical, structured log lines — lots for the pipeline to fold.
+        let line = "2026-05-30T11:54:19.557 [WinFocusMonitor] hwnd=0x1234 focus changed event\n";
+        let raw = line.repeat(200);
+        let r = SqueezeReport {
+            path: "app.log",
+            range: None,
+            raw: &raw,
+            raw_requested: false,
+        };
+
+        let txt = render_text(&r);
+        assert!(
+            txt.contains("[squeezed "),
+            "repetitive input should squeeze, got header in:\n{}",
+            txt.lines().next().unwrap_or("")
+        );
+        assert!(txt.contains("# legend:"), "squeezed output must have a legend");
+
+        // JSON view confirms the decision + that the emitted body shrank.
+        let json = render_json(&r, false);
+        assert!(json.contains("\"emitted\":\"squeezed\""));
+        assert!(json.contains(JSON_SCHEMA_SQUEEZE));
+        assert!(
+            json.contains("ast-bro.squeeze.v1"),
+            "JSON must carry the schema id"
+        );
+    }
+
+    /// The schema id is present in JSON regardless of the emit branch.
+    #[test]
+    fn json_always_contains_schema() {
+        let r = SqueezeReport {
+            path: "x.log",
+            range: Some((1, 1)),
+            raw: "only one line, no newline",
+            raw_requested: false,
+        };
+        let pretty = render_json(&r, true);
+        assert!(pretty.contains(JSON_SCHEMA_SQUEEZE));
+        // Pretty output is multi-line; compact is single-line.
+        let compact = render_json(&r, false);
+        assert!(!compact.contains('\n'));
+        assert!(pretty.contains('\n'));
+        // Range serialized as an object, not null.
+        assert!(compact.contains("\"range\":{\"start\":1,\"end\":1}"));
+    }
+
+    #[test]
+    fn slice_lines_clamps_and_is_inclusive() {
+        let text = "a\nb\nc\nd\n";
+        // Whole file when None.
+        assert_eq!(slice_lines(text, None), text);
+        // 1-indexed inclusive.
+        assert_eq!(slice_lines(text, Some((2, 3))), "b\nc\n");
+        // Clamped past EOF.
+        assert_eq!(slice_lines(text, Some((3, 999))), "c\nd\n");
+        // Start past EOF => empty.
+        assert_eq!(slice_lines(text, Some((10, 20))), "");
+        // Last line without trailing newline is preserved as-is.
+        assert_eq!(slice_lines("x\ny\nz", Some((3, 3))), "z");
+    }
+
+    #[test]
+    fn fmt_bytes_units() {
+        assert_eq!(fmt_bytes(412), "412B");
+        assert_eq!(fmt_bytes(45_000), "45.0KB");
+        assert_eq!(fmt_bytes(1_200_000), "1.2MB");
+    }
+}

--- a/src/squeeze/render.rs
+++ b/src/squeeze/render.rs
@@ -281,7 +281,7 @@ pub fn render_json(r: &SqueezeReport, pretty: bool) -> String {
     } else {
         serde_json::to_string(&doc)
     };
-    res.unwrap_or_else(|err| format!("{{\"error\":\"{}\"}}", err))
+    res.unwrap_or_else(|err| serde_json::json!({ "error": err.to_string() }).to_string())
 }
 
 #[cfg(test)]

--- a/src/squeeze/render.rs
+++ b/src/squeeze/render.rs
@@ -5,11 +5,11 @@
 //!
 //! 1. Call [`crate::squeeze::squeeze`] on the (already line-sliced) `raw` text.
 //! 2. Assemble the squeezed output as `legend block + body` and measure it in bytes.
-//! 3. Apply the **degenerate floor** (§7 of the plan): if `--raw` was requested, OR
-//!    the squeezed total (legend block **and** its `# legend:` marker **included**)
-//!    is `>=` the raw byte length, emit the raw input instead. Every squeezed-only
-//!    byte MUST be counted or the floor lies about being smaller.
-//! 4. Format as text (§4) or JSON (§5).
+//! 3. Apply the **degenerate floor**: if `--raw` was requested, OR the squeezed
+//!    total (legend block **and** its `# legend:` marker **included**) is `>=` the
+//!    raw byte length, emit the raw input instead. Every squeezed-only byte MUST
+//!    be counted or the floor lies about being smaller.
+//! 4. Format as text or JSON.
 
 use colored::Colorize;
 use serde::Serialize;
@@ -116,7 +116,7 @@ fn decide(r: &SqueezeReport) -> Emit {
 }
 
 /// Human-readable byte size: `412B`, `45.0KB`, `1.2MB`. Decimal (1000) units,
-/// matching the plan's examples (`45.0KB → 10.2KB`).
+/// e.g. `45.0KB → 10.2KB`.
 fn fmt_bytes(n: usize) -> String {
     const KB: f64 = 1000.0;
     const MB: f64 = 1000.0 * 1000.0;
@@ -152,37 +152,18 @@ pub fn slice_lines(text: &str, range: Option<(usize, usize)>) -> String {
         None => return text.to_string(),
         Some(r) => r,
     };
-    // Normalize: clamp start to >= 1; ensure start <= end.
     let start = start.max(1);
     if end < start {
         return String::new();
     }
 
-    let total = text.len();
-    let mut out = String::new();
-    let mut line_no = 0usize;
-    let mut idx = 0usize;
-
-    // Walk the byte offsets of each line (content + its '\n' if present).
-    while idx < total {
-        line_no += 1;
-        let rel = text[idx..].find('\n');
-        let line_end = match rel {
-            Some(off) => idx + off + 1, // include the '\n'
-            None => total,              // last line, no trailing newline
-        };
-        if line_no >= start && line_no <= end {
-            out.push_str(&text[idx..line_end]);
-        }
-        if line_no > end {
-            break;
-        }
-        idx = line_end;
-    }
-    out
+    text.split_inclusive('\n')
+        .skip(start - 1)
+        .take(end - start + 1)
+        .collect()
 }
 
-/// Text rendering (§4): muted-truecolor header, then the comment-prefixed
+/// Text rendering: muted-truecolor header, then the comment-prefixed
 /// legend, then a `---` separator, then the body.
 pub fn render_text(r: &SqueezeReport) -> String {
     let e = decide(r);
@@ -228,7 +209,7 @@ pub fn render_text(r: &SqueezeReport) -> String {
     out
 }
 
-/// JSON document for `ast-bro.squeeze.v1` (§5).
+/// JSON document for `ast-bro.squeeze.v1`.
 #[derive(Serialize)]
 struct JsonSqueezeDoc<'a> {
     schema: &'static str,
@@ -254,7 +235,7 @@ struct JsonLegendEntry<'a> {
     value: &'a str,
 }
 
-/// JSON rendering (§5). `pretty = !compact`. Legend always present (empty when
+/// JSON rendering. `pretty = !compact`. Legend always present (empty when
 /// emitting raw). `savings_pct` rounded to one decimal to match the text line.
 pub fn render_json(r: &SqueezeReport, pretty: bool) -> String {
     let e = decide(r);

--- a/tests/squeeze_e2e.rs
+++ b/tests/squeeze_e2e.rs
@@ -74,17 +74,17 @@ fn repetitive_log_is_squeezed_with_legend() {
 
     let out = run_ok(&["squeeze", path_str]);
 
-    // §4 text format: a legend block must be present for the squeezed case.
+    // Text format: a legend block must be present for the squeezed case.
     assert!(
         out.contains("# legend:"),
         "expected a legend block in squeezed output:\n{out}"
     );
-    // §4: header advertises the squeezed transition with a savings figure.
+    // Header advertises the squeezed transition with a savings figure.
     assert!(
         out.contains("[squeezed"),
         "expected '[squeezed ...]' header marker:\n{out}"
     );
-    // §4: body is separated from the header/legend by a `---` rule.
+    // Body is separated from the header/legend by a `---` rule.
     assert!(out.contains("---"), "expected '---' separator:\n{out}");
 
     // The whole point: the squeezed emission is smaller than a raw `--raw`
@@ -103,7 +103,7 @@ fn tiny_nonrepetitive_file_falls_back_to_raw() {
     let tmp = tempfile::tempdir().unwrap();
     let path = tmp.path().join("notes.txt");
     // Short, all-unique content: legend overhead would make a squeeze larger,
-    // so the degenerate safety floor (§0, §7) must emit raw instead.
+    // so the degenerate safety floor must emit raw instead.
     let content = "alpha one\nbeta two\ngamma three\n";
     write(&path, content);
     let path_str = path.to_str().unwrap();
@@ -136,7 +136,7 @@ fn json_output_matches_squeeze_schema() {
 
     let out = run_ok(&["squeeze", path_str, "--json"]);
 
-    // §5: must carry the versioned schema id and an `emitted` discriminator.
+    // JSON must carry the versioned schema id and an `emitted` discriminator.
     assert!(
         out.contains("ast-bro.squeeze.v1"),
         "missing JSON schema id:\n{out}"
@@ -195,7 +195,7 @@ fn raw_flag_emits_original_without_legend() {
 
     let out = run_ok(&["squeeze", path_str, "--raw"]);
 
-    // §4: --raw prints a `[raw ...]` header and NO legend / no squeeze claim.
+    // --raw prints a `[raw ...]` header and NO legend / no squeeze claim.
     assert!(out.contains("[raw"), "expected '[raw ...]' header:\n{}", &out[..out.len().min(200)]);
     assert!(
         !out.contains("# legend:"),

--- a/tests/squeeze_e2e.rs
+++ b/tests/squeeze_e2e.rs
@@ -1,0 +1,239 @@
+//! End-to-end tests for `ast-bro squeeze`.
+//!
+//! These shell out to the built `ast-bro` binary (the same path users hit;
+//! `sb` is a thin compatibility shim that execs `ast-bro`). Each test writes a
+//! temp fixture file and asserts invariants on the output rather than full
+//! snapshots — snapshots are brittle to colour/whitespace changes.
+//!
+//! Harness: `std::process::Command` against `env!("CARGO_BIN_EXE_ast-bro")`,
+//! `tempfile::tempdir()` for fixtures — mirroring `tests/calls_e2e.rs` and
+//! `tests/surface_e2e.rs`. (No `assert_cmd` dev-dependency is present, so we
+//! use std process spawning like the other e2e suites.)
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn bin() -> PathBuf {
+    // CARGO_BIN_EXE_<bin name> is set by cargo for integration tests.
+    // The canonical CLI binary in Cargo.toml's `[[bin]]` list is `ast-bro`.
+    PathBuf::from(env!("CARGO_BIN_EXE_ast-bro"))
+}
+
+/// Run `ast-bro <args...>` with colour disabled. Returns (exit_code, stdout, stderr).
+fn run(args: &[&str]) -> (i32, String, String) {
+    let out = Command::new(bin())
+        .args(args)
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("run ast-bro");
+    let stdout = String::from_utf8(out.stdout).expect("utf8 stdout");
+    let stderr = String::from_utf8(out.stderr).expect("utf8 stderr");
+    let code = out.status.code().unwrap_or(-1);
+    (code, stdout, stderr)
+}
+
+fn run_ok(args: &[&str]) -> String {
+    let (code, stdout, stderr) = run(args);
+    assert!(
+        code == 0,
+        "expected exit 0, got {code}\nargs: {args:?}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    stdout
+}
+
+fn write(p: &Path, body: &str) {
+    if let Some(parent) = p.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(p, body).unwrap();
+}
+
+/// A long, highly-repetitive log: every line shares an ISO8601 timestamp
+/// prefix and a repeated `[Tag]` component, plus repeated `key=` tokens — the
+/// exact shape the squeeze pipeline (timestamp dict + component extraction +
+/// BPE) is built to collapse. 200 lines guarantees the legend overhead is
+/// amortised and the squeezed form is a real win.
+fn repetitive_log() -> String {
+    let mut s = String::new();
+    for i in 0..200 {
+        s.push_str(&format!(
+            "2026-05-30T11:54:{:02}.557 [WinFocusMonitor] hwnd=0x{:04x} pid=1234 event=focus_changed state=active title=window\n",
+            i % 60,
+            i
+        ));
+    }
+    s
+}
+
+#[test]
+fn repetitive_log_is_squeezed_with_legend() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("app.log");
+    write(&path, &repetitive_log());
+    let path_str = path.to_str().unwrap();
+
+    let out = run_ok(&["squeeze", path_str]);
+
+    // §4 text format: a legend block must be present for the squeezed case.
+    assert!(
+        out.contains("# legend:"),
+        "expected a legend block in squeezed output:\n{out}"
+    );
+    // §4: header advertises the squeezed transition with a savings figure.
+    assert!(
+        out.contains("[squeezed"),
+        "expected '[squeezed ...]' header marker:\n{out}"
+    );
+    // §4: body is separated from the header/legend by a `---` rule.
+    assert!(out.contains("---"), "expected '---' separator:\n{out}");
+
+    // The whole point: the squeezed emission is smaller than a raw `--raw`
+    // run of the very same file.
+    let raw_out = run_ok(&["squeeze", path_str, "--raw"]);
+    assert!(
+        out.len() < raw_out.len(),
+        "squeezed output ({}) should be smaller than raw output ({}):\n--- squeezed ---\n{out}\n--- raw ---\n{raw_out}",
+        out.len(),
+        raw_out.len()
+    );
+}
+
+#[test]
+fn tiny_nonrepetitive_file_falls_back_to_raw() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("notes.txt");
+    // Short, all-unique content: legend overhead would make a squeeze larger,
+    // so the degenerate safety floor (§0, §7) must emit raw instead.
+    let content = "alpha one\nbeta two\ngamma three\n";
+    write(&path, content);
+    let path_str = path.to_str().unwrap();
+
+    let out = run_ok(&["squeeze", path_str]);
+
+    // No squeeze claim should be made on the degenerate fallback.
+    assert!(
+        !out.contains("[squeezed"),
+        "tiny input should NOT claim to be squeezed:\n{out}"
+    );
+    // Raw fallback emits no legend (the body is verbatim original).
+    assert!(
+        !out.contains("# legend:"),
+        "raw fallback should not print a legend:\n{out}"
+    );
+    // The original text comes through verbatim.
+    assert!(
+        out.contains("alpha one") && out.contains("gamma three"),
+        "expected original lines in raw fallback:\n{out}"
+    );
+}
+
+#[test]
+fn json_output_matches_squeeze_schema() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("app.log");
+    write(&path, &repetitive_log());
+    let path_str = path.to_str().unwrap();
+
+    let out = run_ok(&["squeeze", path_str, "--json"]);
+
+    // §5: must carry the versioned schema id and an `emitted` discriminator.
+    assert!(
+        out.contains("ast-bro.squeeze.v1"),
+        "missing JSON schema id:\n{out}"
+    );
+    assert!(out.contains("\"emitted\""), "missing 'emitted' field:\n{out}");
+
+    // It must be valid JSON. We avoid a hard dep on a JSON crate's typed model
+    // and instead do a lenient structural parse with serde_json::Value, which
+    // is already a transitive dependency of the project.
+    let v: serde_json::Value =
+        serde_json::from_str(&out).unwrap_or_else(|e| panic!("stdout is not valid JSON: {e}\n{out}"));
+    assert_eq!(
+        v.get("schema").and_then(|s| s.as_str()),
+        Some("ast-bro.squeeze.v1"),
+        "schema field mismatch in JSON:\n{out}"
+    );
+    assert!(
+        v.get("emitted").and_then(|s| s.as_str()).is_some(),
+        "emitted field should be a string:\n{out}"
+    );
+    // A repetitive log should report the squeezed emission.
+    assert_eq!(
+        v.get("emitted").and_then(|s| s.as_str()),
+        Some("squeezed"),
+        "repetitive log should emit 'squeezed':\n{out}"
+    );
+}
+
+#[test]
+fn json_compact_is_single_line() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("app.log");
+    write(&path, &repetitive_log());
+    let path_str = path.to_str().unwrap();
+
+    let out = run_ok(&["squeeze", path_str, "--json", "--compact"]);
+    assert!(
+        out.contains("ast-bro.squeeze.v1"),
+        "compact JSON missing schema id:\n{out}"
+    );
+    // Compact JSON should still parse.
+    let _v: serde_json::Value =
+        serde_json::from_str(out.trim()).unwrap_or_else(|e| panic!("compact stdout not valid JSON: {e}\n{out}"));
+    // pretty = !compact, so compact output is a single line (sans trailing newline).
+    let line_count = out.trim_end_matches('\n').lines().count();
+    assert_eq!(line_count, 1, "compact JSON should be one line, got {line_count}:\n{out}");
+}
+
+#[test]
+fn raw_flag_emits_original_without_legend() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("app.log");
+    let content = repetitive_log();
+    write(&path, &content);
+    let path_str = path.to_str().unwrap();
+
+    let out = run_ok(&["squeeze", path_str, "--raw"]);
+
+    // §4: --raw prints a `[raw ...]` header and NO legend / no squeeze claim.
+    assert!(out.contains("[raw"), "expected '[raw ...]' header:\n{}", &out[..out.len().min(200)]);
+    assert!(
+        !out.contains("# legend:"),
+        "--raw must not print a legend:\n{}",
+        &out[..out.len().min(200)]
+    );
+    assert!(
+        !out.contains("[squeezed"),
+        "--raw must not claim to squeeze:\n{}",
+        &out[..out.len().min(200)]
+    );
+    // The original body is present verbatim (sample a distinctive line).
+    assert!(
+        out.contains("[WinFocusMonitor] hwnd=0x0000"),
+        "expected verbatim original content under --raw"
+    );
+}
+
+#[test]
+fn line_range_limits_considered_lines() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("ranged.log");
+    // Five clearly-distinguishable lines; we ask for 2:4 (1-indexed, inclusive).
+    write(
+        &path,
+        "LINE_ALPHA\nLINE_BRAVO\nLINE_CHARLIE\nLINE_DELTA\nLINE_ECHO\n",
+    );
+    let path_str = path.to_str().unwrap();
+
+    // Use --raw so the body is emitted verbatim and the slice is unambiguous
+    // (no compression mangling the marker strings).
+    let out = run_ok(&["squeeze", path_str, "2:4", "--raw"]);
+
+    // Only lines 2..=4 should be considered.
+    assert!(out.contains("LINE_BRAVO"), "range should include line 2:\n{out}");
+    assert!(out.contains("LINE_CHARLIE"), "range should include line 3:\n{out}");
+    assert!(out.contains("LINE_DELTA"), "range should include line 4:\n{out}");
+    // Lines 1 and 5 are outside the range and must be excluded from the body.
+    assert!(!out.contains("LINE_ALPHA"), "line 1 should be excluded by range 2:4:\n{out}");
+    assert!(!out.contains("LINE_ECHO"), "line 5 should be excluded by range 2:4:\n{out}");
+}

--- a/tests/squeeze_e2e.rs
+++ b/tests/squeeze_e2e.rs
@@ -237,3 +237,22 @@ fn line_range_limits_considered_lines() {
     assert!(!out.contains("LINE_ALPHA"), "line 1 should be excluded by range 2:4:\n{out}");
     assert!(!out.contains("LINE_ECHO"), "line 5 should be excluded by range 2:4:\n{out}");
 }
+
+#[test]
+fn open_ended_json_range_clamps_end_to_eof() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("open-ended.log");
+    write(&path, "ONE\nTWO\nTHREE\n");
+    let path_str = path.to_str().unwrap();
+
+    let out = run_ok(&["squeeze", path_str, "2:", "--json"]);
+    let v: serde_json::Value =
+        serde_json::from_str(&out).unwrap_or_else(|e| panic!("stdout is not valid JSON: {e}\n{out}"));
+    let range = v
+        .get("range")
+        .and_then(|r| r.as_object())
+        .unwrap_or_else(|| panic!("expected object range in JSON:\n{out}"));
+
+    assert_eq!(range.get("start").and_then(|n| n.as_u64()), Some(2));
+    assert_eq!(range.get("end").and_then(|n| n.as_u64()), Some(3));
+}

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -1,16 +1,17 @@
 # Architecture
 
-`ast-bro` is a fast, structurally-aware code-navigation toolkit. It started as a "shape extractor" (signatures with line ranges, no method bodies) and has grown into five orthogonal subsystems sharing one binary, one filter pipeline, and one walk infrastructure:
+`ast-bro` is a fast, structurally-aware code-navigation toolkit. It started as a "shape extractor" (signatures with line ranges, no method bodies) and has grown into six orthogonal subsystems sharing one binary, one filter pipeline, and one walk infrastructure:
 
 1. **`src/adapters/` + `src/core.rs`** — language adapters parse files into a shared `Declaration` IR; renderers turn that into `map` / `digest` / `show` / `implements` output.
 2. **`src/surface/`** — resolves the *true public API* of a package (`pub use`, `__all__`, TypeScript barrels, Scala `export`) instead of just listing every public item per file.
 3. **`src/deps/`** — file-level dependency graph (`deps`, `reverse-deps`, `cycles`, `graph`) for nine languages. See [deps.md](deps.md).
 4. **`src/calls/`** — symbol-level call graph (`callers`, `callees`) for all 14 languages, with a three-pass resolver (same-file → global symbol table → dep-graph disambiguation). See [calls.md](calls.md).
 5. **`src/search/`** — hybrid BM25 + dense semantic search, plus `find-related`. Cached at `.ast-bro/index/`. See [search.md](search.md).
+6. **`src/squeeze/`** — reversible token compression for **logs/text** (`squeeze`): a ported `logs-tokenizer` pipeline that shrinks repetitive lines and emits a legend so the output round-trips back to the original. Not a code tool — for code, the "compression" is `map` / `digest` / `show`. See [squeeze.md](squeeze.md).
 
 The dep graph and call graph share one on-disk cache at `.ast-bro/deps/graph.bin` (`UnifiedGraph { deps, calls: Option<CallGraph> }`) and one process-wide `Arc<UnifiedGraph>` registry in `src/graph_cache/` so MCP `tools/call`s reuse a single parsed copy across the whole session.
 
-It is written natively in Rust, relying heavily on the [tree-sitter](https://tree-sitter.github.io/tree-sitter/) parsing framework via the excellent [`ast-grep`](https://ast-grep.github.io/) ecosystem bindings, achieving incredibly fast speeds while still taking advantage of `rayon` for massive multithreading across directories. The five subsystems all share `src/file_filter.rs` for what gets walked (see [file-filtering.md](file-filtering.md)) — adding a feature in one subsystem doesn't change what files the others see.
+It is written natively in Rust, relying heavily on the [tree-sitter](https://tree-sitter.github.io/tree-sitter/) parsing framework via the excellent [`ast-grep`](https://ast-grep.github.io/) ecosystem bindings, achieving incredibly fast speeds while still taking advantage of `rayon` for massive multithreading across directories. The five walking subsystems all share `src/file_filter.rs` for what gets walked (see [file-filtering.md](file-filtering.md)) — adding a feature in one subsystem doesn't change what files the others see. (`squeeze` is the exception: it reads one explicit file path directly, so it neither walks nor touches the filter pipeline.)
 
 ## Core Flow (shape commands)
 
@@ -36,7 +37,7 @@ Every operation is an explicit subcommand — there's no implicit-default form. 
 
 - **Transport**: line-delimited JSON-RPC 2.0 on stdin/stdout, fully synchronous — no tokio, no extra dependencies. The cost is ~600 KB of binary (~1%) and zero overhead on the regular CLI commands, since none of the MCP code runs unless you invoke the `mcp` subcommand.
 - **`src/mcp/protocol.rs`**: serde types for `Request`/`Response`/`RpcError` and the standard JSON-RPC error codes.
-- **`src/mcp/tools.rs`**: declares fourteen tool schemas (`map`, `digest`, `show`, `implements`, `callers`, `callees`, `surface`, `deps`, `reverse_deps`, `cycles`, `graph`, `search`, `find_related`, `index`) and dispatches `tools/call` into the existing `core::render_*` / `calls::*` / `surface::*` / `deps::*` / `search::*` functions. Each tool maps 1:1 to a CLI subcommand and reuses its render logic byte-for-byte, so the JSON schemas are shared with the CLI's `--json` output.
+- **`src/mcp/tools.rs`**: declares fifteen tool schemas (`map`, `digest`, `show`, `implements`, `callers`, `callees`, `surface`, `squeeze`, `deps`, `reverse_deps`, `cycles`, `graph`, `search`, `find_related`, `index`) and dispatches `tools/call` into the existing `core::render_*` / `calls::*` / `surface::*` / `deps::*` / `search::*` functions. Each tool maps 1:1 to a CLI subcommand and reuses its render logic byte-for-byte, so the JSON schemas are shared with the CLI's `--json` output.
 - **`src/mcp/mod.rs`**: read loop, method routing (`initialize`, `ping`, `tools/list`, `tools/call`, `resources/list`, `prompts/list`), and panic-safe tool dispatch (panics are surfaced as `-32603 internal error` instead of taking the server down).
 
 Tools are exposed in their text form by default — that's what the agent prompt is built around — with `json: true` available for any client that wants the structured payload.

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -7,7 +7,7 @@
 3. **`src/deps/`** — file-level dependency graph (`deps`, `reverse-deps`, `cycles`, `graph`) for nine languages. See [deps.md](deps.md).
 4. **`src/calls/`** — symbol-level call graph (`callers`, `callees`) for all 14 languages, with a three-pass resolver (same-file → global symbol table → dep-graph disambiguation). See [calls.md](calls.md).
 5. **`src/search/`** — hybrid BM25 + dense semantic search, plus `find-related`. Cached at `.ast-bro/index/`. See [search.md](search.md).
-6. **`src/squeeze/`** — reversible token compression for **logs/text** (`squeeze`): a ported `logs-tokenizer` pipeline that shrinks repetitive lines and emits a legend so the output round-trips back to the original. Not a code tool — for code, the "compression" is `map` / `digest` / `show`. See [squeeze.md](squeeze.md).
+6. **`src/squeeze/`** — reversible token compression for **logs/text** (`squeeze`): a multi-stage pipeline that shrinks repetitive lines and emits a legend so the output round-trips back to the original. Not a code tool — for code, the "compression" is `map` / `digest` / `show`. See [squeeze.md](squeeze.md).
 
 The dep graph and call graph share one on-disk cache at `.ast-bro/deps/graph.bin` (`UnifiedGraph { deps, calls: Option<CallGraph> }`) and one process-wide `Arc<UnifiedGraph>` registry in `src/graph_cache/` so MCP `tools/call`s reuse a single parsed copy across the whole session.
 

--- a/wiki/squeeze.md
+++ b/wiki/squeeze.md
@@ -1,0 +1,76 @@
+# Squeeze (log/text compression)
+
+`sb squeeze` compresses repetitive **log/text** content with a *reversible* legend and emits the squeezed form directly. It ports the pure `Compressor` pipeline from `../logs-tokenizer` (`src/core/mod.rs`) verbatim — same stages, same tuning constants — and wraps it in this repo's CLI/MCP conventions. For internals and the design rationale see [refs/plan_tokenizer.md](../refs/plan_tokenizer.md).
+
+## When to use it (and when not to)
+
+This is a tool for **logs and text**, not code. `squeeze` keeps the full `logs-tokenizer` pipeline because the user invokes it intentionally on log-like input, where 70–80% of the content is genuinely repetitive (timestamps, component tags, near-identical lines).
+
+For **code**, the "compression" is already structural and lives elsewhere — reach for `map` / `digest` / `show` (drop bodies, keep shapes) instead. `squeeze` makes no attempt to compress source code.
+
+## What it does
+
+The engine runs an ordered set of stages, each replacing a recurring substring or pattern with a short tag and recording the mapping in a legend:
+
+1. **Leading-zero trim** — `0x0001` → `0x1`.
+2. **Timestamp dictionary** — the most-frequent ISO8601 prefix → `#T#`.
+3. **Component / key extraction** — frequent `[Tag]` / `key=` → `#0#`, `#1#`, …
+4. **Base62 tag names** — `#10#` → `#a#` to shrink tag width.
+5. **BPE** — repeated token sequences → `#n#` (normal) and repeated sequences *of tags* → `!n!` (meta).
+6. **Macro templating** — lines differing by a single tag → `&1=…`, referenced as `&1:C`.
+7. **Tag-sequence macros** — repeated multi-tag runs → macros.
+8. **Dedup** — identical consecutive lines → `… xN`.
+
+Tag assignment is **deterministic** (sort by savings, then first-seen), so output is stable and testable.
+
+## Reversible by design
+
+The **legend** is printed (comment-prefixed) *before* the body so a consumer reads the dictionary first. Because every replacement is recorded, the squeezed output round-trips back to the original text — a downstream model gets the exact content, just smaller.
+
+## Size proxy: chars/bytes, not tokens
+
+The comparison unit is **chars/bytes**, matching `logs-tokenizer` and this repo's stance (see `src/core.rs`) that token estimates mislead because tokenizers vary. The savings line is always printed — `# squeezed 45.0KB → 10.2KB (-77.3%)` — purely because the number is the satisfying/auditable part, not because any decision depends on it.
+
+## The one fallback: the degenerate floor
+
+There is exactly one fallback. If the squeezed **body + legend** ends up **larger** than the raw input (tiny inputs, all-unique lines), `squeeze` falls back to emitting the raw text and notes it:
+
+```
+# app.log  [raw 412B; squeeze would be larger, emitting original]
+---
+<raw body>
+```
+
+The size comparison **must include legend bytes** in the squeezed total — otherwise the floor would lie. This single `if` is essentially free and prevents "squeeze made it bigger."
+
+There is no dual-render, no "show both," no pick-smaller feature: the user ran `squeeze` because they want it squeezed.
+
+## Usage
+
+```
+sb squeeze <file> [from:to] [--raw] [--json] [--compact]
+```
+
+- `<file>` — path to read. A single explicit file is read directly (`read_to_string`); `squeeze` does not walk a directory or use the `file_filter` pipeline.
+- `[from:to]` — optional 1-indexed inclusive line range, clamped to file bounds. Also accepts `from`, `from:`, `:to`. Useful for squeezing a slice of a huge log.
+- `--raw` — escape hatch: skip compression and behave like `cat`-with-header, for diffing or inspecting the original.
+- `--json` / `--compact` — structured output under schema `ast-bro.squeeze.v1` (`pretty = !compact`). The legend is always included (empty when the raw fallback fires).
+
+### Text output (normal case)
+
+```
+# app.log  [squeezed 45.0KB → 10.2KB, -77.3%]
+# legend:
+#   #T# = 2026-05-30T11:54:
+#   #0# = [WinFocusMonitor]
+#   #1# = hwnd=
+#   &1  = #T#19.557 #0##@##8##81# #90#
+---
+<squeezed body>
+```
+
+### Edge cases
+
+- **Non-UTF8 file** — `read_to_string` fails, so `squeeze` notes `not valid UTF-8` and bails rather than squeezing raw bytes.
+- **Range out of bounds** — clamped; a start past EOF yields an empty body plus a note.
+- **Empty / tiny slice** — legend overhead guarantees a loss, so the degenerate floor emits raw.

--- a/wiki/squeeze.md
+++ b/wiki/squeeze.md
@@ -35,7 +35,7 @@ The comparison unit is **chars/bytes**, matching `logs-tokenizer` and this repo'
 
 There is exactly one fallback. If the squeezed **body + legend** ends up **larger** than the raw input (tiny inputs, all-unique lines), `squeeze` falls back to emitting the raw text and notes it:
 
-```
+```text
 # app.log  [raw 412B; squeeze would be larger, emitting original]
 ---
 <raw body>
@@ -47,7 +47,7 @@ There is no dual-render, no "show both," no pick-smaller feature: the user ran `
 
 ## Usage
 
-```
+```bash
 sb squeeze <file> [from:to] [--raw] [--json] [--compact]
 ```
 
@@ -58,7 +58,7 @@ sb squeeze <file> [from:to] [--raw] [--json] [--compact]
 
 ### Text output (normal case)
 
-```
+```text
 # app.log  [squeezed 45.0KB → 10.2KB, -77.3%]
 # legend:
 #   #T# = 2026-05-30T11:54:
@@ -71,6 +71,6 @@ sb squeeze <file> [from:to] [--raw] [--json] [--compact]
 
 ### Edge cases
 
-- **Non-UTF8 file** — `read_to_string` fails, so `squeeze` notes `not valid UTF-8` and bails rather than squeezing raw bytes.
+- **Unreadable file** — `read_to_string` failures are surfaced directly: directories note `path is a directory`, and other I/O failures print `could not read ...`.
 - **Range out of bounds** — clamped; a start past EOF yields an empty body plus a note.
 - **Empty / tiny slice** — legend overhead guarantees a loss, so the degenerate floor emits raw.

--- a/wiki/squeeze.md
+++ b/wiki/squeeze.md
@@ -1,10 +1,10 @@
 # Squeeze (log/text compression)
 
-`sb squeeze` compresses repetitive **log/text** content with a *reversible* legend and emits the squeezed form directly. It ports the pure `Compressor` pipeline from `../logs-tokenizer` (`src/core/mod.rs`) verbatim — same stages, same tuning constants — and wraps it in this repo's CLI/MCP conventions. For internals and the design rationale see [refs/plan_tokenizer.md](../refs/plan_tokenizer.md).
+`sb squeeze` compresses repetitive **log/text** content with a *reversible* legend and emits the squeezed form directly. The engine is a self-contained, multi-stage token compressor (`src/squeeze/`) wrapped in this repo's CLI/MCP conventions. (An earlier design had a 7th "tag-sequence macro" stage, but its matcher relies on a `\1` backreference the `regex` crate rejects, so it never fired and was dropped.)
 
 ## When to use it (and when not to)
 
-This is a tool for **logs and text**, not code. `squeeze` keeps the full `logs-tokenizer` pipeline because the user invokes it intentionally on log-like input, where 70–80% of the content is genuinely repetitive (timestamps, component tags, near-identical lines).
+This is a tool for **logs and text**, not code. `squeeze` runs the full compression pipeline because the user invokes it intentionally on log-like input, where 70–80% of the content is genuinely repetitive (timestamps, component tags, near-identical lines).
 
 For **code**, the "compression" is already structural and lives elsewhere — reach for `map` / `digest` / `show` (drop bodies, keep shapes) instead. `squeeze` makes no attempt to compress source code.
 
@@ -18,8 +18,7 @@ The engine runs an ordered set of stages, each replacing a recurring substring o
 4. **Base62 tag names** — `#10#` → `#a#` to shrink tag width.
 5. **BPE** — repeated token sequences → `#n#` (normal) and repeated sequences *of tags* → `!n!` (meta).
 6. **Macro templating** — lines differing by a single tag → `&1=…`, referenced as `&1:C`.
-7. **Tag-sequence macros** — repeated multi-tag runs → macros.
-8. **Dedup** — identical consecutive lines → `… xN`.
+7. **Dedup** — identical consecutive lines → `… xN`.
 
 Tag assignment is **deterministic** (sort by savings, then first-seen), so output is stable and testable.
 
@@ -29,7 +28,7 @@ The **legend** is printed (comment-prefixed) *before* the body so a consumer rea
 
 ## Size proxy: chars/bytes, not tokens
 
-The comparison unit is **chars/bytes**, matching `logs-tokenizer` and this repo's stance (see `src/core.rs`) that token estimates mislead because tokenizers vary. The savings line is always printed — `# squeezed 45.0KB → 10.2KB (-77.3%)` — purely because the number is the satisfying/auditable part, not because any decision depends on it.
+The comparison unit is **chars/bytes**, matching this repo's stance (see `src/core.rs`) that token estimates mislead because tokenizers vary. The savings line is always printed — `# squeezed 45.0KB → 10.2KB (-77.3%)` — purely because the number is the satisfying/auditable part, not because any decision depends on it.
 
 ## The one fallback: the degenerate floor
 


### PR DESCRIPTION
## 1. High-Level Summary (TL;DR)
*   **Impact:** Medium - Introduces a new `squeeze` subsystem to compress repetitive logs and text for LLM agents, reducing token consumption.
*   **Key Changes:**
    *   ✨ **New `squeeze` Command:** Added `ast-bro squeeze` to both the CLI and MCP tools for log/text compression.
    *   ⚙️ **Ported Compressor Engine:** Introduced `src/squeeze/mod.rs`, porting the `logs-tokenizer` pipeline (BPE, macros, dictionary replacement) with fully deterministic tag assignment.
    *   🛡️ **Smart Fallback:** Implemented a "degenerate floor" in `src/squeeze/render.rs` that automatically falls back to raw text if the compressed output (including legend overhead) is larger than the original.
    *   ✂️ **Line Range Slicing:** Added support for parsing and clamping 1-indexed inclusive line ranges to process specific chunks of large logs.
    *   📝 **Documentation & Tests:** Added `wiki/squeeze.md`, updated `README.md` and `AGENTS.md`, and provided comprehensive E2E tests in `tests/squeeze_e2e.rs`.

## 2. Visual Overview (Code & Logic Map)
```mermaid
graph TD
    A["User / MCP Client"]:::user -->|"`ast-bro squeeze`"| B["CLI / MCP Tools<br>(`lib.rs`, `tools.rs`)"]:::blue
    B -->|"`slice_lines()`"| C["Renderer<br>(`render.rs`)"]:::blue
    C -->|"`squeeze()`"| D["Compressor Engine<br>(`mod.rs`)"]:::green
    D -->|"Pipeline: BPE, Dict, Macros"| E["Squeezed { body, legend }"]:::green
    E -->|"`decide()`"| F{"Is Squeezed Total <br> < Raw Size?"}:::orange
    F -- "Yes" --> G["Emit Squeezed Format<br>(Text / JSON)"]:::purple
    F -- "No / --raw" --> H["Emit Raw Format<br>(Degenerate Floor)"]:::purple

    classDef user fill:#e0e0e0,color:#333333,stroke:#9e9e9e
    classDef blue fill:#bbdefb,color:#0d47a1,stroke:#1976d2
    classDef green fill:#c8e6c9,color:#1a5e20,stroke:#388e3c
    classDef orange fill:#fff3e0,color:#e65100,stroke:#f57c00
    classDef purple fill:#f3e5f5,color:#7b1fa2,stroke:#8e24aa
```

## 3. Detailed Change Analysis

### 📦 Squeeze Engine (`src/squeeze/mod.rs`)
*   **What Changed:** Added the core compression engine. It runs multiple stages (leading-zero trim, timestamp dictionary, BPE, macro templating, line dedup) to shrink repetitive logs. Replaced upstream's non-deterministic HashMap ordering with lexicographic tie-breaking to ensure deterministic tag assignments.

### 🎨 Rendering & Fallback Logic (`src/squeeze/render.rs`)
*   **What Changed:** Centralized the emit decision logic. The `decide()` function measures the raw input against the squeezed total (which correctly includes the `# legend:` marker bytes). If compression doesn't save space or if `--raw` is passed, it returns the raw text. Handles both human-readable text and `ast-bro.squeeze.v1` JSON formatting.

### 🔌 CLI & MCP Integration (`src/lib.rs`, `src/mcp/tools.rs`, `src/prompt.rs`)
*   **What Changed:** Exposed the `Squeeze` tool to users and agents. Added line range parsing logic (`parse_line_range`) to handle inputs like `100:200`. The MCP tool implementation (`run_squeeze`) reads the file directly and shares validation/rendering logic with the CLI.

### 📊 CLI / MCP Arguments
| Argument | Type | Required | Description |
|---|---|---|---|
| `path` | `PathBuf` / `String` | Yes | Path to the log/text file to read. |
| `range` / `start`,`end` | `String` / `Integer` | No | Optional 1-indexed inclusive line range (e.g., `100:200`). |
| `raw` | `Boolean` | No | Skip compression — emit the raw text with a header. |
| `json` | `Boolean` | No | Emit output as JSON (`ast-bro.squeeze.v1`) instead of text. |
| `compact` | `Boolean` | No | With `--json`: emit compact (single-line) JSON. |

## 4. Impact & Risk Assessment
*   **Breaking Changes:** None. This is a purely additive subsystem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new squeeze command to compress repetitive log/text with optional line-range selection and --raw/--json/--compact outputs; reversible legend; CLI and server/tool exposure; increases available tools to fifteen.

* **Documentation**
  * Updated README, architecture, skill docs, agent prompt, and added a dedicated squeeze guide with usage examples, behavior rules, fallback semantics, and edge‑case notes.

* **Tests**
  * Added unit and end-to-end tests covering squeezing, JSON output, raw fallback, compaction, and range slicing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aeroxy/ast-bro/pull/19?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->