### PR TITLE
perf(squeeze): stop BPE on tag-sparse logs from stalling for ~minute

### DIFF
--- a/src/squeeze/mod.rs
+++ b/src/squeeze/mod.rs
@@ -43,6 +43,17 @@ const RADIX: usize = 62;
 // Tuning parameters for compression.
 const BPE_MAX_ITERATIONS: usize = 100;
 const BPE_MIN_SAVINGS: i32 = 5;
+// Diminishing-returns floor: stop a BPE pass once its best remaining merge would
+// save less than `input_len / BPE_MIN_SAVINGS_RATIO` bytes (i.e. less than ~0.5%
+// of the pass's input). Each iteration pays a full-corpus recount to extract a
+// single merge, so on a large input the long flat tail of merges that each shave
+// a fraction of a percent costs far more wall-clock than it saves. Expressed
+// relative to the pass's input size so the cutoff scales with the corpus; for
+// inputs under ~1 KB the ratio falls below `BPE_MIN_SAVINGS`, leaving the
+// absolute floor in charge so small-log output is unchanged. Measured on a 2.8 MB
+// Jenkins log: 46 s / 73 % reduction at the old uncapped behaviour vs 10 s / 65 %
+// here — the dropped tail merges each save < 0.5 % of the file.
+const BPE_MIN_SAVINGS_RATIO: usize = 200;
 const MACRO_MIN_COUNT: usize = 4;
 const MACRO_MIN_TEMPLATE_LEN: usize = 5;
 const MACRO_OVERHEAD_MULT: i32 = 4;
@@ -170,6 +181,21 @@ impl BpeStrategy for NormalBpe {
         let (mut parts, mut seps, bytes) = (Vec::new(), Vec::new(), text.as_bytes());
         let (mut i, mut last_end) = (0, 0);
         while i < bytes.len() {
+            // Split on newlines as well as `#…#` tags. A merged phrase can never
+            // span a newline anyway (the run_bpe validity check rejects slices
+            // containing `\n`/`\r`), so this leaves the chosen merges — and thus
+            // the output — byte-identical. Its only effect is to bound each part
+            // to a single line: without it, a tag-sparse log (e.g. one whose
+            // timestamps are bracketed so the component regex can't tag them)
+            // collapses into one enormous part and the O(part_len × max_n²)
+            // counting loop blows up.
+            if bytes[i] == b'\n' {
+                parts.push(&text[last_end..i]);
+                seps.push(&text[i..=i]);
+                last_end = i + 1;
+                i += 1;
+                continue;
+            }
             if bytes[i] == b'#' {
                 let mut j = i + 1;
                 if j < bytes.len() && bytes[j] == b'T' {
@@ -349,6 +375,13 @@ impl Compressor {
             })
         };
 
+        // Scale the diminishing-returns cutoff to this pass's input size, but
+        // never below the absolute floor (so small inputs behave exactly as before).
+        let min_savings = std::cmp::max(
+            BPE_MIN_SAVINGS,
+            (text.len() / BPE_MIN_SAVINGS_RATIO) as i32,
+        );
+
         let (part_strs, seps) = strategy.split_text_with_separators(&text);
         let mut parts: Vec<Vec<u32>> = part_strs
             .into_iter()
@@ -434,7 +467,7 @@ impl Compressor {
                 }
             }
 
-            if best_savings < BPE_MIN_SAVINGS {
+            if best_savings < min_savings {
                 break;
             }
 


### PR DESCRIPTION
`sb squeeze` on a 2.8 MB Jenkins log stalled ~46 s with no output. Two compounding causes in the BPE stage:

1. NormalBpe split parts only on `#…#` tags, not newlines. Logs whose timestamps are bracketed (`[2026-…Z]`) defeat the component regex, so few tags fire and the whole file collapses into a handful of giant parts, blowing up the O(part_len × max_n²) counting loop. Split on newlines too — a merge can never span one anyway (the validity check rejects slices containing `\n`/`\r`), so the chosen merges are unchanged; parts are now bounded to a single line.

2. Each BPE iteration rebuilds the full n-gram count table over the entire corpus to extract one merge, and the loop ran the full 100-iteration cap — the last ~80 iterations each shaved < 0.5 % while paying a full recount. Add a diminishing-returns floor (BPE_MIN_SAVINGS_RATIO): stop once the best remaining merge saves less than input_len/200 bytes. Scale-relative, so it falls below the absolute BPE_MIN_SAVINGS floor for inputs under ~1 KB and leaves small-log output unchanged.

Measured on the 2.8 MB log: 46 s / 73 % reduction → 10 s / 65 % reduction (4.6× faster, ~2.9× compression retained). All squeeze round-trip and e2e tests still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced BPE text compression to efficiently process inputs containing newlines and line breaks
  * Refined compression algorithm with adaptive stopping criteria that optimize performance based on compression efficiency metrics
  * Better handling of structured text formats that previously caused performance degradation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->