### PR TITLE
Fix: Glob support for filepath in cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,7 @@ dependencies = [
  "colored",
  "dirs",
  "fs2",
+ "glob",
  "ignore",
  "memmap2",
  "rayon",
@@ -708,6 +709,12 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "globset"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ bincode = { version = "2", features = ["serde"] }
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 fs2 = "0.4"
 toml_edit = "0.22"
+glob = "0.3.3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/deps/manifest.rs
+++ b/src/deps/manifest.rs
@@ -174,7 +174,9 @@ pub fn parse_composer_psr4(path: &Path) -> Vec<(String, String)> {
     };
     let mut out = Vec::new();
     for section in ["autoload", "autoload-dev"] {
-        let Some(autoload) = v.get(section) else { continue };
+        let Some(autoload) = v.get(section) else {
+            continue;
+        };
         let Some(psr4) = autoload.get("psr-4").and_then(|x| x.as_object()) else {
             continue;
         };
@@ -238,5 +240,9 @@ pub fn cargo_workspace_members(root: &Path) -> Vec<PathBuf> {
             }
         }
     }
-    members.into_iter().map(|m| root.join(m)).collect()
+    members
+        .into_iter()
+        .flat_map(|m| crate::path_glob::expand_pattern(&root.join(m)))
+        .filter(|p| p.join("Cargo.toml").is_file())
+        .collect()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,14 +8,15 @@ mod core;
 mod deps;
 mod file_filter;
 mod graph_cache;
-mod prompt;
-mod installers;
 mod hook;
+mod installers;
 mod main_helpers;
 mod mcp;
+mod path_glob;
 mod project_root;
-mod search;
+mod prompt;
 mod run;
+mod search;
 mod squeeze;
 mod surface;
 
@@ -540,22 +541,23 @@ fn parse_file_line(s: &str) -> Option<(String, u32)> {
 
 /// Filter out non-existent paths, build a WalkBuilder with filters and glob overrides,
 /// and return (builder, existing_paths). Returns None if no paths exist.
-fn build_filtered_walker(paths: &[PathBuf], glob_str: Option<&str>) -> Option<(WalkBuilder, Vec<PathBuf>)> {
+fn build_filtered_walker(
+    paths: &[PathBuf],
+    glob_str: Option<&str>,
+) -> Option<(WalkBuilder, Vec<PathBuf>)> {
     if paths.is_empty() {
         return None;
     }
 
     let existing: Vec<PathBuf> = paths
         .iter()
-        .filter(|p| {
-            if p.exists() {
-                true
-            } else {
+        .flat_map(|p| {
+            let expanded = path_glob::expand_existing(p);
+            if expanded.is_empty() {
                 println!("# note: path not found: {}", p.display());
-                false
             }
+            expanded
         })
-        .cloned()
         .collect();
     if existing.is_empty() {
         return None;
@@ -641,8 +643,8 @@ pub(crate) fn walk_and_parse(paths: &[PathBuf], glob_str: Option<&str>) -> Vec<P
 }
 
 pub fn run() {
-    use clap::CommandFactory;
     use clap::error::ErrorKind;
+    use clap::CommandFactory;
 
     // Agent-friendly arg handling: instead of dying on a typo or unknown
     // flag, print the help text so the calling agent can self-correct
@@ -659,564 +661,540 @@ pub fn run() {
                 let mut cmd = Cli::command();
                 let _ = cmd.print_help();
                 println!();
-                println!("# note: could not parse args ({}). Showing help instead.", e.kind());
+                println!(
+                    "# note: could not parse args ({}). Showing help instead.",
+                    e.kind()
+                );
                 std::process::exit(0);
             }
         },
     };
 
     match &cli.command {
-            Commands::Map {
-                paths,
-                no_private,
-                no_fields,
-                no_docs,
-                no_attrs,
-                no_lines,
-                glob,
-                json,
-                compact,
-            } => {
-                let results = walk_and_parse(paths, glob.as_deref());
-                let opts = MapOptions {
-                    include_private: !(*no_private),
-                    include_fields: !(*no_fields),
-                    include_docs: !(*no_docs),
-                    include_attributes: !(*no_attrs),
-                    include_line_numbers: !(*no_lines),
-                    max_doc_lines: 6,
-                    max_members: None,
-                };
-                let json_on = *json;
-                let pretty = !(*compact);
-                if json_on {
-                    println!("{}", crate::core::render_json_map(&results, &opts, pretty));
-                } else {
-                    for res in results {
-                        println!("{}", crate::core::render_map(&res, &opts));
-                        println!();
-                    }
+        Commands::Map {
+            paths,
+            no_private,
+            no_fields,
+            no_docs,
+            no_attrs,
+            no_lines,
+            glob,
+            json,
+            compact,
+        } => {
+            let results = walk_and_parse(paths, glob.as_deref());
+            let opts = MapOptions {
+                include_private: !(*no_private),
+                include_fields: !(*no_fields),
+                include_docs: !(*no_docs),
+                include_attributes: !(*no_attrs),
+                include_line_numbers: !(*no_lines),
+                max_doc_lines: 6,
+                max_members: None,
+            };
+            let json_on = *json;
+            let pretty = !(*compact);
+            if json_on {
+                println!("{}", crate::core::render_json_map(&results, &opts, pretty));
+            } else {
+                for res in results {
+                    println!("{}", crate::core::render_map(&res, &opts));
+                    println!();
                 }
             }
-            Commands::Show {
-                path,
-                symbol,
-                others,
-                json,
-                compact,
-            } => {
-                if !path.exists() {
-                    println!("# note: path not found: {}", path.display());
-                } else if let Some(res) = parse_file(path) {
-                    let mut symbols = vec![symbol.as_str()];
-                    symbols.extend(others.iter().map(|s| s.as_str()));
-                    if *json {
-                        let mut seen = std::collections::HashSet::new();
-                        let mut all_matches = Vec::new();
-                        for sym in &symbols {
-                            for m in crate::core::find_symbols(&res, sym) {
-                                let key = (m.start_line, m.end_line, m.qualified_name.clone());
-                                if seen.insert(key) {
-                                    all_matches.push(m);
-                                }
+        }
+        Commands::Show {
+            path,
+            symbol,
+            others,
+            json,
+            compact,
+        } => {
+            if !path.exists() {
+                println!("# note: path not found: {}", path.display());
+            } else if let Some(res) = parse_file(path) {
+                let mut symbols = vec![symbol.as_str()];
+                symbols.extend(others.iter().map(|s| s.as_str()));
+                if *json {
+                    let mut seen = std::collections::HashSet::new();
+                    let mut all_matches = Vec::new();
+                    for sym in &symbols {
+                        for m in crate::core::find_symbols(&res, sym) {
+                            let key = (m.start_line, m.end_line, m.qualified_name.clone());
+                            if seen.insert(key) {
+                                all_matches.push(m);
                             }
-                        }
-                        println!(
-                            "{}",
-                            crate::core::render_json_show(&res, &all_matches, !(*compact))
-                        );
-                        if all_matches.is_empty() {
-                            // JSON consumers see [] in the payload; humans/agents
-                            // glancing at stderr-free output get a hint too.
-                            println!("# note: no symbol matching {:?} in {}", symbol, path.display());
-                        }
-                    } else {
-                        let mut any_match = false;
-                        for sym in &symbols {
-                            let matches = crate::core::find_symbols(&res, sym);
-                            for m in matches {
-                                any_match = true;
-                                println!(
-                                    "# {}:{}-{} {} ({})",
-                                    res.path.display(),
-                                    m.start_line,
-                                    m.end_line,
-                                    m.qualified_name,
-                                    m.kind
-                                );
-                                if !m.ancestor_signatures.is_empty() {
-                                    println!("# in: {}", m.ancestor_signatures.join(" → "));
-                                }
-                                println!("{}", m.source);
-                            }
-                        }
-                        if !any_match {
-                            let joined = symbols.join(", ");
-                            println!(
-                                "# note: no symbol matching '{}' in {}",
-                                joined,
-                                path.display()
-                            );
                         }
                     }
-                } else {
                     println!(
-                        "# note: unsupported file type for `show`: {}",
-                        path.display()
+                        "{}",
+                        crate::core::render_json_show(&res, &all_matches, !(*compact))
                     );
+                    if all_matches.is_empty() {
+                        // JSON consumers see [] in the payload; humans/agents
+                        // glancing at stderr-free output get a hint too.
+                        println!(
+                            "# note: no symbol matching {:?} in {}",
+                            symbol,
+                            path.display()
+                        );
+                    }
+                } else {
+                    let mut any_match = false;
+                    for sym in &symbols {
+                        let matches = crate::core::find_symbols(&res, sym);
+                        for m in matches {
+                            any_match = true;
+                            println!(
+                                "# {}:{}-{} {} ({})",
+                                res.path.display(),
+                                m.start_line,
+                                m.end_line,
+                                m.qualified_name,
+                                m.kind
+                            );
+                            if !m.ancestor_signatures.is_empty() {
+                                println!("# in: {}", m.ancestor_signatures.join(" → "));
+                            }
+                            println!("{}", m.source);
+                        }
+                    }
+                    if !any_match {
+                        let joined = symbols.join(", ");
+                        println!(
+                            "# note: no symbol matching '{}' in {}",
+                            joined,
+                            path.display()
+                        );
+                    }
                 }
+            } else {
+                println!(
+                    "# note: unsupported file type for `show`: {}",
+                    path.display()
+                );
             }
-            Commands::Squeeze {
-                path,
-                range,
-                raw,
-                json,
-                compact,
-            } => {
-                if !path.exists() {
-                    println!("# note: path not found: {}", path.display());
+        }
+        Commands::Squeeze {
+            path,
+            range,
+            raw,
+            json,
+            compact,
+        } => {
+            if !path.exists() {
+                println!("# note: path not found: {}", path.display());
+                return;
+            }
+            let text = match std::fs::read_to_string(path) {
+                Ok(t) => t,
+                Err(e) => {
+                    if path.is_dir() {
+                        println!("# note: path is a directory: {}", path.display());
+                    } else {
+                        println!("# note: could not read {}: {}", path.display(), e);
+                    }
                     return;
                 }
-                let text = match std::fs::read_to_string(path) {
-                    Ok(t) => t,
-                    Err(e) => {
-                        if path.is_dir() {
-                            println!("# note: path is a directory: {}", path.display());
-                        } else {
-                            println!("# note: could not read {}: {}", path.display(), e);
-                        }
-                        return;
-                    }
-                };
-                let line_count = text.lines().count();
-                let resolved: Option<(usize, usize)> =
-                    range.as_ref().map(|r| r.resolve(line_count));
-                let sliced = crate::squeeze::render::slice_lines(&text, resolved);
-                let path_str = path.display().to_string();
-                let report = crate::squeeze::render::SqueezeReport {
-                    path: &path_str,
-                    range: resolved,
-                    raw: &sliced,
-                    raw_requested: *raw,
-                };
-                if *json {
-                    println!("{}", crate::squeeze::render::render_json(&report, !(*compact)));
-                } else {
-                    println!("{}", crate::squeeze::render::render_text(&report));
-                }
+            };
+            let line_count = text.lines().count();
+            let resolved: Option<(usize, usize)> = range.as_ref().map(|r| r.resolve(line_count));
+            let sliced = crate::squeeze::render::slice_lines(&text, resolved);
+            let path_str = path.display().to_string();
+            let report = crate::squeeze::render::SqueezeReport {
+                path: &path_str,
+                range: resolved,
+                raw: &sliced,
+                raw_requested: *raw,
+            };
+            if *json {
+                println!(
+                    "{}",
+                    crate::squeeze::render::render_json(&report, !(*compact))
+                );
+            } else {
+                println!("{}", crate::squeeze::render::render_text(&report));
             }
-            Commands::Digest {
-                paths,
-                include_private,
-                include_fields,
-                max_members,
-                json,
-                compact,
-            } => {
-                let results = walk_and_parse(paths, None);
-                if *json {
-                    let opts = MapOptions {
-                        include_private: *include_private,
-                        include_fields: *include_fields,
-                        include_docs: true,
-                        include_attributes: true,
-                        include_line_numbers: true,
-                        max_doc_lines: 6,
-                        max_members: Some(*max_members),
-                    };
-                    println!(
-                        "{}",
-                        crate::core::render_json_map(&results, &opts, !(*compact))
-                    );
+        }
+        Commands::Digest {
+            paths,
+            include_private,
+            include_fields,
+            max_members,
+            json,
+            compact,
+        } => {
+            let results = walk_and_parse(paths, None);
+            if *json {
+                let opts = MapOptions {
+                    include_private: *include_private,
+                    include_fields: *include_fields,
+                    include_docs: true,
+                    include_attributes: true,
+                    include_line_numbers: true,
+                    max_doc_lines: 6,
+                    max_members: Some(*max_members),
+                };
+                println!(
+                    "{}",
+                    crate::core::render_json_map(&results, &opts, !(*compact))
+                );
+            } else {
+                let opts = DigestOptions {
+                    include_private: *include_private,
+                    include_fields: *include_fields,
+                    max_members_per_type: *max_members,
+                    max_heading_depth: 3,
+                };
+                let root = if paths.len() == 1 && paths[0].is_dir() {
+                    Some(paths[0].as_path())
                 } else {
-                    let opts = DigestOptions {
-                        include_private: *include_private,
-                        include_fields: *include_fields,
-                        max_members_per_type: *max_members,
-                        max_heading_depth: 3,
-                    };
-                    let root = if paths.len() == 1 && paths[0].is_dir() {
-                        Some(paths[0].as_path())
+                    None
+                };
+                println!("{}", crate::core::render_digest(&results, &opts, root));
+            }
+        }
+        Commands::Implements {
+            target,
+            paths,
+            direct,
+            json,
+            compact,
+        } => {
+            let results = walk_and_parse(paths, None);
+            let transitive = !direct;
+            let matches = crate::core::find_implementations(&results, target, transitive);
+            if *json {
+                println!(
+                    "{}",
+                    crate::core::render_json_implements(target, &matches, transitive, !(*compact),)
+                );
+            } else {
+                println!(
+                    "# {} match(es) for '{}' (incl. transitive):",
+                    matches.len(),
+                    target
+                );
+                for m in matches {
+                    let via = if m.via.is_empty() {
+                        String::new()
                     } else {
-                        None
+                        format!(" [via {}]", m.via.last().unwrap())
                     };
-                    println!("{}", crate::core::render_digest(&results, &opts, root));
+                    println!("{}:{}  {} {}{}", m.path, m.start_line, m.kind, m.name, via);
                 }
             }
-            Commands::Implements {
-                target,
-                paths,
-                direct,
-                json,
-                compact,
-            } => {
-                let results = walk_and_parse(paths, None);
-                let transitive = !direct;
-                let matches = crate::core::find_implementations(&results, target, transitive);
-                if *json {
-                    println!(
-                        "{}",
-                        crate::core::render_json_implements(
-                            target,
-                            &matches,
-                            transitive,
-                            !(*compact),
-                        )
-                    );
-                } else {
-                    println!(
-                        "# {} match(es) for '{}' (incl. transitive):",
-                        matches.len(),
-                        target
-                    );
-                    for m in matches {
-                        let via = if m.via.is_empty() {
-                            String::new()
-                        } else {
-                            format!(" [via {}]", m.via.last().unwrap())
-                        };
-                        println!("{}:{}  {} {}{}", m.path, m.start_line, m.kind, m.name, via);
-                    }
+        }
+        Commands::Prompt => {
+            println!("{}", crate::prompt::AGENT_PROMPT);
+        }
+        Commands::Install {
+            target,
+            all,
+            local,
+            global,
+            always,
+            min_lines,
+            dry_run,
+            force,
+            mcp,
+            skills,
+        } => {
+            let scope = resolve_scope(*local, *global);
+            let opts = installers::InstallOpts {
+                min_lines: *min_lines,
+                always: *always,
+                dry_run: *dry_run,
+                force: *force,
+            };
+            let exit = run_install(target.as_deref(), *all, *mcp, *skills, &scope, &opts);
+            std::process::exit(exit);
+        }
+        Commands::Uninstall {
+            target,
+            all,
+            local,
+            global,
+            dry_run,
+        } => {
+            let scope = resolve_scope(*local, *global);
+            let opts = installers::InstallOpts {
+                dry_run: *dry_run,
+                ..installers::InstallOpts::default()
+            };
+            let exit = run_uninstall(target.as_deref(), *all, &scope, &opts);
+            std::process::exit(exit);
+        }
+        Commands::Status { local, global } => {
+            let scope = resolve_scope(*local, *global);
+            run_status(&scope);
+        }
+        Commands::Hook {
+            protocol,
+            min_lines,
+            always,
+        } => {
+            let exit = hook::run(protocol, *min_lines, *always);
+            std::process::exit(exit);
+        }
+        Commands::Mcp => {
+            let exit = mcp::run();
+            std::process::exit(exit);
+        }
+        Commands::Search {
+            query,
+            path,
+            top_k,
+            alpha,
+            languages,
+            rebuild,
+            json,
+            compact,
+        } => {
+            if *rebuild {
+                let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+                if let Err(e) = crate::search::index::Index::build(path, &cwd) {
+                    eprintln!("ast-bro: rebuild failed: {e}");
+                    std::process::exit(1);
                 }
             }
-            Commands::Prompt => {
-                println!("{}", crate::prompt::AGENT_PROMPT);
-            }
-            Commands::Install {
-                target,
-                all,
-                local,
-                global,
-                always,
-                min_lines,
-                dry_run,
-                force,
-                mcp,
-                skills,
-            } => {
-                let scope = resolve_scope(*local, *global);
-                let opts = installers::InstallOpts {
-                    min_lines: *min_lines,
-                    always: *always,
-                    dry_run: *dry_run,
-                    force: *force,
-                };
-                let exit = run_install(target.as_deref(), *all, *mcp, *skills, &scope, &opts);
-                std::process::exit(exit);
-            }
-            Commands::Uninstall {
-                target,
-                all,
-                local,
-                global,
-                dry_run,
-            } => {
-                let scope = resolve_scope(*local, *global);
-                let opts = installers::InstallOpts {
-                    dry_run: *dry_run,
-                    ..installers::InstallOpts::default()
-                };
-                let exit = run_uninstall(target.as_deref(), *all, &scope, &opts);
-                std::process::exit(exit);
-            }
-            Commands::Status { local, global } => {
-                let scope = resolve_scope(*local, *global);
-                run_status(&scope);
-            }
-            Commands::Hook {
-                protocol,
-                min_lines,
-                always,
-            } => {
-                let exit = hook::run(protocol, *min_lines, *always);
-                std::process::exit(exit);
-            }
-            Commands::Mcp => {
-                let exit = mcp::run();
-                std::process::exit(exit);
-            }
-            Commands::Search {
+            let exit = crate::search::cli::run_search(
                 query,
                 path,
-                top_k,
-                alpha,
-                languages,
-                rebuild,
-                json,
-                compact,
-            } => {
-                if *rebuild {
-                    let cwd = std::env::current_dir()
-                        .unwrap_or_else(|_| std::path::PathBuf::from("."));
-                    if let Err(e) = crate::search::index::Index::build(path, &cwd) {
-                        eprintln!("ast-bro: rebuild failed: {e}");
-                        std::process::exit(1);
-                    }
-                }
-                let exit = crate::search::cli::run_search(
-                    query,
-                    path,
-                    *top_k,
-                    *alpha,
-                    languages.clone(),
-                    *json,
-                    !(*compact),
-                );
-                std::process::exit(exit);
-            }
-            Commands::FindRelated {
-                target,
-                path,
-                file,
-                line,
-                top_k,
-                json,
-                compact,
-            } => {
-                // Clap guarantees one of: (target alone) or (file + line).
-                let (file_path, line_num) = match (target, file, line) {
-                    (Some(t), _, _) => match parse_file_line(t) {
-                        Some(parsed) => parsed,
-                        None => {
-                            println!(
-                                "# note: expected <FILE>:<LINE>, got {t:?} \
+                *top_k,
+                *alpha,
+                languages.clone(),
+                *json,
+                !(*compact),
+            );
+            std::process::exit(exit);
+        }
+        Commands::FindRelated {
+            target,
+            path,
+            file,
+            line,
+            top_k,
+            json,
+            compact,
+        } => {
+            // Clap guarantees one of: (target alone) or (file + line).
+            let (file_path, line_num) = match (target, file, line) {
+                (Some(t), _, _) => match parse_file_line(t) {
+                    Some(parsed) => parsed,
+                    None => {
+                        println!(
+                            "# note: expected <FILE>:<LINE>, got {t:?} \
                                  (or use --file FILE --line N instead)"
-                            );
-                            return;
-                        }
-                    },
-                    (None, Some(f), Some(l)) => (f.clone(), *l),
-                    _ => unreachable!("clap should have rejected this argument combination"),
-                };
-                let exit = crate::search::cli::run_find_related(
-                    &file_path,
-                    line_num,
-                    path,
-                    *top_k,
-                    *json,
-                    !(*compact),
-                );
-                std::process::exit(exit);
-            }
-            Commands::Surface {
+                        );
+                        return;
+                    }
+                },
+                (None, Some(f), Some(l)) => (f.clone(), *l),
+                _ => unreachable!("clap should have rejected this argument combination"),
+            };
+            let exit = crate::search::cli::run_find_related(
+                &file_path,
+                line_num,
                 path,
-                tree,
-                include_chain,
-                max_depth,
-                include_private,
-                lang,
-                json,
-                compact,
-            } => {
-                let lang_override = match lang {
-                    Some(s) => match crate::surface::LangOverride::parse(s) {
-                        Some(l) => Some(l),
-                        None => {
-                            println!("# note: unknown --lang value '{}'. Expected rust|python|fallback.", s);
-                            return;
-                        }
-                    },
-                    None => None,
-                };
-                let json_on = *json;
-                let pretty = !(*compact);
-                let output = if json_on {
-                    crate::surface::OutputMode::Json { compact: !pretty }
-                } else if *tree {
-                    crate::surface::OutputMode::Tree
-                } else {
-                    crate::surface::OutputMode::Flat
-                };
-                let opts = crate::surface::SurfaceOptions {
-                    output,
-                    include_private: *include_private,
-                    max_depth: *max_depth,
-                    include_chain: *include_chain,
-                    lang_override,
-                };
-                match crate::surface::resolve_surface(path, &opts) {
-                    Ok(entries) => {
-                        let rendered =
-                            crate::surface::render::render(&entries, opts.output, opts.include_chain);
-                        print!("{}", rendered);
+                *top_k,
+                *json,
+                !(*compact),
+            );
+            std::process::exit(exit);
+        }
+        Commands::Surface {
+            path,
+            tree,
+            include_chain,
+            max_depth,
+            include_private,
+            lang,
+            json,
+            compact,
+        } => {
+            let lang_override = match lang {
+                Some(s) => match crate::surface::LangOverride::parse(s) {
+                    Some(l) => Some(l),
+                    None => {
+                        println!(
+                            "# note: unknown --lang value '{}'. Expected rust|python|fallback.",
+                            s
+                        );
+                        return;
                     }
-                    Err(e) => {
-                        println!("# note: {e}");
-                    }
+                },
+                None => None,
+            };
+            let json_on = *json;
+            let pretty = !(*compact);
+            let output = if json_on {
+                crate::surface::OutputMode::Json { compact: !pretty }
+            } else if *tree {
+                crate::surface::OutputMode::Tree
+            } else {
+                crate::surface::OutputMode::Flat
+            };
+            let opts = crate::surface::SurfaceOptions {
+                output,
+                include_private: *include_private,
+                max_depth: *max_depth,
+                include_chain: *include_chain,
+                lang_override,
+            };
+            match crate::surface::resolve_surface(path, &opts) {
+                Ok(entries) => {
+                    let rendered =
+                        crate::surface::render::render(&entries, opts.output, opts.include_chain);
+                    print!("{}", rendered);
+                }
+                Err(e) => {
+                    println!("# note: {e}");
                 }
             }
-            Commands::Deps {
+        }
+        Commands::Deps {
+            file,
+            depth,
+            rebuild,
+            json,
+            compact,
+        } => {
+            let exit = crate::deps::cli::run_deps(file, *depth, *json, !(*compact), *rebuild);
+            std::process::exit(exit);
+        }
+        Commands::ReverseDeps {
+            file,
+            depth,
+            limit,
+            rebuild,
+            json,
+            compact,
+        } => {
+            let exit = crate::deps::cli::run_reverse_deps(
                 file,
-                depth,
-                rebuild,
-                json,
-                compact,
-            } => {
-                let exit = crate::deps::cli::run_deps(
-                    file,
-                    *depth,
-                    *json,
-                    !(*compact),
-                    *rebuild,
-                );
-                std::process::exit(exit);
-            }
-            Commands::ReverseDeps {
-                file,
-                depth,
-                limit,
-                rebuild,
-                json,
-                compact,
-            } => {
-                let exit = crate::deps::cli::run_reverse_deps(
-                    file,
-                    *depth,
-                    *limit,
-                    *json,
-                    !(*compact),
-                    *rebuild,
-                );
-                std::process::exit(exit);
-            }
-            Commands::Cycles {
+                *depth,
+                *limit,
+                *json,
+                !(*compact),
+                *rebuild,
+            );
+            std::process::exit(exit);
+        }
+        Commands::Cycles {
+            path,
+            min_size,
+            rebuild,
+            json,
+            compact,
+        } => {
+            let exit = crate::deps::cli::run_cycles(path, *min_size, *json, !(*compact), *rebuild);
+            std::process::exit(exit);
+        }
+        Commands::Graph {
+            path,
+            json,
+            include_external,
+            rebuild,
+            compact,
+        } => {
+            let exit =
+                crate::deps::cli::run_graph(path, *json, *include_external, !(*compact), *rebuild);
+            std::process::exit(exit);
+        }
+        Commands::Index {
+            path,
+            rebuild,
+            stats,
+            json,
+            compact,
+        } => {
+            let exit = crate::search::cli::run_index(path, *rebuild, *stats, *json, !(*compact));
+            std::process::exit(exit);
+        }
+        Commands::Callers {
+            target,
+            path,
+            file,
+            symbol,
+            depth,
+            limit,
+            include_ambiguous,
+            rebuild,
+            json,
+            compact,
+        } => {
+            let resolved = compose_target(target.as_deref(), file.as_deref(), symbol.as_deref());
+            let exit = crate::calls::cli::run_callers(
+                &resolved,
                 path,
-                min_size,
-                rebuild,
-                json,
-                compact,
-            } => {
-                let exit = crate::deps::cli::run_cycles(
-                    path,
-                    *min_size,
-                    *json,
-                    !(*compact),
-                    *rebuild,
-                );
-                std::process::exit(exit);
-            }
-            Commands::Graph {
+                *depth,
+                *limit,
+                *include_ambiguous,
+                *rebuild,
+                *json,
+                !(*compact),
+            );
+            std::process::exit(exit);
+        }
+        Commands::Callees {
+            target,
+            path,
+            file,
+            symbol,
+            depth,
+            external,
+            rebuild,
+            json,
+            compact,
+        } => {
+            let resolved = compose_target(target.as_deref(), file.as_deref(), symbol.as_deref());
+            let exit = crate::calls::cli::run_callees(
+                &resolved,
                 path,
-                json,
-                include_external,
-                rebuild,
-                compact,
-            } => {
-                let exit = crate::deps::cli::run_graph(
-                    path,
-                    *json,
-                    *include_external,
-                    !(*compact),
-                    *rebuild,
-                );
-                std::process::exit(exit);
-            }
-            Commands::Index {
-                path,
-                rebuild,
-                stats,
-                json,
-                compact,
-            } => {
-                let exit = crate::search::cli::run_index(
-                    path,
-                    *rebuild,
-                    *stats,
-                    *json,
-                    !(*compact),
-                );
-                std::process::exit(exit);
-            }
-            Commands::Callers {
-                target,
-                path,
-                file,
-                symbol,
-                depth,
-                limit,
-                include_ambiguous,
-                rebuild,
-                json,
-                compact,
-            } => {
-                let resolved = compose_target(target.as_deref(), file.as_deref(), symbol.as_deref());
-                let exit = crate::calls::cli::run_callers(
-                    &resolved,
-                    path,
-                    *depth,
-                    *limit,
-                    *include_ambiguous,
-                    *rebuild,
-                    *json,
-                    !(*compact),
-                );
-                std::process::exit(exit);
-            }
-            Commands::Callees {
-                target,
-                path,
-                file,
-                symbol,
-                depth,
-                external,
-                rebuild,
-                json,
-                compact,
-            } => {
-                let resolved = compose_target(target.as_deref(), file.as_deref(), symbol.as_deref());
-                let exit = crate::calls::cli::run_callees(
-                    &resolved,
-                    path,
-                    *depth,
-                    *external,
-                    *rebuild,
-                    *json,
-                    !(*compact),
-                );
-                std::process::exit(exit);
-            }
-            Commands::Trace {
-                from,
-                to,
-                path,
-                depth,
-                rebuild,
-                json,
-                compact,
-            } => {
-                let exit = crate::calls::cli::run_trace(
-                    from,
-                    to,
-                    path,
-                    *depth,
-                    *rebuild,
-                    *json,
-                    !(*compact),
-                );
-                std::process::exit(exit);
-            }
-            Commands::Run {
+                *depth,
+                *external,
+                *rebuild,
+                *json,
+                !(*compact),
+            );
+            std::process::exit(exit);
+        }
+        Commands::Trace {
+            from,
+            to,
+            path,
+            depth,
+            rebuild,
+            json,
+            compact,
+        } => {
+            let exit =
+                crate::calls::cli::run_trace(from, to, path, *depth, *rebuild, *json, !(*compact));
+            std::process::exit(exit);
+        }
+        Commands::Run {
+            pattern,
+            rewrite,
+            lang,
+            paths,
+            glob,
+            write,
+            json,
+            compact,
+        } => {
+            let exit = crate::run::cli::run(
                 pattern,
-                rewrite,
-                lang,
+                rewrite.as_deref(),
+                lang.as_deref(),
                 paths,
-                glob,
-                write,
-                json,
-                compact,
-            } => {
-                let exit = crate::run::cli::run(
-                    pattern,
-                    rewrite.as_deref(),
-                    lang.as_deref(),
-                    paths,
-                    glob.as_deref(),
-                    *write,
-                    *json,
-                    !(*compact),
-                );
-                std::process::exit(exit);
-            }
+                glob.as_deref(),
+                *write,
+                *json,
+                !(*compact),
+            );
+            std::process::exit(exit);
+        }
     }
 }
 
@@ -1256,11 +1234,7 @@ fn run_install(
         match registry.iter().find(|i| i.name() == name) {
             Some(i) => vec![i],
             None => {
-                eprintln!(
-                    "unknown --target '{}'. Known: {}",
-                    name,
-                    names(&registry)
-                );
+                eprintln!("unknown --target '{}'. Known: {}", name, names(&registry));
                 return 2;
             }
         }
@@ -1385,11 +1359,7 @@ fn run_uninstall(
         match registry.iter().find(|i| i.name() == name) {
             Some(i) => vec![i],
             None => {
-                eprintln!(
-                    "unknown --target '{}'. Known: {}",
-                    name,
-                    names(&registry)
-                );
+                eprintln!("unknown --target '{}'. Known: {}", name, names(&registry));
                 return 2;
             }
         }
@@ -1430,9 +1400,17 @@ fn run_status(scope: &installers::Scope) {
         } else {
             "prompt -".to_string()
         };
-        let hook = if s.hook_installed { "hook ✓" } else { "hook -" };
+        let hook = if s.hook_installed {
+            "hook ✓"
+        } else {
+            "hook -"
+        };
         let mcp = if s.mcp_installed { "mcp ✓" } else { "mcp -" };
-        let skills = if s.skills_installed { "skills ✓" } else { "skills -" };
+        let skills = if s.skills_installed {
+            "skills ✓"
+        } else {
+            "skills -"
+        };
         println!(
             "{:<14} {:<14} {:<8} {:<8} {}",
             inst.name(),
@@ -1470,7 +1448,11 @@ fn select_all<'a>(
             }
             let d = inst.detect(scope);
             if !d.present {
-                println!("{:<14} {:<10} skipped  (not detected on this system)", inst.name(), "detect");
+                println!(
+                    "{:<14} {:<10} skipped  (not detected on this system)",
+                    inst.name(),
+                    "detect"
+                );
             }
             d.present
         })

--- a/src/path_glob.rs
+++ b/src/path_glob.rs
@@ -1,0 +1,15 @@
+use glob::glob;
+use std::path::{Path, PathBuf};
+
+pub fn expand_existing(path: &Path) -> Vec<PathBuf> {
+    if path.exists() {
+        return vec![path.to_path_buf()];
+    }
+    expand_pattern(path)
+}
+
+pub fn expand_pattern(pattern: &Path) -> Vec<PathBuf> {
+    glob(&pattern.to_string_lossy().replace('\\', "/"))
+        .map(|paths| paths.filter_map(Result::ok).collect())
+        .unwrap_or_default()
+}

--- a/src/search/index.rs
+++ b/src/search/index.rs
@@ -321,7 +321,7 @@ impl Index {
         // 2. Build flat chunks vec + per-file chunk_range.
         let mut chunks = Vec::new();
         let mut files: Vec<FileRecord> = Vec::with_capacity(file_paths.len());
-        for (path, file_chunks) in file_paths.iter().zip(chunks_per_file.into_iter()) {
+        for (path, file_chunks) in file_paths.iter().zip(chunks_per_file) {
             let rel = match path.strip_prefix(&paths.root) {
                 Ok(r) => normalise_path(r),
                 Err(_) => continue,

--- a/src/search/index.rs
+++ b/src/search/index.rs
@@ -321,7 +321,7 @@ impl Index {
         // 2. Build flat chunks vec + per-file chunk_range.
         let mut chunks = Vec::new();
         let mut files: Vec<FileRecord> = Vec::with_capacity(file_paths.len());
-        for (path, file_chunks) in file_paths.iter().zip(chunks_per_file) {
+        for (path, file_chunks) in file_paths.iter().zip(chunks_per_file.into_iter()) {
             let rel = match path.strip_prefix(&paths.root) {
                 Ok(r) => normalise_path(r),
                 Err(_) => continue,

--- a/src/surface/entry_point.rs
+++ b/src/surface/entry_point.rs
@@ -10,6 +10,7 @@
 
 use crate::surface::manifest::{self, CargoManifest};
 use crate::surface::options::{LangOverride, SurfaceError};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone)]
@@ -185,6 +186,13 @@ fn _has_scala_file(dir: &Path) -> bool {
 }
 
 fn discover_rust(root: &Path) -> Result<EntryPoint, SurfaceError> {
+    discover_rust_inner(root, &mut HashSet::new())
+}
+
+fn discover_rust_inner(
+    root: &Path,
+    seen: &mut HashSet<PathBuf>,
+) -> Result<EntryPoint, SurfaceError> {
     let manifest_path = if root.join("Cargo.toml").is_file() {
         root.join("Cargo.toml")
     } else if root.is_file() && root.file_name().and_then(|s| s.to_str()) == Some("Cargo.toml") {
@@ -201,6 +209,16 @@ fn discover_rust(root: &Path) -> Result<EntryPoint, SurfaceError> {
         path: manifest_path.clone(),
         source: std::io::Error::other("cannot read Cargo.toml"),
     })?;
+    let manifest_dir = manifest
+        .manifest_dir
+        .canonicalize()
+        .unwrap_or_else(|_| manifest.manifest_dir.clone());
+    if !seen.insert(manifest_dir) {
+        return Err(SurfaceError::NoEntryPoint {
+            path: manifest.manifest_dir.clone(),
+            hint: "Cargo workspace member cycle detected".into(),
+        });
+    }
 
     // Workspace?
     if !manifest.workspace_members.is_empty() {
@@ -210,7 +228,7 @@ fn discover_rust(root: &Path) -> Result<EntryPoint, SurfaceError> {
             .iter()
             .flat_map(|m| _expand_workspace_member(&manifest.manifest_dir, m))
         {
-            if let Ok(ep) = discover_rust(&member_root) {
+            if let Ok(ep) = discover_rust_inner(&member_root, seen) {
                 members.push(ep);
             }
         }

--- a/src/surface/entry_point.rs
+++ b/src/surface/entry_point.rs
@@ -227,6 +227,9 @@ fn discover_rust_inner(
             .workspace_members
             .iter()
             .flat_map(|m| _expand_workspace_member(&manifest.manifest_dir, m))
+            .filter(|p| {
+                !_workspace_member_excluded(&manifest.manifest_dir, p, &manifest.workspace_exclude)
+            })
         {
             if let Ok(ep) = discover_rust_inner(&member_root, seen) {
                 members.push(ep);
@@ -343,6 +346,24 @@ fn _expand_workspace_member(manifest_dir: &Path, member: &str) -> Vec<PathBuf> {
         .into_iter()
         .filter(|p| p.join("Cargo.toml").is_file())
         .collect()
+}
+
+fn _workspace_member_excluded(
+    manifest_dir: &Path,
+    member_root: &Path,
+    excludes: &[String],
+) -> bool {
+    excludes.iter().any(|exclude| {
+        crate::path_glob::expand_pattern(&manifest_dir.join(exclude))
+            .into_iter()
+            .any(|p| _same_path(&p, member_root))
+    })
+}
+
+fn _same_path(a: &Path, b: &Path) -> bool {
+    let a = a.canonicalize().unwrap_or_else(|_| a.to_path_buf());
+    let b = b.canonicalize().unwrap_or_else(|_| b.to_path_buf());
+    a == b
 }
 
 fn _resolve_rust_root(m: &CargoManifest) -> Option<PathBuf> {

--- a/src/surface/entry_point.rs
+++ b/src/surface/entry_point.rs
@@ -73,7 +73,8 @@ fn discover_file(file: &Path) -> Result<EntryPoint, SurfaceError> {
     let ext = file.extension().and_then(|s| s.to_str()).unwrap_or("");
     if name == "lib.rs" || name == "main.rs" {
         let src_dir = file.parent().unwrap_or(Path::new(".")).to_path_buf();
-        let crate_name = _crate_name_from_cargo(&src_dir).unwrap_or_else(|| _dir_basename(&src_dir));
+        let crate_name =
+            _crate_name_from_cargo(&src_dir).unwrap_or_else(|| _dir_basename(&src_dir));
         return Ok(EntryPoint::RustCrate {
             root_file: file.to_path_buf(),
             crate_name,
@@ -96,7 +97,10 @@ fn discover_file(file: &Path) -> Result<EntryPoint, SurfaceError> {
     if name == "package.json" {
         return discover_typescript(file.parent().unwrap_or(Path::new(".")));
     }
-    if matches!(ext, "ts" | "tsx" | "mts" | "cts" | "js" | "jsx" | "mjs" | "cjs") {
+    if matches!(
+        ext,
+        "ts" | "tsx" | "mts" | "cts" | "js" | "jsx" | "mjs" | "cjs"
+    ) {
         let dir = file.parent().unwrap_or(Path::new("."));
         let pkg_name = manifest::parse_package_json(&dir.join("package.json"))
             .and_then(|p| p.name)
@@ -188,7 +192,8 @@ fn discover_rust(root: &Path) -> Result<EntryPoint, SurfaceError> {
     } else {
         return Err(SurfaceError::NoEntryPoint {
             path: root.to_path_buf(),
-            hint: "no Cargo.toml here; pass `--lang fallback` or point at lib.rs/main.rs directly".into(),
+            hint: "no Cargo.toml here; pass `--lang fallback` or point at lib.rs/main.rs directly"
+                .into(),
         });
     };
 
@@ -200,8 +205,11 @@ fn discover_rust(root: &Path) -> Result<EntryPoint, SurfaceError> {
     // Workspace?
     if !manifest.workspace_members.is_empty() {
         let mut members = Vec::new();
-        for m in &manifest.workspace_members {
-            let member_root = manifest.manifest_dir.join(m);
+        for member_root in manifest
+            .workspace_members
+            .iter()
+            .flat_map(|m| _expand_workspace_member(&manifest.manifest_dir, m))
+        {
             if let Ok(ep) = discover_rust(&member_root) {
                 members.push(ep);
             }
@@ -312,6 +320,13 @@ fn discover_scala(root: &Path) -> Result<EntryPoint, SurfaceError> {
     })
 }
 
+fn _expand_workspace_member(manifest_dir: &Path, member: &str) -> Vec<PathBuf> {
+    crate::path_glob::expand_pattern(&manifest_dir.join(member))
+        .into_iter()
+        .filter(|p| p.join("Cargo.toml").is_file())
+        .collect()
+}
+
 fn _resolve_rust_root(m: &CargoManifest) -> Option<PathBuf> {
     if let Some(p) = &m.lib_path {
         let abs = m.manifest_dir.join(p);
@@ -345,7 +360,8 @@ fn _find_nearest_manifest(dir: &Path) -> Option<PathBuf> {
         if !p.is_dir() {
             continue;
         }
-        if p.join("Cargo.toml").is_file() || p.join("pyproject.toml").is_file()
+        if p.join("Cargo.toml").is_file()
+            || p.join("pyproject.toml").is_file()
             || p.join("__init__.py").is_file()
         {
             return Some(p);

--- a/src/surface/manifest.rs
+++ b/src/surface/manifest.rs
@@ -93,7 +93,10 @@ pub fn parse_cargo_toml(path: &Path) -> Option<CargoManifest> {
             section = format!("[{}]", hdr);
             if hdr == "[bin]" {
                 section = "[[bin]]".to_string();
-                current_bin = Some(BinTarget { name: None, path: None });
+                current_bin = Some(BinTarget {
+                    name: None,
+                    path: None,
+                });
             }
             continue;
         }
@@ -105,14 +108,12 @@ pub fn parse_cargo_toml(path: &Path) -> Option<CargoManifest> {
         };
 
         match section.as_str() {
-            "[package]"
-                if key == "name" => {
-                    m.package_name = _unquote(value);
-                }
-            "[lib]"
-                if key == "path" => {
-                    m.lib_path = _unquote(value).map(PathBuf::from);
-                }
+            "[package]" if key == "name" => {
+                m.package_name = _unquote(value);
+            }
+            "[lib]" if key == "path" => {
+                m.lib_path = _unquote(value).map(PathBuf::from);
+            }
             "[[bin]]" => {
                 if let Some(b) = current_bin.as_mut() {
                     if key == "name" {
@@ -122,10 +123,11 @@ pub fn parse_cargo_toml(path: &Path) -> Option<CargoManifest> {
                     }
                 }
             }
-            "[workspace]"
-                if key == "members" => {
+            "[workspace]" => {
+                if key == "members" {
                     m.workspace_members = _parse_string_array(value);
                 }
+            }
             _ => {}
         }
     }
@@ -165,9 +167,18 @@ pub fn parse_package_json(path: &Path) -> Option<PackageJson> {
     let v: Value = serde_json::from_str(&raw).ok()?;
     let manifest_dir = path.parent().unwrap_or(Path::new(".")).to_path_buf();
 
-    let name = v.get("name").and_then(|x| x.as_str()).map(|s| s.to_string());
-    let main = v.get("main").and_then(|x| x.as_str()).map(|s| s.to_string());
-    let module = v.get("module").and_then(|x| x.as_str()).map(|s| s.to_string());
+    let name = v
+        .get("name")
+        .and_then(|x| x.as_str())
+        .map(|s| s.to_string());
+    let main = v
+        .get("main")
+        .and_then(|x| x.as_str())
+        .map(|s| s.to_string());
+    let module = v
+        .get("module")
+        .and_then(|x| x.as_str())
+        .map(|s| s.to_string());
     let types = v
         .get("types")
         .or_else(|| v.get("typings"))
@@ -204,7 +215,12 @@ pub fn resolve_package_entry(pkg: &PackageJson) -> Option<PathBuf> {
             }
         }
     }
-    if let Some(rel) = pkg.types.as_deref().or(pkg.module.as_deref()).or(pkg.main.as_deref()) {
+    if let Some(rel) = pkg
+        .types
+        .as_deref()
+        .or(pkg.module.as_deref())
+        .or(pkg.main.as_deref())
+    {
         if let Some(p) = _exists_with_source_pref(&pkg.manifest_dir.join(rel)) {
             return Some(p);
         }
@@ -328,7 +344,11 @@ fn _unquote(v: &str) -> Option<String> {
     let v = v.trim();
     if let Some(s) = v.strip_prefix('"').and_then(|s| s.strip_suffix('"')) {
         Some(s.to_string())
-    } else { v.strip_prefix('\'').and_then(|s| s.strip_suffix('\'')).map(|s| s.to_string()) }
+    } else {
+        v.strip_prefix('\'')
+            .and_then(|s| s.strip_suffix('\''))
+            .map(|s| s.to_string())
+    }
 }
 
 fn _parse_string_array(v: &str) -> Vec<String> {

--- a/src/surface/manifest.rs
+++ b/src/surface/manifest.rs
@@ -105,16 +105,14 @@ pub fn parse_cargo_toml(path: &Path) -> Option<CargoManifest> {
         };
 
         match section.as_str() {
-            "[package]" => {
-                if key == "name" {
+            "[package]"
+                if key == "name" => {
                     m.package_name = _unquote(value);
                 }
-            }
-            "[lib]" => {
-                if key == "path" {
+            "[lib]"
+                if key == "path" => {
                     m.lib_path = _unquote(value).map(PathBuf::from);
                 }
-            }
             "[[bin]]" => {
                 if let Some(b) = current_bin.as_mut() {
                     if key == "name" {
@@ -124,11 +122,10 @@ pub fn parse_cargo_toml(path: &Path) -> Option<CargoManifest> {
                     }
                 }
             }
-            "[workspace]" => {
-                if key == "members" {
+            "[workspace]"
+                if key == "members" => {
                     m.workspace_members = _parse_string_array(value);
                 }
-            }
             _ => {}
         }
     }

--- a/src/surface/manifest.rs
+++ b/src/surface/manifest.rs
@@ -5,7 +5,7 @@
 //! - `[package].name` for the crate name
 //! - `[lib].path` for an explicit lib root
 //! - `[[bin]].path` (and the matching `name`) for binary roots
-//! - `[workspace].members` for workspace fan-out
+//! - `[workspace].members` / `[workspace].exclude` for workspace fan-out
 //! - `[project].name` for Python pkg name
 //!
 //! The parser is strict-enough-for-our-needs: it understands sections,
@@ -22,6 +22,7 @@ pub struct CargoManifest {
     pub lib_path: Option<PathBuf>,
     pub bins: Vec<BinTarget>,
     pub workspace_members: Vec<String>,
+    pub workspace_exclude: Vec<String>,
     pub manifest_dir: PathBuf,
 }
 
@@ -123,11 +124,11 @@ pub fn parse_cargo_toml(path: &Path) -> Option<CargoManifest> {
                     }
                 }
             }
-            "[workspace]" => {
-                if key == "members" {
-                    m.workspace_members = _parse_string_array(value);
-                }
-            }
+            "[workspace]" => match key {
+                "members" => m.workspace_members = _parse_string_array(value),
+                "exclude" => m.workspace_exclude = _parse_string_array(value),
+                _ => {}
+            },
             _ => {}
         }
     }

--- a/src/surface/rust.rs
+++ b/src/surface/rust.rs
@@ -128,9 +128,9 @@ struct SurfaceWalker {
     crate_name: String,
     graph: ModuleGraph,
     max_depth: usize,
-    /// Per-walk visited set keyed by `(module_path, item_name)` — breaks
-    /// cycles in `pub use` chains.
-    visited: HashSet<(String, String)>,
+    /// Active recursion stack keyed by `(module_path, item_name)` — breaks
+    /// cycles in `pub use` chains without suppressing later re-exports.
+    reexport_stack: HashSet<(String, String)>,
     /// Final emitted entries, dedup'd by qualified_path.
     entries: Vec<SurfaceEntry>,
     seen_qualified: HashSet<String>,
@@ -142,7 +142,7 @@ impl SurfaceWalker {
             crate_name,
             graph,
             max_depth,
-            visited: HashSet::new(),
+            reexport_stack: HashSet::new(),
             entries: Vec::new(),
             seen_qualified: HashSet::new(),
         }
@@ -354,10 +354,6 @@ impl SurfaceWalker {
                 let (target_file, target_decls, target_uses) = target_data;
 
                 for d in &target_decls {
-                    let cycle_key = (key.clone(), d.name.clone());
-                    if !self.visited.insert(cycle_key) {
-                        continue;
-                    }
                     self._emit_renamed(
                         from_segments,
                         &d.name,
@@ -406,7 +402,7 @@ impl SurfaceWalker {
             return;
         }
         let cycle_key = (ModuleGraph::key(target_module), item.to_string());
-        if !self.visited.insert(cycle_key) {
+        if !self.reexport_stack.insert(cycle_key.clone()) {
             return;
         }
         let key = ModuleGraph::key(target_module);
@@ -439,13 +435,17 @@ impl SurfaceWalker {
                     .collect();
                 (m.file.clone(), decl, uses)
             }
-            None => return,
+            None => {
+                self.reexport_stack.remove(&cycle_key);
+                return;
+            }
         };
         let (target_file, target_decl, target_uses) = target_data;
 
         // Is `item` an actual declaration in `target_module`?
         if let Some(d) = target_decl {
             self._emit_renamed(from_segments, alias, &d, &target_file, chain, via_glob);
+            self.reexport_stack.remove(&cycle_key);
             return;
         }
         // Is `item` re-exported from inside `target_module`?
@@ -494,6 +494,7 @@ impl SurfaceWalker {
                 }
             }
         }
+        self.reexport_stack.remove(&cycle_key);
     }
 
     fn _republish_via_use(
@@ -549,10 +550,6 @@ impl SurfaceWalker {
                     None => return,
                 };
                 for d in snap.1 {
-                    let cycle_key = (key.clone(), d.name.clone());
-                    if !self.visited.insert(cycle_key) {
-                        continue;
-                    }
                     self._emit_renamed(from_segments, &d.name, &d, &snap.0, chain.clone(), true);
                 }
             }

--- a/src/surface/rust.rs
+++ b/src/surface/rust.rs
@@ -314,10 +314,6 @@ impl SurfaceWalker {
                 }
                 let item = resolved.last().unwrap().clone();
                 let target_module = resolved[..resolved.len() - 1].to_vec();
-                let cycle_key = (target_module.join("::"), item.clone());
-                if !self.visited.insert(cycle_key) {
-                    return;
-                }
                 let alias = u.alias.clone().unwrap_or_else(|| item.clone());
                 self._republish(
                     from_segments,
@@ -334,19 +330,30 @@ impl SurfaceWalker {
                 let target_module = resolved.clone();
                 let key = ModuleGraph::key(&target_module);
                 let target_data = match self.graph.modules.get(&key) {
-                    Some(m) => (
-                        m.file.clone(),
-                        m.parse.declarations.clone(),
-                        m.imports.uses.clone(),
-                    ),
+                    Some(m) => {
+                        let decls: Vec<Declaration> = m
+                            .parse
+                            .declarations
+                            .iter()
+                            .filter(|d| {
+                                _is_public(d) && !matches!(d.kind, DeclarationKind::Namespace)
+                            })
+                            .cloned()
+                            .collect();
+                        let uses: Vec<UseItem> = m
+                            .imports
+                            .uses
+                            .iter()
+                            .filter(|u| _vis_is_public(&u.visibility))
+                            .cloned()
+                            .collect();
+                        (m.file.clone(), decls, uses)
+                    }
                     None => return,
                 };
                 let (target_file, target_decls, target_uses) = target_data;
 
                 for d in &target_decls {
-                    if !_is_public(d) || matches!(d.kind, DeclarationKind::Namespace) {
-                        continue;
-                    }
                     let cycle_key = (key.clone(), d.name.clone());
                     if !self.visited.insert(cycle_key) {
                         continue;
@@ -362,9 +369,6 @@ impl SurfaceWalker {
                 }
                 // Transitive globs: target's own pub uses become reachable too.
                 for tu in target_uses {
-                    if !_vis_is_public(&tu.visibility) {
-                        continue;
-                    }
                     let mut next_chain = chain.clone();
                     next_chain.push(ReExportHop {
                         file: target_file.clone(),
@@ -401,40 +405,51 @@ impl SurfaceWalker {
         if depth > self.max_depth {
             return;
         }
+        let cycle_key = (ModuleGraph::key(target_module), item.to_string());
+        if !self.visited.insert(cycle_key) {
+            return;
+        }
         let key = ModuleGraph::key(target_module);
         let target_data = match self.graph.modules.get(&key) {
-            Some(m) => (
-                m.file.clone(),
-                m.parse.declarations.clone(),
-                m.imports.uses.clone(),
-            ),
+            Some(m) => {
+                let decl = m
+                    .parse
+                    .declarations
+                    .iter()
+                    .find(|d| d.name == item && _is_public(d))
+                    .cloned();
+                let uses: Vec<UseItem> = m
+                    .imports
+                    .uses
+                    .iter()
+                    .filter(|tu| {
+                        if !_vis_is_public(&tu.visibility) {
+                            return false;
+                        }
+                        let local_name = tu
+                            .alias
+                            .as_deref()
+                            .unwrap_or_else(|| _last_segment(&tu.path));
+                        match tu.kind {
+                            UseSegmentKind::Item => local_name == item,
+                            UseSegmentKind::Glob => true,
+                        }
+                    })
+                    .cloned()
+                    .collect();
+                (m.file.clone(), decl, uses)
+            }
             None => return,
         };
-        let (target_file, target_decls, target_uses) = target_data;
+        let (target_file, target_decl, target_uses) = target_data;
 
         // Is `item` an actual declaration in `target_module`?
-        for d in &target_decls {
-            if d.name == item && _is_public(d) {
-                self._emit_renamed(from_segments, alias, d, &target_file, chain, via_glob);
-                return;
-            }
+        if let Some(d) = target_decl {
+            self._emit_renamed(from_segments, alias, &d, &target_file, chain, via_glob);
+            return;
         }
         // Is `item` re-exported from inside `target_module`?
         for tu in target_uses {
-            if !_vis_is_public(&tu.visibility) {
-                continue;
-            }
-            let local_name = tu
-                .alias
-                .clone()
-                .unwrap_or_else(|| _last_segment(&tu.path).to_string());
-            let matches_item = match tu.kind {
-                UseSegmentKind::Item => local_name == item,
-                UseSegmentKind::Glob => true,
-            };
-            if !matches_item {
-                continue;
-            }
             let mut next_chain = chain.clone();
             next_chain.push(ReExportHop {
                 file: target_file.clone(),
@@ -519,24 +534,26 @@ impl SurfaceWalker {
                 let target_module = resolved.clone();
                 let key = ModuleGraph::key(&target_module);
                 let snap = match self.graph.modules.get(&key) {
-                    Some(m) => (m.file.clone(), m.parse.declarations.clone()),
+                    Some(m) => {
+                        let decls: Vec<Declaration> = m
+                            .parse
+                            .declarations
+                            .iter()
+                            .filter(|d| {
+                                _is_public(d) && !matches!(d.kind, DeclarationKind::Namespace)
+                            })
+                            .cloned()
+                            .collect();
+                        (m.file.clone(), decls)
+                    }
                     None => return,
                 };
                 for d in snap.1 {
-                    if _is_public(&d) && !matches!(d.kind, DeclarationKind::Namespace) {
-                        let cycle_key = (key.clone(), d.name.clone());
-                        if !self.visited.insert(cycle_key) {
-                            continue;
-                        }
-                        self._emit_renamed(
-                            from_segments,
-                            &d.name,
-                            &d,
-                            &snap.0,
-                            chain.clone(),
-                            true,
-                        );
+                    let cycle_key = (key.clone(), d.name.clone());
+                    if !self.visited.insert(cycle_key) {
+                        continue;
                     }
+                    self._emit_renamed(from_segments, &d.name, &d, &snap.0, chain.clone(), true);
                 }
             }
         }

--- a/src/surface/rust.rs
+++ b/src/surface/rust.rs
@@ -319,14 +319,26 @@ impl SurfaceWalker {
                     return;
                 }
                 let alias = u.alias.clone().unwrap_or_else(|| item.clone());
-                self._republish(from_segments, &target_module, &item, &alias, chain, false, depth);
+                self._republish(
+                    from_segments,
+                    &target_module,
+                    &item,
+                    &alias,
+                    chain,
+                    false,
+                    depth,
+                );
             }
             UseSegmentKind::Glob => {
                 // `resolved` IS the target module here (no item segment).
                 let target_module = resolved.clone();
                 let key = ModuleGraph::key(&target_module);
                 let target_data = match self.graph.modules.get(&key) {
-                    Some(m) => (m.file.clone(), m.parse.declarations.clone(), m.imports.uses.clone()),
+                    Some(m) => (
+                        m.file.clone(),
+                        m.parse.declarations.clone(),
+                        m.imports.uses.clone(),
+                    ),
                     None => return,
                 };
                 let (target_file, target_decls, target_uses) = target_data;
@@ -360,7 +372,13 @@ impl SurfaceWalker {
                         module_path: key.clone(),
                         statement: tu.statement.clone(),
                     });
-                    self._republish_via_use(from_segments, &target_module, &tu, next_chain, depth + 1);
+                    self._republish_via_use(
+                        from_segments,
+                        &target_module,
+                        &tu,
+                        next_chain,
+                        depth + 1,
+                    );
                 }
             }
         }
@@ -380,9 +398,16 @@ impl SurfaceWalker {
         via_glob: bool,
         depth: usize,
     ) {
+        if depth > self.max_depth {
+            return;
+        }
         let key = ModuleGraph::key(target_module);
         let target_data = match self.graph.modules.get(&key) {
-            Some(m) => (m.file.clone(), m.parse.declarations.clone(), m.imports.uses.clone()),
+            Some(m) => (
+                m.file.clone(),
+                m.parse.declarations.clone(),
+                m.imports.uses.clone(),
+            ),
             None => return,
         };
         let (target_file, target_decls, target_uses) = target_data;
@@ -468,11 +493,10 @@ impl SurfaceWalker {
             return;
         }
         let path_segments: Vec<String> = u.path.split("::").map(|s| s.to_string()).collect();
-        let resolved =
-            match _resolve_path(&self.crate_name, upstream_module, &path_segments) {
-                Some(r) => r,
-                None => return,
-            };
+        let resolved = match _resolve_path(&self.crate_name, upstream_module, &path_segments) {
+            Some(r) => r,
+            None => return,
+        };
         match u.kind {
             UseSegmentKind::Item => {
                 if resolved.is_empty() {
@@ -504,7 +528,14 @@ impl SurfaceWalker {
                         if !self.visited.insert(cycle_key) {
                             continue;
                         }
-                        self._emit_renamed(from_segments, &d.name, &d, &snap.0, chain.clone(), true);
+                        self._emit_renamed(
+                            from_segments,
+                            &d.name,
+                            &d,
+                            &snap.0,
+                            chain.clone(),
+                            true,
+                        );
                     }
                 }
             }
@@ -518,11 +549,7 @@ impl SurfaceWalker {
 /// Resolve a `use`-path written in `from_segments` against the module
 /// graph. Returns the absolute module path (segments) the user is
 /// referring to, or `None` if it leaves the crate.
-fn _resolve_path(
-    crate_name: &str,
-    from: &[String],
-    path: &[String],
-) -> Option<Vec<String>> {
+fn _resolve_path(crate_name: &str, from: &[String], path: &[String]) -> Option<Vec<String>> {
     if path.is_empty() {
         return None;
     }
@@ -604,17 +631,13 @@ fn _is_type_with_methods(d: &Declaration) -> bool {
 fn _is_method_like(d: &Declaration) -> bool {
     matches!(
         d.kind,
-        DeclarationKind::Method
-            | DeclarationKind::Function
-            | DeclarationKind::Constructor
+        DeclarationKind::Method | DeclarationKind::Function | DeclarationKind::Constructor
     )
 }
 
 fn _vis_is_public(v: &str) -> bool {
     let v = v.trim();
-    v == "pub"
-        || v.starts_with("pub ")
-        || v.starts_with("pub(")
+    v == "pub" || v.starts_with("pub ") || v.starts_with("pub(")
 }
 
 fn _last_segment(path: &str) -> &str {


### PR DESCRIPTION
In src/surface/manifest.rs, parse_cargo_toml() reads [workspace].members with _parse_string_array(value) and stores entries like "crates/*" literally, without expanding Cargo workspace globs.

In src/surface/entry_point.rs, discover_rust() iterates manifest.workspace_members, builds member_root = manifest.manifest_dir.join(m), and calls discover_rust(&member_root), so it tries to inspect a literal path like ./crates/* instead of the real crate directories.

When no workspace members resolve, discover_rust() falls through to _resolve_rust_root(), fails to find root-level src/lib.rs, src/main.rs, [lib].path, or [[bin]].path, and emits Cargo.toml found but no lib.rs/main.rs and no [lib].path/[[bin]].path entry.

Patched with a glob fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Workspace member paths now support glob patterns for richer project discovery.
  * Better path expansion and resolution for files and workspaces, reducing missed crates.
  * Cycle detection in Rust project discovery to avoid infinite recursion.
  * Workspace exclusion support to respect workspace ignore lists.
  * Minor UX/message refinements for clearer diagnostics during discovery and parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->