### PR TITLE
feat: enhance call graph for arrow functions

### DIFF
--- a/src/adapters/typescript.rs
+++ b/src/adapters/typescript.rs
@@ -780,13 +780,15 @@ fn _walk_calls_in_body<'a, D: Doc>(node: &Node<'a, D>, src: &[u8], out: &mut Vec
     // (`.map(x => f(x))`) show up in the call graph. Anonymous closures are
     // never extracted as separate declarations, so there is no double-count.
     //
-    // `arrow_function` and `function_expression` are intentionally NOT in this
+    // `arrow_function`, `function_expression`, and `function` (the legacy
+    // grammar name for a function expression) are intentionally NOT in this
     // list — see _walk_calls_in_body's callers, which pass a body node, so the
-    // root of a walk is never one of these for its own declaration.
+    // root of a walk is never one of these for its own declaration. They are
+    // also what `_lexical_to_decl` treats as expression-like initializers, so
+    // the two sites must agree on the set.
     if matches!(
         kind,
         "function_declaration"
-            | "function"
             | "method_definition"
             | "class_declaration"
             | "class"

--- a/src/adapters/typescript.rs
+++ b/src/adapters/typescript.rs
@@ -535,9 +535,14 @@ fn _lexical_to_decl<'a, D: Doc>(node: &Node<'a, D>, src: &[u8]) -> Option<Declar
             "arrow_function" | "function_expression" | "function"
         ) {
             let body = v.field("body");
-            let end = body.map(|b| b.range().start).unwrap_or(v.range().end);
+            let end = body.as_ref().map(|b| b.range().start).unwrap_or(v.range().end);
             let text = String::from_utf8_lossy(&src[node.range().start..end]).to_string();
             let sig = collapse_ws(&text).trim_end_matches('{').trim().to_string();
+
+            let mut calls = Vec::new();
+            if let Some(body) = &body {
+                _walk_calls_in_body(body, src, &mut calls);
+            }
 
             let range = node.range();
             return Some(Declaration {
@@ -558,7 +563,7 @@ fn _lexical_to_decl<'a, D: Doc>(node: &Node<'a, D>, src: &[u8]) -> Option<Declar
                 modifiers: Vec::new(),
                 deprecated: false,
                 children: Vec::new(),
-                calls: Vec::new(),
+                calls,
             });
         }
     }

--- a/src/adapters/typescript.rs
+++ b/src/adapters/typescript.rs
@@ -773,12 +773,20 @@ fn _leading_doc_start_byte<'a, D: Doc>(node: &Node<'a, D>) -> Option<usize> {
 fn _walk_calls_in_body<'a, D: Doc>(node: &Node<'a, D>, src: &[u8], out: &mut Vec<CallSite>) {
     let kind = node.kind();
     let kind: &str = kind.as_ref();
+    // Stop at *named* nested scopes (they are — or should be — their own graph
+    // nodes), but descend *through* anonymous closures so their calls are
+    // attributed to the enclosing declaration. This is what makes curried
+    // arrows (`a => b => f()`), returned closures, and inline callbacks
+    // (`.map(x => f(x))`) show up in the call graph. Anonymous closures are
+    // never extracted as separate declarations, so there is no double-count.
+    //
+    // `arrow_function` and `function_expression` are intentionally NOT in this
+    // list — see _walk_calls_in_body's callers, which pass a body node, so the
+    // root of a walk is never one of these for its own declaration.
     if matches!(
         kind,
         "function_declaration"
-            | "function_expression"
             | "function"
-            | "arrow_function"
             | "method_definition"
             | "class_declaration"
             | "class"

--- a/tests/calls_e2e.rs
+++ b/tests/calls_e2e.rs
@@ -142,6 +142,69 @@ fn typescript_callers_finds_cross_file_caller() {
 }
 
 #[test]
+fn typescript_callees_from_arrow_const() {
+    // Regression: arrow functions / function expressions bound to a const
+    // had their bodies skipped, so the call graph saw zero calls from them.
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    write(
+        &root.join("package.json"),
+        r#"{"name":"smoke","version":"0.0.0"}"#,
+    );
+    write(
+        &root.join("src/main.ts"),
+        "function beta(): void {}\n\
+         // block-body arrow\n\
+         const gamma = (): void => { beta(); };\n\
+         // async block-body arrow\n\
+         const delta = async (): Promise<void> => { beta(); };\n\
+         // concise expression-body arrow\n\
+         const epsilon = (): void => beta();\n\
+         // function expression\n\
+         const zeta = function (): void { beta(); };\n",
+    );
+
+    for sym in ["gamma", "delta", "epsilon", "zeta"] {
+        let (out, code) = run_in(root, &["callees", sym, ".", "--rebuild"]);
+        assert_eq!(code, 0, "callees {} exited non-zero: {}", sym, out);
+        assert!(
+            out.contains("beta"),
+            "expected `beta` in callees of {}, got:\n{}",
+            sym,
+            out
+        );
+    }
+}
+
+#[test]
+fn typescript_callers_includes_arrow_const() {
+    // The flip side: `beta`'s callers must include the arrow-const callers.
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    write(
+        &root.join("package.json"),
+        r#"{"name":"smoke","version":"0.0.0"}"#,
+    );
+    write(
+        &root.join("src/main.ts"),
+        "function beta(): void {}\n\
+         function alpha(): void { beta(); }\n\
+         const gamma = (): void => { beta(); };\n\
+         const epsilon = (): void => beta();\n",
+    );
+    let (out, code) = run_in(root, &["callers", "beta", ".", "--rebuild"]);
+    assert_eq!(code, 0, "callers exited non-zero: {}", out);
+    for caller in ["alpha", "gamma", "epsilon"] {
+        assert!(
+            out.contains(caller),
+            "expected `{}` in callers of beta, got:\n{}",
+            caller,
+            out
+        );
+    }
+}
+
+#[test]
 fn callers_with_file_filter_narrows_match() {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();

--- a/tests/calls_e2e.rs
+++ b/tests/calls_e2e.rs
@@ -177,6 +177,65 @@ fn typescript_callees_from_arrow_const() {
 }
 
 #[test]
+fn typescript_callees_descends_into_anonymous_closures() {
+    // Calls inside anonymous closures — curried arrows, returned closures,
+    // and inline callbacks — are attributed to the enclosing declaration.
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    write(
+        &root.join("package.json"),
+        r#"{"name":"smoke","version":"0.0.0"}"#,
+    );
+    write(
+        &root.join("src/main.ts"),
+        "function beta(): void {}\n\
+         // curried arrow: outer body IS the inner arrow\n\
+         const curried = (x: number) => (y: number) => beta();\n\
+         // block body returning an anonymous closure\n\
+         const returns = () => { return () => beta(); };\n\
+         // inline callback inside a plain function declaration\n\
+         function withCallback(): void { [1].forEach(() => beta()); }\n",
+    );
+
+    for sym in ["curried", "returns", "withCallback"] {
+        let (out, code) = run_in(root, &["callees", sym, ".", "--rebuild"]);
+        assert_eq!(code, 0, "callees {} exited non-zero: {}", sym, out);
+        assert!(
+            out.contains("beta"),
+            "expected `beta` in callees of {}, got:\n{}",
+            sym,
+            out
+        );
+    }
+}
+
+#[test]
+fn typescript_callees_still_stops_at_named_nested_scope() {
+    // A *named* nested function is its own scope: calls inside it must NOT
+    // bubble up to the enclosing declaration.
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    write(
+        &root.join("package.json"),
+        r#"{"name":"smoke","version":"0.0.0"}"#,
+    );
+    write(
+        &root.join("src/main.ts"),
+        "function beta(): void {}\n\
+         function outer(): void {\n\
+           function nested(): void { beta(); }\n\
+         }\n",
+    );
+    let (out, code) = run_in(root, &["callees", "outer", ".", "--rebuild"]);
+    assert_eq!(code, 0, "callees exited non-zero: {}", out);
+    assert!(
+        !out.contains("beta"),
+        "beta should NOT be a callee of outer (it is inside named `nested`), got:\n{}",
+        out
+    );
+}
+
+#[test]
 fn typescript_callers_includes_arrow_const() {
     // The flip side: `beta`'s callers must include the arrow-const callers.
     let tmp = tempfile::tempdir().unwrap();

--- a/tests/calls_e2e.rs
+++ b/tests/calls_e2e.rs
@@ -194,10 +194,12 @@ fn typescript_callees_descends_into_anonymous_closures() {
          // block body returning an anonymous closure\n\
          const returns = () => { return () => beta(); };\n\
          // inline callback inside a plain function declaration\n\
-         function withCallback(): void { [1].forEach(() => beta()); }\n",
+         function withCallback(): void { [1].forEach(() => beta()); }\n\
+         // inline `function` expression callback (legacy `function` node kind)\n\
+         function withFnExpr(): void { [1].forEach(function () { beta(); }); }\n",
     );
 
-    for sym in ["curried", "returns", "withCallback"] {
+    for sym in ["curried", "returns", "withCallback", "withFnExpr"] {
         let (out, code) = run_in(root, &["callees", sym, ".", "--rebuild"]);
         assert_eq!(code, 0, "callees {} exited non-zero: {}", sym, out);
         assert!(
@@ -207,6 +209,32 @@ fn typescript_callees_descends_into_anonymous_closures() {
             out
         );
     }
+}
+
+#[test]
+fn typescript_callees_bubbles_block_local_const_closure() {
+    // A const-bound closure declared *inside* a function body is not extracted
+    // as its own declaration, so — like an inline callback — its calls are
+    // attributed to the enclosing function. (Intentionally the opposite of the
+    // named-nested-function case below.)
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    write(
+        &root.join("package.json"),
+        r#"{"name":"smoke","version":"0.0.0"}"#,
+    );
+    write(
+        &root.join("src/main.ts"),
+        "function beta(): void {}\n\
+         function outer(): void { const inner = () => beta(); inner(); }\n",
+    );
+    let (out, code) = run_in(root, &["callees", "outer", ".", "--rebuild"]);
+    assert_eq!(code, 0, "callees exited non-zero: {}", out);
+    assert!(
+        out.contains("beta"),
+        "expected `beta` to bubble up to outer from the const closure, got:\n{}",
+        out
+    );
 }
 
 #[test]


### PR DESCRIPTION
https://github.com/aeroxy/ast-bro/issues/23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved call attribution so calls inside arrow functions, function expressions, and anonymous closures are correctly attributed to the enclosing declaration while still excluding calls inside named nested functions.

* **Tests**
  * Added TypeScript regression tests covering callers/callees for arrow/function-expression bindings, anonymous closures, block-scoped closures, and named nested-scope exclusions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->