### PR TITLE
fix: add markdown files to crane source filter

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,15 @@
         ...
       }: let
         craneLib = crane.mkLib pkgs;
-        src = craneLib.cleanCargoSource ./.;
+        # Only keeps markdown files and regular cargo source files (e.g. .rs, Cargo.toml, Cargo.lock)
+        markdownFilter = path: _type: lib.hasSuffix ".md" path;
+        markdownOrCargo = path: type:
+          type == "directory" || (markdownFilter path type) || (craneLib.filterCargoSources path type);
+        src = pkgs.lib.cleanSourceWith {
+          src = ./.;
+          filter = markdownOrCargo;
+          name = "source";
+        };
 
         # Read package metadata from Cargo.toml so we don't have to
         # duplicate it here.


### PR DESCRIPTION
Flake stopped working since commit
e9cfb2fc0cdc0dd72df505c5babc93fe4196ba1e started to include the prompt directly from skill file.

This is because crane (and nix in general) will only copy certain subsets of files to the build sandbox.

This commit adds markdown files to the filter as well