### PR TITLE
chore: fix clippy warnings + cargo fmt

### DIFF
--- a/src/adapters/cpp.rs
+++ b/src/adapters/cpp.rs
@@ -360,12 +360,7 @@ fn _function_to_decl<'a, D: Doc>(
         start_byte: range.start,
         end_byte: range.end,
         doc_start_byte: range.start,
-        native_kind: Some(if inside_class {
-            "method"
-        } else {
-            "function"
-        }
-        .to_string()),
+        native_kind: Some(if inside_class { "method" } else { "function" }.to_string()),
         modifiers: Vec::new(),
         deprecated: false,
         children: Vec::new(),
@@ -500,9 +495,9 @@ fn _drill_function_declarator_name<'a, D: Doc>(node: &Node<'a, D>) -> Option<Str
             _drill_function_declarator_name(&inner)
         }
         "pointer_declarator" | "reference_declarator" | "parenthesized_declarator" => {
-            let inner = node.field("declarator").or_else(|| {
-                node.children().find(|c| c.is_named())
-            })?;
+            let inner = node
+                .field("declarator")
+                .or_else(|| node.children().find(|c| c.is_named()))?;
             _drill_function_declarator_name(&inner)
         }
         "identifier" | "field_identifier" | "operator_name" | "destructor_name" => {
@@ -534,9 +529,9 @@ fn _drill_function_declarator_qname<'a, D: Doc>(node: &Node<'a, D>) -> Option<St
             _drill_function_declarator_qname(&inner)
         }
         "pointer_declarator" | "reference_declarator" | "parenthesized_declarator" => {
-            let inner = node.field("declarator").or_else(|| {
-                node.children().find(|c| c.is_named())
-            })?;
+            let inner = node
+                .field("declarator")
+                .or_else(|| node.children().find(|c| c.is_named()))?;
             _drill_function_declarator_qname(&inner)
         }
         // Explicit terminals — preserve the full scope (`Foo::bar`) for
@@ -606,14 +601,10 @@ fn _call_site_from_call_cpp<'a, D: Doc>(node: &Node<'a, D>, src: &[u8]) -> Optio
     })
 }
 
-fn _call_site_from_new_expression<'a, D: Doc>(
-    node: &Node<'a, D>,
-    src: &[u8],
-) -> Option<CallSite> {
-    let type_node = node.field("type").or_else(|| {
-        node.children()
-            .find(|c| c.is_named() && c.kind() != "new")
-    })?;
+fn _call_site_from_new_expression<'a, D: Doc>(node: &Node<'a, D>, src: &[u8]) -> Option<CallSite> {
+    let type_node = node
+        .field("type")
+        .or_else(|| node.children().find(|c| c.is_named() && c.kind() != "new"))?;
     let raw = String::from_utf8_lossy(&src[type_node.range()]).to_string();
     let name = _last_type_segment_cpp(&raw);
     if name.is_empty() {
@@ -643,14 +634,17 @@ fn _split_callee_cpp<'a, D: Doc>(
             let field = node.field("field")?;
             let arg = node.field("argument");
             let name = String::from_utf8_lossy(&src[field.range()]).to_string();
-            let receiver = arg
-                .map(|a| collapse_ws(&String::from_utf8_lossy(&src[a.range()])));
+            let receiver = arg.map(|a| collapse_ws(&String::from_utf8_lossy(&src[a.range()])));
             Some((name, receiver))
         }
         "qualified_identifier" | "scoped_identifier" => {
             let raw = String::from_utf8_lossy(&src[node.range()]).to_string();
             let collapsed = collapse_ws(&raw);
-            let name = collapsed.rsplit("::").next().unwrap_or(&collapsed).to_string();
+            let name = collapsed
+                .rsplit("::")
+                .next()
+                .unwrap_or(&collapsed)
+                .to_string();
             let receiver = if collapsed.contains("::") {
                 let cut = collapsed.rfind("::").unwrap();
                 Some(collapsed[..cut].to_string())
@@ -660,9 +654,9 @@ fn _split_callee_cpp<'a, D: Doc>(
             Some((name, receiver))
         }
         "template_function" => {
-            let name_node = node.field("name").or_else(|| {
-                node.children().find(|c| c.is_named())
-            })?;
+            let name_node = node
+                .field("name")
+                .or_else(|| node.children().find(|c| c.is_named()))?;
             _split_callee_cpp(&name_node, src)
         }
         _ => {

--- a/src/adapters/csharp.rs
+++ b/src/adapters/csharp.rs
@@ -576,8 +576,7 @@ fn _walk_calls_in_body<'a, D: Doc>(node: &Node<'a, D>, src: &[u8], out: &mut Vec
         if let Some(cs) = _call_site_from_invocation(node, src) {
             out.push(cs);
         }
-    } else if kind == "object_creation_expression"
-        || kind == "implicit_object_creation_expression"
+    } else if kind == "object_creation_expression" || kind == "implicit_object_creation_expression"
     {
         if let Some(cs) = _call_site_from_object_creation(node, src) {
             out.push(cs);
@@ -589,10 +588,7 @@ fn _walk_calls_in_body<'a, D: Doc>(node: &Node<'a, D>, src: &[u8], out: &mut Vec
     }
 }
 
-fn _call_site_from_invocation<'a, D: Doc>(
-    node: &Node<'a, D>,
-    src: &[u8],
-) -> Option<CallSite> {
+fn _call_site_from_invocation<'a, D: Doc>(node: &Node<'a, D>, src: &[u8]) -> Option<CallSite> {
     let func = node.field("function")?;
     let (name, receiver) = _split_callee(&func, src)?;
     let line = node.start_pos().line() as u32 + 1;
@@ -604,10 +600,7 @@ fn _call_site_from_invocation<'a, D: Doc>(
     })
 }
 
-fn _call_site_from_object_creation<'a, D: Doc>(
-    node: &Node<'a, D>,
-    src: &[u8],
-) -> Option<CallSite> {
+fn _call_site_from_object_creation<'a, D: Doc>(node: &Node<'a, D>, src: &[u8]) -> Option<CallSite> {
     let type_node = node.field("type")?;
     let raw = String::from_utf8_lossy(&src[type_node.range()]).to_string();
     let name = _last_type_segment(&raw);
@@ -635,16 +628,14 @@ fn _split_callee<'a, D: Doc>(node: &Node<'a, D>, src: &[u8]) -> Option<(String, 
             let object = node.field("expression");
             let name_node = node.field("name")?;
             let raw = String::from_utf8_lossy(&src[name_node.range()]).to_string();
-            let recv = object
-                .map(|o| collapse_ws(&String::from_utf8_lossy(&src[o.range()])));
+            let recv = object.map(|o| collapse_ws(&String::from_utf8_lossy(&src[o.range()])));
             Some((_strip_generics(&raw), recv))
         }
         "qualified_name" => {
             let name_node = node.field("name")?;
             let qualifier = node.field("qualifier");
             let raw = String::from_utf8_lossy(&src[name_node.range()]).to_string();
-            let recv = qualifier
-                .map(|q| collapse_ws(&String::from_utf8_lossy(&src[q.range()])));
+            let recv = qualifier.map(|q| collapse_ws(&String::from_utf8_lossy(&src[q.range()])));
             Some((_strip_generics(&raw), recv))
         }
         "alias_qualified_name" => {

--- a/src/adapters/go.rs
+++ b/src/adapters/go.rs
@@ -841,14 +841,13 @@ fn _split_callee_go<'a, D: Doc>(
             let field = node.field("field")?;
             let operand = node.field("operand");
             let name = String::from_utf8_lossy(&src[field.range()]).to_string();
-            let receiver = operand
-                .map(|o| collapse_ws(&String::from_utf8_lossy(&src[o.range()])));
+            let receiver = operand.map(|o| collapse_ws(&String::from_utf8_lossy(&src[o.range()])));
             Some((name, receiver, CallKind::Call))
         }
         "index_expression" | "parenthesized_expression" => {
-            let inner = node.field("operand").or_else(|| {
-                node.children().find(|c| c.is_named())
-            })?;
+            let inner = node
+                .field("operand")
+                .or_else(|| node.children().find(|c| c.is_named()))?;
             _split_callee_go(&inner, src)
         }
         _ => {

--- a/src/adapters/java.rs
+++ b/src/adapters/java.rs
@@ -614,10 +614,7 @@ fn _call_site_from_method_invocation<'a, D: Doc>(
     })
 }
 
-fn _call_site_from_object_creation<'a, D: Doc>(
-    node: &Node<'a, D>,
-    src: &[u8],
-) -> Option<CallSite> {
+fn _call_site_from_object_creation<'a, D: Doc>(node: &Node<'a, D>, src: &[u8]) -> Option<CallSite> {
     let type_node = node.field("type")?;
     let raw = String::from_utf8_lossy(&src[type_node.range()]).to_string();
     let name = _last_type_segment(&raw);

--- a/src/adapters/kotlin.rs
+++ b/src/adapters/kotlin.rs
@@ -848,7 +848,9 @@ fn _walk_calls_in_body<'a, D: Doc>(node: &Node<'a, D>, src: &[u8], out: &mut Vec
 fn _call_site_from_call_kt<'a, D: Doc>(node: &Node<'a, D>, src: &[u8]) -> Option<CallSite> {
     // tree-sitter-kotlin's call_expression is positional: first named child is
     // the callee expression, second is the call_suffix carrying arguments.
-    let callee = node.children().find(|c| c.is_named() && c.kind() != "call_suffix")?;
+    let callee = node
+        .children()
+        .find(|c| c.is_named() && c.kind() != "call_suffix")?;
     let (name, receiver) = _extract_callee_name_kt(&callee, src)?;
     let line = node.start_pos().line() as u32 + 1;
     Some(CallSite {
@@ -866,9 +868,10 @@ fn _extract_callee_name_kt<'a, D: Doc>(
     let kind = node.kind();
     let kind: &str = kind.as_ref();
     match kind {
-        "simple_identifier" | "identifier" => {
-            Some((String::from_utf8_lossy(&src[node.range()]).to_string(), None))
-        }
+        "simple_identifier" | "identifier" => Some((
+            String::from_utf8_lossy(&src[node.range()]).to_string(),
+            None,
+        )),
         "navigation_expression" => {
             // A navigation_expression has the receiver as the first named
             // child and a navigation_suffix containing the member name.

--- a/src/adapters/markdown.rs
+++ b/src/adapters/markdown.rs
@@ -209,7 +209,9 @@ fn _end_line_ts(node: tree_sitter::Node) -> usize {
 
 fn _find_heading_ts(section: tree_sitter::Node) -> Option<tree_sitter::Node> {
     let mut cursor = section.walk();
-    let ret = section.named_children(&mut cursor).find(|&c| c.kind() == "atx_heading" || c.kind() == "setext_heading");
+    let ret = section
+        .named_children(&mut cursor)
+        .find(|&c| c.kind() == "atx_heading" || c.kind() == "setext_heading");
     ret
 }
 

--- a/src/adapters/php.rs
+++ b/src/adapters/php.rs
@@ -43,7 +43,8 @@ fn _node_to_decl<'a, D: Doc>(
 ) -> Option<Declaration> {
     let kind = node.kind();
 
-    if kind == "class_declaration" || kind == "interface_declaration" || kind == "trait_declaration" {
+    if kind == "class_declaration" || kind == "interface_declaration" || kind == "trait_declaration"
+    {
         return _class_to_decl(node, src);
     } else if kind == "function_definition" {
         return _function_to_decl(node, src, inside_class);
@@ -481,10 +482,7 @@ fn _call_site_from_function_call_php<'a, D: Doc>(
     })
 }
 
-fn _call_site_from_member_call_php<'a, D: Doc>(
-    node: &Node<'a, D>,
-    src: &[u8],
-) -> Option<CallSite> {
+fn _call_site_from_member_call_php<'a, D: Doc>(node: &Node<'a, D>, src: &[u8]) -> Option<CallSite> {
     let name_node = node.field("name")?;
     let object = node.field("object");
     let name = _bare_name_text_php(&name_node, src);
@@ -501,10 +499,7 @@ fn _call_site_from_member_call_php<'a, D: Doc>(
     })
 }
 
-fn _call_site_from_scoped_call_php<'a, D: Doc>(
-    node: &Node<'a, D>,
-    src: &[u8],
-) -> Option<CallSite> {
+fn _call_site_from_scoped_call_php<'a, D: Doc>(node: &Node<'a, D>, src: &[u8]) -> Option<CallSite> {
     let name_node = node.field("name")?;
     let scope = node.field("scope");
     let name = _bare_name_text_php(&name_node, src);
@@ -553,7 +548,11 @@ fn _call_site_from_object_creation_php<'a, D: Doc>(
     // Unwrap `new (Class)()` — the class ref appears wrapped in a
     // parenthesized_expression. Drill once to find the inner reference.
     let class_ref = if class_ref.kind().as_ref() == "parenthesized_expression" {
-        class_ref.clone().children().find(|c| c.is_named()).unwrap_or(class_ref)
+        class_ref
+            .clone()
+            .children()
+            .find(|c| c.is_named())
+            .unwrap_or(class_ref)
     } else {
         class_ref
     };

--- a/src/adapters/python.rs
+++ b/src/adapters/python.rs
@@ -345,11 +345,17 @@ fn _call_site_from_call<'a, D: Doc>(node: &Node<'a, D>, src: &[u8]) -> Option<Ca
     })
 }
 
-fn _extract_callee_name<'a, D: Doc>(node: &Node<'a, D>, src: &[u8]) -> Option<(String, Option<String>)> {
+fn _extract_callee_name<'a, D: Doc>(
+    node: &Node<'a, D>,
+    src: &[u8],
+) -> Option<(String, Option<String>)> {
     let kind = node.kind();
     let kind: &str = kind.as_ref();
     match kind {
-        "identifier" => Some((String::from_utf8_lossy(&src[node.range()]).to_string(), None)),
+        "identifier" => Some((
+            String::from_utf8_lossy(&src[node.range()]).to_string(),
+            None,
+        )),
         "attribute" => {
             // obj.method or pkg.mod.fn — last attribute is the name, prefix is receiver.
             let object = node.field("object");
@@ -358,7 +364,10 @@ fn _extract_callee_name<'a, D: Doc>(node: &Node<'a, D>, src: &[u8]) -> Option<(S
             let recv = object.map(|o| String::from_utf8_lossy(&src[o.range()]).to_string());
             Some((name, recv))
         }
-        _ => Some((String::from_utf8_lossy(&src[node.range()]).to_string(), None)),
+        _ => Some((
+            String::from_utf8_lossy(&src[node.range()]).to_string(),
+            None,
+        )),
     }
 }
 
@@ -401,7 +410,11 @@ fn _handle_import_statement<'a, D: Doc>(
             "dotted_name" => {
                 let module = String::from_utf8_lossy(&src[child.range()]).to_string();
                 let local = module.split('.').next_back().unwrap_or(&module).to_string();
-                out.push(ImportBinding { local, module, line });
+                out.push(ImportBinding {
+                    local,
+                    module,
+                    line,
+                });
             }
             "aliased_import" => {
                 let name = child.field("name");
@@ -409,7 +422,11 @@ fn _handle_import_statement<'a, D: Doc>(
                 if let (Some(n), Some(a)) = (name, alias) {
                     let module = String::from_utf8_lossy(&src[n.range()]).to_string();
                     let local = String::from_utf8_lossy(&src[a.range()]).to_string();
-                    out.push(ImportBinding { local, module, line });
+                    out.push(ImportBinding {
+                        local,
+                        module,
+                        line,
+                    });
                 }
             }
             _ => {}
@@ -467,7 +484,11 @@ fn _handle_import_from<'a, D: Doc>(
                         format!("{}.{}", module_prefix, bare)
                     };
                     let local = String::from_utf8_lossy(&src[a.range()]).to_string();
-                    out.push(ImportBinding { local, module, line });
+                    out.push(ImportBinding {
+                        local,
+                        module,
+                        line,
+                    });
                 }
             }
             "wildcard_import" => { /* `from X import *` — no specific local */ }

--- a/src/adapters/ruby.rs
+++ b/src/adapters/ruby.rs
@@ -52,10 +52,7 @@ fn _node_to_decl<'a, D: Doc>(node: &Node<'a, D>, src: &[u8]) -> Option<Declarati
     } else if kind == "assignment" {
         // tree-sitter-ruby uses one `assignment` kind for both regular and
         // constant assignments — distinguish by the LHS shape.
-        if node
-            .field("left")
-            .is_some_and(|l| l.kind() == "constant")
-        {
+        if node.field("left").is_some_and(|l| l.kind() == "constant") {
             return _constant_to_decl(node, src);
         }
         return _assignment_to_decl(node, src);
@@ -130,7 +127,11 @@ fn _class_to_decl<'a, D: Doc>(node: &Node<'a, D>, src: &[u8]) -> Option<Declarat
             if child.kind() == "identifier" {
                 let text = collapse_ws(&child.text()).trim().to_string();
                 if matches!(text.as_str(), "private" | "protected" | "public") {
-                    current_vis = if text == "public" { String::new() } else { text };
+                    current_vis = if text == "public" {
+                        String::new()
+                    } else {
+                        text
+                    };
                     continue;
                 }
             }
@@ -211,10 +212,7 @@ fn _method_to_decl<'a, D: Doc>(node: &Node<'a, D>, src: &[u8]) -> Option<Declara
     })
 }
 
-fn _singleton_method_to_decl<'a, D: Doc>(
-    node: &Node<'a, D>,
-    src: &[u8],
-) -> Option<Declaration> {
+fn _singleton_method_to_decl<'a, D: Doc>(node: &Node<'a, D>, src: &[u8]) -> Option<Declaration> {
     let name = field_text(node, "name").unwrap_or_else(|| "?".to_string());
     let object = node
         .field("object")
@@ -499,9 +497,5 @@ fn _looks_like_constant_ruby(text: &str) -> bool {
 }
 
 fn _last_const_segment_ruby(text: &str) -> String {
-    text.rsplit("::")
-        .next()
-        .unwrap_or(text)
-        .trim()
-        .to_string()
+    text.rsplit("::").next().unwrap_or(text).trim().to_string()
 }

--- a/src/adapters/rust.rs
+++ b/src/adapters/rust.rs
@@ -627,10 +627,12 @@ fn _expand_use_tree<'a, D: Doc>(
             let module = full.join("::");
             let local = alias
                 .map(|a| String::from_utf8_lossy(&src[a.range()]).to_string())
-                .unwrap_or_else(|| {
-                    full.last().cloned().unwrap_or_default()
-                });
-            out.push(ImportBinding { local, module, line });
+                .unwrap_or_else(|| full.last().cloned().unwrap_or_default());
+            out.push(ImportBinding {
+                local,
+                module,
+                line,
+            });
         }
         "use_list" | "scoped_use_list" => {
             let mut new_prefix = prefix.clone();

--- a/src/adapters/scala.rs
+++ b/src/adapters/scala.rs
@@ -991,10 +991,7 @@ fn _call_site_from_call_scala<'a, D: Doc>(
     })
 }
 
-fn _call_site_from_instance<'a, D: Doc>(
-    node: &Node<'a, D>,
-    src: &[u8],
-) -> Option<CallSite> {
+fn _call_site_from_instance<'a, D: Doc>(node: &Node<'a, D>, src: &[u8]) -> Option<CallSite> {
     // `new T(...)` — find the first identifier-like child after `new`.
     for c in node.children() {
         if !c.is_named() {
@@ -1029,15 +1026,15 @@ fn _split_callee_scala<'a, D: Doc>(
     let kind = node.kind();
     let kind: &str = kind.as_ref();
     match kind {
-        "identifier" | "operator_identifier" => {
-            Some((String::from_utf8_lossy(&src[node.range()]).to_string(), None))
-        }
+        "identifier" | "operator_identifier" => Some((
+            String::from_utf8_lossy(&src[node.range()]).to_string(),
+            None,
+        )),
         "field_expression" => {
             let value = node.field("value");
             let field = node.field("field")?;
             let name = String::from_utf8_lossy(&src[field.range()]).to_string();
-            let recv = value
-                .map(|v| collapse_ws(&String::from_utf8_lossy(&src[v.range()])));
+            let recv = value.map(|v| collapse_ws(&String::from_utf8_lossy(&src[v.range()])));
             Some((name, recv))
         }
         "generic_function" => {

--- a/src/adapters/sql.rs
+++ b/src/adapters/sql.rs
@@ -25,13 +25,17 @@ static RE_VIEW: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r#"(?im)^\s*CREATE\s+(?:OR\s+REPLACE\s+)?(?:TEMP(?:ORARY)?\s+)?(?:MATERIALIZED\s+)?VIEW\s+(?:IF\s+NOT\s+EXISTS\s+)?["']?((?:\w+\.)?\w+)["']?"#).unwrap()
 });
 static RE_FUNC: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"(?im)^\s*CREATE\s+(?:OR\s+REPLACE\s+)?(FUNCTION|PROCEDURE)\s+["']?((?:\w+\.)?\w+)["']?"#).unwrap()
+    Regex::new(
+        r#"(?im)^\s*CREATE\s+(?:OR\s+REPLACE\s+)?(FUNCTION|PROCEDURE)\s+["']?((?:\w+\.)?\w+)["']?"#,
+    )
+    .unwrap()
 });
 static RE_INDEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r#"(?im)^\s*CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:IF\s+NOT\s+EXISTS\s+)?["']?((?:\w+\.)?\w+)["']?\s+ON"#).unwrap()
 });
 static RE_SEQ: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"(?im)^\s*CREATE\s+SEQUENCE\s+(?:IF\s+NOT\s+EXISTS\s+)?["']?((?:\w+\.)?\w+)["']?"#).unwrap()
+    Regex::new(r#"(?im)^\s*CREATE\s+SEQUENCE\s+(?:IF\s+NOT\s+EXISTS\s+)?["']?((?:\w+\.)?\w+)["']?"#)
+        .unwrap()
 });
 
 /// Parse a SQL source. Takes `&str` because UTF-8 validation has already
@@ -76,7 +80,11 @@ pub fn parse_sql(path: &Path, source: &str) -> ParseResult {
             DeclarationKind::Function,
             // Native kind preserves the source-true keyword
             // (`function` vs `procedure`).
-            if kind_str == "procedure" { "procedure" } else { "function" },
+            if kind_str == "procedure" {
+                "procedure"
+            } else {
+                "function"
+            },
             &name,
             &format!("{} {}", kind_str, name),
             m.start(),
@@ -340,7 +348,10 @@ CREATE SEQUENCE order_seq;
         let src = "CREATE TABLE app.users (id INT);\nCREATE VIEW reporting.daily_sales AS SELECT 1;\nCREATE INDEX app.idx_x ON app.users(id);\n";
         let r = parse_sql(Path::new("x.sql"), src);
         let names: Vec<_> = r.declarations.iter().map(|d| d.name.as_str()).collect();
-        assert_eq!(names, vec!["app.users", "reporting.daily_sales", "app.idx_x"]);
+        assert_eq!(
+            names,
+            vec!["app.users", "reporting.daily_sales", "app.idx_x"]
+        );
     }
 
     #[test]

--- a/src/adapters/typescript.rs
+++ b/src/adapters/typescript.rs
@@ -69,7 +69,9 @@ fn _node_to_decl<'a, D: Doc>(
                 inner.clone()
             };
             if _is_handled_top_level(effective.kind().as_ref()) {
-                if let Some(mut decl) = _node_to_decl(&effective, src, _inside_class, _inside_interface) {
+                if let Some(mut decl) =
+                    _node_to_decl(&effective, src, _inside_class, _inside_interface)
+                {
                     decl.start_byte = node.range().start;
                     decl.start_line = node.start_pos().line() + 1;
                     let ds_byte = _leading_doc_start_byte(node).unwrap_or(node.range().start);
@@ -535,7 +537,10 @@ fn _lexical_to_decl<'a, D: Doc>(node: &Node<'a, D>, src: &[u8]) -> Option<Declar
             "arrow_function" | "function_expression" | "function"
         ) {
             let body = v.field("body");
-            let end = body.as_ref().map(|b| b.range().start).unwrap_or(v.range().end);
+            let end = body
+                .as_ref()
+                .map(|b| b.range().start)
+                .unwrap_or(v.range().end);
             let text = String::from_utf8_lossy(&src[node.range().start..end]).to_string();
             let sig = collapse_ws(&text).trim_end_matches('{').trim().to_string();
 
@@ -815,23 +820,42 @@ fn _walk_calls_in_body<'a, D: Doc>(node: &Node<'a, D>, src: &[u8], out: &mut Vec
     }
 }
 
-fn _call_site_from_call<'a, D: Doc>(node: &Node<'a, D>, src: &[u8], is_construct: bool) -> Option<CallSite> {
+fn _call_site_from_call<'a, D: Doc>(
+    node: &Node<'a, D>,
+    src: &[u8],
+    is_construct: bool,
+) -> Option<CallSite> {
     // tree-sitter-typescript exposes the callee as the `function` field on
     // call_expression and `constructor` on new_expression.
-    let func = node.field("function").or_else(|| node.field("constructor"))?;
+    let func = node
+        .field("function")
+        .or_else(|| node.field("constructor"))?;
     let (name, receiver) = _extract_callee_name_ts(&func, src)?;
     let line = node.start_pos().line() as u32 + 1;
-    let kind = if is_construct { CallKind::Construct } else { CallKind::Call };
-    Some(CallSite { name, receiver, line, kind })
+    let kind = if is_construct {
+        CallKind::Construct
+    } else {
+        CallKind::Call
+    };
+    Some(CallSite {
+        name,
+        receiver,
+        line,
+        kind,
+    })
 }
 
-fn _extract_callee_name_ts<'a, D: Doc>(node: &Node<'a, D>, src: &[u8]) -> Option<(String, Option<String>)> {
+fn _extract_callee_name_ts<'a, D: Doc>(
+    node: &Node<'a, D>,
+    src: &[u8],
+) -> Option<(String, Option<String>)> {
     let kind = node.kind();
     let kind: &str = kind.as_ref();
     match kind {
-        "identifier" | "property_identifier" => {
-            Some((String::from_utf8_lossy(&src[node.range()]).to_string(), None))
-        }
+        "identifier" | "property_identifier" => Some((
+            String::from_utf8_lossy(&src[node.range()]).to_string(),
+            None,
+        )),
         "member_expression" => {
             let object = node.field("object");
             let property = node.field("property")?;
@@ -839,7 +863,10 @@ fn _extract_callee_name_ts<'a, D: Doc>(node: &Node<'a, D>, src: &[u8]) -> Option
             let recv = object.map(|o| String::from_utf8_lossy(&src[o.range()]).to_string());
             Some((name, recv))
         }
-        _ => Some((String::from_utf8_lossy(&src[node.range()]).to_string(), None)),
+        _ => Some((
+            String::from_utf8_lossy(&src[node.range()]).to_string(),
+            None,
+        )),
     }
 }
 
@@ -895,14 +922,22 @@ fn _handle_import_stmt<'a, D: Doc>(
                 match ik {
                     "identifier" => {
                         let local = String::from_utf8_lossy(&src[inner.range()]).to_string();
-                        out.push(ImportBinding { local, module: source.clone(), line });
+                        out.push(ImportBinding {
+                            local,
+                            module: source.clone(),
+                            line,
+                        });
                     }
                     "namespace_import" => {
                         // namespace_import has children including `* as ident`
                         for ns in inner.children() {
                             if matches!(ns.kind().as_ref(), "identifier") {
                                 let local = String::from_utf8_lossy(&src[ns.range()]).to_string();
-                                out.push(ImportBinding { local, module: source.clone(), line });
+                                out.push(ImportBinding {
+                                    local,
+                                    module: source.clone(),
+                                    line,
+                                });
                             }
                         }
                     }
@@ -943,7 +978,13 @@ fn _handle_import_stmt<'a, D: Doc>(
 
 fn _unquote(s: &str) -> String {
     let s = s.trim();
-    let s = s.strip_prefix('\'').or_else(|| s.strip_prefix('"')).unwrap_or(s);
-    let s = s.strip_suffix('\'').or_else(|| s.strip_suffix('"')).unwrap_or(s);
+    let s = s
+        .strip_prefix('\'')
+        .or_else(|| s.strip_prefix('"'))
+        .unwrap_or(s);
+    let s = s
+        .strip_suffix('\'')
+        .or_else(|| s.strip_suffix('"'))
+        .unwrap_or(s);
     s.to_string()
 }

--- a/src/bin/ast-outline.rs
+++ b/src/bin/ast-outline.rs
@@ -4,9 +4,10 @@ fn main() {
     use std::process::{Command, Stdio};
 
     // Try same directory first (e.g. ./target/release/ast-bro), then fall back to PATH.
-    let exe_dir = std::env::current_exe()
-        .ok()
-        .and_then(|p| p.parent().map(|d| d.join(format!("ast-bro{}", std::env::consts::EXE_SUFFIX))));
+    let exe_dir = std::env::current_exe().ok().and_then(|p| {
+        p.parent()
+            .map(|d| d.join(format!("ast-bro{}", std::env::consts::EXE_SUFFIX)))
+    });
     let program = exe_dir
         .filter(|p| p.exists())
         .unwrap_or_else(|| "ast-bro".into());

--- a/src/bin/sb.rs
+++ b/src/bin/sb.rs
@@ -4,9 +4,10 @@ fn main() {
     use std::process::{Command, Stdio};
 
     // Try same directory first (e.g. ./target/release/ast-bro), then fall back to PATH.
-    let exe_dir = std::env::current_exe()
-        .ok()
-        .and_then(|p| p.parent().map(|d| d.join(format!("ast-bro{}", std::env::consts::EXE_SUFFIX))));
+    let exe_dir = std::env::current_exe().ok().and_then(|p| {
+        p.parent()
+            .map(|d| d.join(format!("ast-bro{}", std::env::consts::EXE_SUFFIX)))
+    });
     let program = exe_dir
         .filter(|p| p.exists())
         .unwrap_or_else(|| "ast-bro".into());

--- a/src/calls/build.rs
+++ b/src/calls/build.rs
@@ -134,9 +134,9 @@ pub fn extract_file(root: &Path, file: &Path) -> Option<FilePass> {
         &mut types,
     );
 
-     Some(FilePass {
-         file: file.to_path_buf(),
-         defined,
+    Some(FilePass {
+        file: file.to_path_buf(),
+        defined,
         callable_locations,
         imports: parse.imports,
         raw_edges,
@@ -180,10 +180,7 @@ fn walk(
             types.push((
                 qn,
                 TypeMeta {
-                    kind: d
-                        .native_kind
-                        .clone()
-                        .unwrap_or_else(|| d.kind.to_string()),
+                    kind: d.native_kind.clone().unwrap_or_else(|| d.kind.to_string()),
                     file: PathBuf::from(rel_file),
                     line: d.start_line as u32,
                     bases: d.bases.clone(),

--- a/src/calls/cli.rs
+++ b/src/calls/cli.rs
@@ -77,10 +77,8 @@ pub fn run_callers(
                             return false;
                         }
                         if tests || exclude_tests {
-                            let is_test = crate::file_filter::is_test_file(
-                                &root.join(&edge.file),
-                                &root,
-                            );
+                            let is_test =
+                                crate::file_filter::is_test_file(&root.join(&edge.file), &root);
                             if exclude_tests {
                                 if is_test {
                                     return false;
@@ -100,8 +98,7 @@ pub fn run_callers(
                 // carry repo-relative file paths.
                 if tests || exclude_tests {
                     let keep = |file: &Path| {
-                        let is_test =
-                            crate::file_filter::is_test_file(&root.join(file), &root);
+                        let is_test = crate::file_filter::is_test_file(&root.join(file), &root);
                         if exclude_tests {
                             !is_test
                         } else {
@@ -123,13 +120,7 @@ pub fn run_callers(
     if json {
         println!(
             "{}",
-            render::render_callers_json_extended(
-                target,
-                depth.max(1),
-                &hits,
-                &type_groups,
-                pretty,
-            )
+            render::render_callers_json_extended(target, depth.max(1), &hits, &type_groups, pretty,)
         );
     } else {
         print!(
@@ -220,13 +211,7 @@ pub fn run_callees(
     } else {
         print!(
             "{}",
-            render::render_callees_text_extended(
-                calls,
-                &first,
-                &all_edges,
-                &type_groups,
-                external,
-            )
+            render::render_callees_text_extended(calls, &first, &all_edges, &type_groups, external,)
         );
     }
     0
@@ -455,8 +440,7 @@ fn methods_of_type(calls: &CallGraph, type_qn: &Qn) -> Vec<MethodInfo> {
         .forward
         .keys()
         .filter(|qn| {
-            qn.as_str().starts_with(&prefix)
-                && !qn.as_str()[prefix.len()..].contains("::")
+            qn.as_str().starts_with(&prefix) && !qn.as_str()[prefix.len()..].contains("::")
         })
         .map(|m_qn| {
             let (file, line) = calls
@@ -548,4 +532,3 @@ pub fn run_trace(
         TraceOutcome::Unresolved => 2,
     }
 }
-

--- a/src/calls/cli_helpers.rs
+++ b/src/calls/cli_helpers.rs
@@ -56,7 +56,10 @@ pub fn resolve_target_full(calls: &CallGraph, target: &str) -> Vec<ResolvedTarge
             }
         }
         if qn_matches(&qn, symbol, &parts) {
-            out.push(ResolvedTarget { qn, kind: SymbolKind::Callable });
+            out.push(ResolvedTarget {
+                qn,
+                kind: SymbolKind::Callable,
+            });
         }
     }
     for qn in calls.types.keys() {
@@ -106,7 +109,10 @@ fn file_matches(qn: &Qn, filter: &str) -> bool {
         return true;
     }
     // Trailing-path match — `Player.cs` matches `src/game/Player.cs`.
-    f.ends_with(filter) && f.as_bytes().get(f.len().saturating_sub(filter.len()).saturating_sub(1)) == Some(&b'/')
+    f.ends_with(filter)
+        && f.as_bytes()
+            .get(f.len().saturating_sub(filter.len()).saturating_sub(1))
+            == Some(&b'/')
 }
 
 fn collect_callable_qns(calls: &CallGraph) -> Vec<Qn> {
@@ -129,7 +135,10 @@ fn qn_matches(qn: &Qn, raw: &str, parts: &[&str]) -> bool {
         return false;
     }
     let start = segments.len() - parts.len();
-    parts.iter().enumerate().all(|(i, p)| segments[start + i] == *p)
+    parts
+        .iter()
+        .enumerate()
+        .all(|(i, p)| segments[start + i] == *p)
 }
 
 #[cfg(test)]

--- a/src/calls/graph.rs
+++ b/src/calls/graph.rs
@@ -276,6 +276,4 @@ impl CallGraph {
         }
         self.reverse = rev;
     }
-
-
 }

--- a/src/calls/mcp.rs
+++ b/src/calls/mcp.rs
@@ -4,7 +4,14 @@
 
 use std::path::Path;
 
-pub fn run_callers_text(target: &str, root: &Path, depth: usize, limit: usize, include_ambiguous: bool, json: bool) -> String {
+pub fn run_callers_text(
+    target: &str,
+    root: &Path,
+    depth: usize,
+    limit: usize,
+    include_ambiguous: bool,
+    json: bool,
+) -> String {
     use crate::calls::build::build_call_graph;
     use crate::calls::{render, traverse};
     use crate::graph_cache;
@@ -31,8 +38,7 @@ pub fn run_callers_text(target: &str, root: &Path, depth: usize, limit: usize, i
         // Filter inside the traversal so dropped ambiguous edges don't
         // consume the limit (mirrors the CLI's run_callers).
         hits.extend(traverse::callers(calls, qn, depth.max(1), limit, |e| {
-            include_ambiguous
-                || !matches!(e.confidence, crate::calls::graph::Confidence::Ambiguous)
+            include_ambiguous || !matches!(e.confidence, crate::calls::graph::Confidence::Ambiguous)
         }));
     }
     if hits.len() > limit {
@@ -70,7 +76,13 @@ pub fn run_trace_text(from: &str, to: &str, root: &Path, depth: usize, json: boo
     out
 }
 
-pub fn run_callees_text(target: &str, root: &Path, depth: usize, external: bool, json: bool) -> String {
+pub fn run_callees_text(
+    target: &str,
+    root: &Path,
+    depth: usize,
+    external: bool,
+    json: bool,
+) -> String {
     use crate::calls::build::build_call_graph;
     use crate::calls::graph::Qn;
     use crate::calls::{render, traverse};
@@ -103,7 +115,10 @@ pub fn run_callees_text(target: &str, root: &Path, depth: usize, external: bool,
             }
         }
     }
-    let first = qns.first().cloned().unwrap_or_else(|| Qn::new(target.to_string()));
+    let first = qns
+        .first()
+        .cloned()
+        .unwrap_or_else(|| Qn::new(target.to_string()));
     if json {
         render::render_callees_json(&first, depth.max(1), &all_edges, true)
     } else {

--- a/src/calls/mod.rs
+++ b/src/calls/mod.rs
@@ -31,4 +31,3 @@ pub mod render;
 pub mod resolve;
 pub mod trace;
 pub mod traverse;
-

--- a/src/calls/pass.rs
+++ b/src/calls/pass.rs
@@ -5,7 +5,9 @@
 //! `build` would otherwise import `resolve::run` while `resolve` imported
 //! `build::FilePass`, forming an avoidable file-level cycle.
 
-use crate::calls::graph::{CallEdge, CallKindCompat, CallTarget, CallableMeta, Confidence, Qn, TypeMeta};
+use crate::calls::graph::{
+    CallEdge, CallKindCompat, CallTarget, CallableMeta, Confidence, Qn, TypeMeta,
+};
 use crate::core::ImportBinding;
 use std::path::{Path, PathBuf};
 

--- a/src/calls/render.rs
+++ b/src/calls/render.rs
@@ -36,8 +36,11 @@ pub fn render_callers_text_extended(
     type_groups: &[crate::calls::cli::TypeCallersGroup],
 ) -> String {
     let mut out = String::new();
-    let total: usize =
-        hits.len() + type_groups.iter().map(|g| g.implementations.len() + g.constructions.len()).sum::<usize>();
+    let total: usize = hits.len()
+        + type_groups
+            .iter()
+            .map(|g| g.implementations.len() + g.constructions.len())
+            .sum::<usize>();
     out.push_str(&header_line("caller", total, target));
 
     for h in hits {
@@ -250,12 +253,7 @@ fn colorize_qn(qn: &Qn) -> String {
     if let Some(idx) = s.rfind("::") {
         let head = &s[..idx];
         let tail = &s[idx + 2..];
-        format!(
-            "{}{}{}",
-            head.dimmed(),
-            "::".dimmed(),
-            tail.yellow()
-        )
+        format!("{}{}{}", head.dimmed(), "::".dimmed(), tail.yellow())
     } else {
         s.yellow().to_string()
     }

--- a/src/calls/resolve.rs
+++ b/src/calls/resolve.rs
@@ -139,7 +139,10 @@ pub fn run_with_table(
             // (e.g. `builder.hidden()` would resolve to any project method
             // happening to be called `hidden`). Defer them to pass C.
             let has_receiver = raw.receiver.is_some()
-                && !matches!(raw.receiver.as_deref(), Some("self") | Some("Self") | Some("crate") | Some("super"));
+                && !matches!(
+                    raw.receiver.as_deref(),
+                    Some("self") | Some("Self") | Some("crate") | Some("super")
+                );
             match symbol_table.get(&raw.bare_name) {
                 Some(cands) if cands.len() == 1 && !has_receiver => {
                     let edge = raw_to_edge(
@@ -193,16 +196,34 @@ pub fn run_with_table(
             .collect();
 
         let (target, confidence, candidates) = if filtered.len() == 1 {
-            (CallTarget::Resolved(filtered[0].clone()), Confidence::Inferred, Vec::new())
+            (
+                CallTarget::Resolved(filtered[0].clone()),
+                Confidence::Inferred,
+                Vec::new(),
+            )
         } else if filtered.is_empty() {
             // No dep-relationship — fall back to ambiguous.
-            (CallTarget::Bare(raw.bare_name.clone()), Confidence::Ambiguous, cands)
+            (
+                CallTarget::Bare(raw.bare_name.clone()),
+                Confidence::Ambiguous,
+                cands,
+            )
         } else {
             // Multiple survivors — keep as ambiguous with surviving set.
-            (CallTarget::Bare(raw.bare_name.clone()), Confidence::Ambiguous, filtered)
+            (
+                CallTarget::Bare(raw.bare_name.clone()),
+                Confidence::Ambiguous,
+                filtered,
+            )
         };
 
-        let edge = raw_to_edge(raw, target, confidence, rel_path(root, &src_file), candidates);
+        let edge = raw_to_edge(
+            raw,
+            target,
+            confidence,
+            rel_path(root, &src_file),
+            candidates,
+        );
         forward.entry(edge.source.clone()).or_default().push(edge);
     }
 
@@ -259,6 +280,7 @@ fn forward_closure_files(deps: &DepGraph, from: &Path) -> HashSet<PathBuf> {
 }
 
 fn rel_path(root: &Path, file: &Path) -> PathBuf {
-    file.strip_prefix(root).map(|p| p.to_path_buf()).unwrap_or_else(|_| file.to_path_buf())
+    file.strip_prefix(root)
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|_| file.to_path_buf())
 }
-

--- a/src/calls/trace.rs
+++ b/src/calls/trace.rs
@@ -57,7 +57,10 @@ fn find_path(calls: &CallGraph, froms: &[Qn], tos: &[Qn], max_depth: usize) -> O
     // from == to: a zero-hop "path".
     for f in froms {
         if to_set.contains(f) {
-            return Some(Found { start: f.clone(), hops: Vec::new() });
+            return Some(Found {
+                start: f.clone(),
+                hops: Vec::new(),
+            });
         }
     }
 
@@ -75,9 +78,13 @@ fn find_path(calls: &CallGraph, froms: &[Qn], tos: &[Qn], max_depth: usize) -> O
         if depth >= max_depth {
             continue;
         }
-        let Some(edges) = calls.forward.get(&cur) else { continue };
+        let Some(edges) = calls.forward.get(&cur) else {
+            continue;
+        };
         for e in edges {
-            let CallTarget::Resolved(next) = &e.target else { continue };
+            let CallTarget::Resolved(next) = &e.target else {
+                continue;
+            };
             if visited.contains(next) {
                 continue;
             }
@@ -97,7 +104,10 @@ fn reconstruct(target: &Qn, parent: &HashMap<Qn, (Qn, CallEdge)>) -> Found {
     let mut hops: Vec<Hop> = Vec::new();
     let mut cur = target.clone();
     while let Some((prev, edge)) = parent.get(&cur) {
-        hops.push(Hop { qn: cur.clone(), via: edge.clone() });
+        hops.push(Hop {
+            qn: cur.clone(),
+            via: edge.clone(),
+        });
         cur = prev.clone();
     }
     hops.reverse();
@@ -122,7 +132,10 @@ struct BodyCache<'a> {
 
 impl<'a> BodyCache<'a> {
     fn new(root: &'a Path) -> Self {
-        Self { root, parsed: HashMap::new() }
+        Self {
+            root,
+            parsed: HashMap::new(),
+        }
     }
 
     fn parse(&mut self, file: &str) -> Option<&ParseResult> {
@@ -161,7 +174,10 @@ fn truncate_body(src: &str) -> String {
     }
     let slice = &src[..cut];
     let cut = slice.rfind('\n').map(|i| i + 1).unwrap_or(slice.len());
-    format!("{}… (body truncated — use `show` for the full text)\n", &src[..cut])
+    format!(
+        "{}… (body truncated — use `show` for the full text)\n",
+        &src[..cut]
+    )
 }
 
 fn meta_line(calls: &CallGraph, qn: &Qn) -> Option<u32> {
@@ -170,11 +186,7 @@ fn meta_line(calls: &CallGraph, qn: &Qn) -> Option<u32> {
 
 fn meta_loc(calls: &CallGraph, qn: &Qn) -> (String, u32, String) {
     match calls.callable_meta.get(qn) {
-        Some(m) => (
-            m.file.display().to_string(),
-            m.line,
-            m.kind.clone(),
-        ),
+        Some(m) => (m.file.display().to_string(), m.line, m.kind.clone()),
         None => (qn.file().to_string(), 0, String::new()),
     }
 }
@@ -260,7 +272,15 @@ fn render_found_text(
     let mut step = 1usize;
 
     // Node 0 — the start.
-    push_node_text(&mut out, calls, &found.start, step, None, cache, &mut budget);
+    push_node_text(
+        &mut out,
+        calls,
+        &found.start,
+        step,
+        None,
+        cache,
+        &mut budget,
+    );
     for hop in &found.hops {
         step += 1;
         out.push_str(&format!(
@@ -268,7 +288,15 @@ fn render_found_text(
             hop.via.kind.as_str(),
             hop.via.line,
         ));
-        push_node_text(&mut out, calls, &hop.qn, step, Some(&hop.via), cache, &mut budget);
+        push_node_text(
+            &mut out,
+            calls,
+            &hop.qn,
+            step,
+            Some(&hop.via),
+            cache,
+            &mut budget,
+        );
     }
     out
 }
@@ -286,8 +314,15 @@ fn push_node_text(
     let conf = via
         .map(|e| format!("  [{}]", e.confidence.as_str()))
         .unwrap_or_default();
-    let kind_tag = if kind.is_empty() { String::new() } else { format!("  [{}]", kind) };
-    out.push_str(&format!("{}. {}  {}:{}{}{}\n", step, qn, file, line, kind_tag, conf));
+    let kind_tag = if kind.is_empty() {
+        String::new()
+    } else {
+        format!("  [{}]", kind)
+    };
+    out.push_str(&format!(
+        "{}. {}  {}:{}{}{}\n",
+        step, qn, file, line, kind_tag, conf
+    ));
 
     if *budget == 0 {
         out.push_str("       … (body budget reached — use `show` for this symbol)\n");
@@ -332,7 +367,11 @@ fn render_nopath_text(
         ));
         for qn in &sibs {
             let (_f, line, kind) = meta_loc(calls, qn);
-            let kind_tag = if kind.is_empty() { String::new() } else { format!("  [{}]", kind) };
+            let kind_tag = if kind.is_empty() {
+                String::new()
+            } else {
+                format!("  [{}]", kind)
+            };
             out.push_str(&format!("   - {}  :{}{}\n", qn.name(), line, kind_tag));
         }
     }
@@ -356,7 +395,12 @@ fn siblings(calls: &CallGraph, target: &Qn) -> Vec<Qn> {
 
 // ---------- json ----------
 
-fn node_json(calls: &CallGraph, qn: &Qn, via: Option<&CallEdge>, cache: &mut BodyCache) -> serde_json::Value {
+fn node_json(
+    calls: &CallGraph,
+    qn: &Qn,
+    via: Option<&CallEdge>,
+    cache: &mut BodyCache,
+) -> serde_json::Value {
     let (file, line, kind) = meta_loc(calls, qn);
     let body = cache.body(qn, meta_line(calls, qn));
     serde_json::json!({
@@ -463,8 +507,8 @@ mod tests {
     fn finds_multi_hop_path() {
         // a -> b -> c
         let g = graph_with(vec![edge("f::a", "f::b"), edge("f::b", "f::c")]);
-        let found = find_path(&g, &[Qn::new("f::a")], &[Qn::new("f::c")], 12)
-            .expect("path a->c exists");
+        let found =
+            find_path(&g, &[Qn::new("f::a")], &[Qn::new("f::c")], 12).expect("path a->c exists");
         assert_eq!(found.start, Qn::new("f::a"));
         let chain: Vec<&str> = found.hops.iter().map(|h| h.qn.as_str()).collect();
         assert_eq!(chain, vec!["f::b", "f::c"]);

--- a/src/context.rs
+++ b/src/context.rs
@@ -111,7 +111,12 @@ fn push_target_entry(
                 let sig_tok = sig.as_ref().map(|s| estimate_tokens(s.len())).unwrap_or(0);
                 if sig.is_some() && sig_tok <= budget.saturating_sub(*used) {
                     *used += sig_tok;
-                    entries.push(entry("target (signature only — budget)", None, sig, sig_tok));
+                    entries.push(entry(
+                        "target (signature only — budget)",
+                        None,
+                        sig,
+                        sig_tok,
+                    ));
                 } else {
                     entries.push(entry("target (metadata only — budget)", None, None, 0));
                 }
@@ -142,12 +147,7 @@ fn push_target_entry(
     }
 }
 
-pub fn run_context(
-    target: &str,
-    path: &Path,
-    opts: &ContextOptions,
-    rebuild: bool,
-) -> i32 {
+pub fn run_context(target: &str, path: &Path, opts: &ContextOptions, rebuild: bool) -> i32 {
     let root = match crate::project_root::find_root_for(path) {
         Ok(r) => r,
         Err(e) => {
@@ -316,7 +316,8 @@ fn build_context(
             if !seen_qns.insert(h.edge.source.as_str().to_string()) {
                 continue;
             }
-            let Some(sig) = signature_from_meta(calls, &h.edge.source, root, &mut parse_cache) else {
+            let Some(sig) = signature_from_meta(calls, &h.edge.source, root, &mut parse_cache)
+            else {
                 continue;
             };
             let sig_tok = estimate_tokens(sig.len());
@@ -399,7 +400,8 @@ fn build_context(
             if !seen_qns.insert(h.edge.source.as_str().to_string()) {
                 continue;
             }
-            let Some(sig) = signature_from_meta(calls, &h.edge.source, root, &mut parse_cache) else {
+            let Some(sig) = signature_from_meta(calls, &h.edge.source, root, &mut parse_cache)
+            else {
                 continue;
             };
             let sig_tok = estimate_tokens(sig.len());
@@ -709,7 +711,10 @@ fn signature_from_meta(
             return Some(first_line(&m.source).to_string());
         }
     }
-    matches.into_iter().next().map(|m| first_line(&m.source).to_string())
+    matches
+        .into_iter()
+        .next()
+        .map(|m| first_line(&m.source).to_string())
 }
 
 fn first_line(s: &str) -> &str {
@@ -734,7 +739,8 @@ fn render_text(report: &ContextReport) -> String {
     if report.body_unavailable {
         out.push_str(&format!(
             "{}\n",
-            "# note: target body could not be resolved (parse failure or unsupported language)".dimmed()
+            "# note: target body could not be resolved (parse failure or unsupported language)"
+                .dimmed()
         ));
     }
     if report.truncated {
@@ -785,14 +791,16 @@ pub mod mcp {
             #[serde(default)]
             json: bool,
         }
-        fn default_dot() -> PathBuf { PathBuf::from(".") }
-        fn default_budget() -> usize { 8000 }
+        fn default_dot() -> PathBuf {
+            PathBuf::from(".")
+        }
+        fn default_budget() -> usize {
+            8000
+        }
 
         let a: Args = match serde_json::from_value(args) {
             Ok(v) => v,
-            Err(e) => {
-                return crate::mcp::tools::CallResult::Error(format!("bad args: {e}"))
-            }
+            Err(e) => return crate::mcp::tools::CallResult::Error(format!("bad args: {e}")),
         };
         let root = match crate::project_root::find_root_for(&a.path) {
             Ok(r) => r,
@@ -800,18 +808,12 @@ pub mod mcp {
         };
         let graph = match graph_cache::ensure_with_calls(&root, false) {
             Ok(g) => g,
-            Err(e) => {
-                return crate::mcp::tools::CallResult::Error(format!(
-                    "# error: {}", e
-                ))
-            }
+            Err(e) => return crate::mcp::tools::CallResult::Error(format!("# error: {}", e)),
         };
         let calls = match &graph.calls {
             Some(c) => c,
             None => {
-                return crate::mcp::tools::CallResult::Error(
-                    "# error: call graph is empty".into(),
-                )
+                return crate::mcp::tools::CallResult::Error("# error: call graph is empty".into())
             }
         };
         let candidates = resolve_target_full(calls, &a.target);

--- a/src/core.rs
+++ b/src/core.rs
@@ -396,13 +396,24 @@ fn _modifiers(d: &Declaration, lang: &str) -> Vec<String> {
         "rust" => &["async", "unsafe", "const", "extern"],
         "python" => &["async"],
         "typescript" => &["async", "static", "abstract", "readonly", "override"],
-        "java" => &["static", "abstract", "final", "synchronized", "default", "native"],
+        "java" => &[
+            "static",
+            "abstract",
+            "final",
+            "synchronized",
+            "default",
+            "native",
+        ],
         "kotlin" => &[
             "suspend", "open", "inner", "value", "inline", "infix", "tailrec", "operator",
             "abstract", "override", "sealed", "final",
         ],
-        "scala" => &["sealed", "final", "abstract", "implicit", "inline", "lazy", "override"],
-        "csharp" => &["partial", "sealed", "static", "abstract", "virtual", "override", "async"],
+        "scala" => &[
+            "sealed", "final", "abstract", "implicit", "inline", "lazy", "override",
+        ],
+        "csharp" => &[
+            "partial", "sealed", "static", "abstract", "virtual", "override", "async",
+        ],
         _ => &[],
     };
     if want.is_empty() {
@@ -414,7 +425,14 @@ fn _modifiers(d: &Declaration, lang: &str) -> Vec<String> {
         "rust" => &["fn", "trait", "struct", "enum", "impl", "type", "mod"],
         "python" => &["def", "class"],
         "typescript" => &[
-            "function", "class", "interface", "enum", "type", "const", "let", "var",
+            "function",
+            "class",
+            "interface",
+            "enum",
+            "type",
+            "const",
+            "let",
+            "var",
         ],
         "java" => &["class", "interface", "enum", "record", "void"],
         "kotlin" => &["fun", "class", "interface", "object", "enum", "val", "var"],
@@ -530,7 +548,10 @@ fn _scan_siblings_for_legend(
         for w in siblings.windows(2) {
             if w[0].kind == w[1].kind
                 && w[0].name == w[1].name
-                && matches!(w[0].kind, Method | Function | Constructor | Destructor | Operator)
+                && matches!(
+                    w[0].kind,
+                    Method | Function | Constructor | Destructor | Operator
+                )
             {
                 *has_overloads = true;
                 break;
@@ -539,7 +560,10 @@ fn _scan_siblings_for_legend(
     }
     for d in siblings {
         if !*has_callable
-            && matches!(d.kind, Method | Function | Constructor | Destructor | Operator)
+            && matches!(
+                d.kind,
+                Method | Function | Constructor | Destructor | Operator
+            )
         {
             *has_callable = true;
         }
@@ -570,7 +594,6 @@ fn _size_label(line_count: usize) -> &'static str {
         _ => "xlarge",
     }
 }
-
 
 pub fn render_map(result: &ParseResult, opts: &MapOptions) -> String {
     let mut lines = vec![_format_file_header(
@@ -849,10 +872,7 @@ fn _digest_one(result: &ParseResult, opts: &DigestOptions) -> Vec<String> {
         }
         // Prefer `native_kind` (`trait`, `case class`, `data class`, …)
         // when the adapter set it; fall back to the canonical kind.
-        let kind_str = t
-            .native_kind
-            .as_deref()
-            .unwrap_or(t.kind.as_str());
+        let kind_str = t.native_kind.as_deref().unwrap_or(t.kind.as_str());
         // Modifiers (abstract / sealed / final / partial / …) — but skip
         // ones the native_kind already names, so we don't render
         // "sealed sealed class" for `sealed class Foo`.
@@ -892,8 +912,7 @@ fn _digest_one(result: &ParseResult, opts: &DigestOptions) -> Vec<String> {
 
     if !free_functions.is_empty() {
         let collapsed = _collapse_overloads(free_functions.iter().map(|d| (*d).clone()).collect());
-        let shown =
-            &collapsed[..std::cmp::min(collapsed.len(), opts.max_members_per_type)];
+        let shown = &collapsed[..std::cmp::min(collapsed.len(), opts.max_members_per_type)];
         let tokens: Vec<String> = shown.iter().map(_format_member_token).collect();
         lines.extend(_wrap_tokens(&tokens, 100, "    "));
     }
@@ -999,9 +1018,13 @@ fn _format_inline_attrs(attrs: &[String]) -> String {
     if joined.len() > 40 {
         // Fall back to a short marker so the reader knows attrs exist
         // without flooding the line.
-        return format!("[{}attr{}]", attrs.len(), if attrs.len() == 1 { "" } else { "s" })
-            .dimmed()
-            .to_string();
+        return format!(
+            "[{}attr{}]",
+            attrs.len(),
+            if attrs.len() == 1 { "" } else { "s" }
+        )
+        .dimmed()
+        .to_string();
     }
     joined.dimmed().to_string()
 }

--- a/src/deps/cli.rs
+++ b/src/deps/cli.rs
@@ -103,10 +103,7 @@ pub fn run_reverse_deps(
     let canonical = match canonicalise_in_root(file, &graph) {
         Some(p) => p,
         None => {
-            eprintln!(
-                "# note: {} is not part of the dep graph",
-                file.display()
-            );
+            eprintln!("# note: {} is not part of the dep graph", file.display());
             return 2;
         }
     };
@@ -135,13 +132,7 @@ pub fn run_reverse_deps(
     0
 }
 
-pub fn run_cycles(
-    path: &Path,
-    min_size: usize,
-    json: bool,
-    pretty: bool,
-    rebuild: bool,
-) -> i32 {
+pub fn run_cycles(path: &Path, min_size: usize, json: bool, pretty: bool, rebuild: bool) -> i32 {
     let cwd = current_dir_or_dot();
     let (root, scope) = match resolve_dir_root_and_scope(path, &cwd) {
         Ok(rs) => rs,
@@ -165,10 +156,7 @@ pub fn run_cycles(
         cycles.retain(|c| c.members.iter().all(|m| graph.in_scope(m, &scope)));
     }
     if json {
-        println!(
-            "{}",
-            render::render_cycles_json(&graph, &cycles, pretty)
-        );
+        println!("{}", render::render_cycles_json(&graph, &cycles, pretty));
     } else {
         print!("{}", render::render_cycles_text(&graph, &cycles));
     }
@@ -220,7 +208,10 @@ pub fn run_graph(
         full.subgraph_for_scope(&scope)
     };
     if json {
-        println!("{}", render::render_graph_json(&graph, include_external, pretty));
+        println!(
+            "{}",
+            render::render_graph_json(&graph, include_external, pretty)
+        );
     } else {
         print!("{}", render::render_graph_text(&graph, include_external));
     }
@@ -264,7 +255,10 @@ fn find_root_for_with_cache(file: &Path) -> Result<PathBuf, String> {
 /// Load (or build) the unified graph for `root`, going through the shared
 /// in-memory `Arc` so repeated calls within one process — most importantly
 /// `ast-bro mcp` — reuse the same parsed graph instead of re-deserialising.
-fn load_unified(root: &Path, force_rebuild: bool) -> std::io::Result<Arc<crate::graph_cache::UnifiedGraph>> {
+fn load_unified(
+    root: &Path,
+    force_rebuild: bool,
+) -> std::io::Result<Arc<crate::graph_cache::UnifiedGraph>> {
     if force_rebuild {
         graph_cache::shared::rebuild(root)
     } else {

--- a/src/deps/extract.rs
+++ b/src/deps/extract.rs
@@ -374,8 +374,7 @@ fn strip_quotes(s: &str) -> String {
     // ends_with against itself, but `t[1..t.len() - 1]` would panic on
     // `1..0`. Require a real pair (>= 2 bytes) before stripping.
     if t.len() >= 2
-        && ((t.starts_with('"') && t.ends_with('"'))
-            || (t.starts_with('\'') && t.ends_with('\'')))
+        && ((t.starts_with('"') && t.ends_with('"')) || (t.starts_with('\'') && t.ends_with('\'')))
     {
         t[1..t.len() - 1].to_string()
     } else {
@@ -581,7 +580,11 @@ fn _walk_csharp<'a, D: Doc>(node: &Node<'a, D>, out: &mut Vec<RawImport>) {
         if kind == "using_directive" {
             let line = (c.start_pos().line() + 1) as u32;
             let stmt = c.text().into_owned();
-            let body = stmt.trim_start_matches("using").trim_end_matches(';').trim().to_string();
+            let body = stmt
+                .trim_start_matches("using")
+                .trim_end_matches(';')
+                .trim()
+                .to_string();
             let is_static = body.starts_with("static ");
             let rest = body.trim_start_matches("static ").trim().to_string();
 
@@ -614,7 +617,10 @@ fn _walk_csharp<'a, D: Doc>(node: &Node<'a, D>, out: &mut Vec<RawImport>) {
                 local_name: None,
                 raw_path: Some(dotted),
             });
-        } else if matches!(kind, "namespace_declaration" | "file_scoped_namespace_declaration") {
+        } else if matches!(
+            kind,
+            "namespace_declaration" | "file_scoped_namespace_declaration"
+        ) {
             // Recurse into namespace bodies; usings can live inside.
             _walk_csharp(&c, out);
         }
@@ -740,7 +746,11 @@ fn consume_cpp_include<'a, D: Doc>(node: &Node<'a, D>, out: &mut Vec<RawImport>)
             // `#include <vector>` — system header. Emit so it shows up in
             // external listings; the resolver won't find it inside the project.
             let raw = sub.text().into_owned();
-            let inner = raw.trim().trim_start_matches('<').trim_end_matches('>').to_string();
+            let inner = raw
+                .trim()
+                .trim_start_matches('<')
+                .trim_end_matches('>')
+                .to_string();
             if inner.is_empty() {
                 continue;
             }
@@ -835,7 +845,13 @@ fn consume_php_use<'a, D: Doc>(node: &Node<'a, D>, out: &mut Vec<RawImport>) {
                 let ik = inner.kind();
                 let ik = ik.as_ref();
                 if (ik == "qualified_name" || ik == "namespace_name") && prefix.is_none() {
-                    prefix = Some(inner.text().into_owned().trim_start_matches('\\').to_string());
+                    prefix = Some(
+                        inner
+                            .text()
+                            .into_owned()
+                            .trim_start_matches('\\')
+                            .to_string(),
+                    );
                 } else if ik == "namespace_use_group_clause" || ik == "namespace_use_clause" {
                     let text = inner.text().into_owned();
                     let (item, alias) = match text.split_once(" as ") {
@@ -910,12 +926,7 @@ fn _php_extract_string_arg<'a, D: Doc>(node: &Node<'a, D>) -> Option<String> {
     let k = k.as_ref();
     if k == "string" || k == "encapsed_string" {
         let raw = node.text().into_owned();
-        return Some(
-            raw.trim()
-                .trim_matches('\'')
-                .trim_matches('"')
-                .to_string(),
-        );
+        return Some(raw.trim().trim_matches('\'').trim_matches('"').to_string());
     }
     if k == "parenthesized_expression" {
         for inner in node.children() {
@@ -990,11 +1001,7 @@ fn consume_ruby_call<'a, D: Doc>(node: &Node<'a, D>, out: &mut Vec<RawImport>) {
         return;
     }
     let raw = path_arg.text().into_owned();
-    let path = raw
-        .trim()
-        .trim_matches('\'')
-        .trim_matches('"')
-        .to_string();
+    let path = raw.trim().trim_matches('\'').trim_matches('"').to_string();
     if path.is_empty() {
         return;
     }

--- a/src/deps/manifest.rs
+++ b/src/deps/manifest.rs
@@ -204,7 +204,7 @@ pub fn parse_composer_psr4(path: &Path) -> Vec<(String, String)> {
     // Longest prefix wins on tie — sort descending so the resolver picks the
     // most specific match first. (Stable sort preserves array order within
     // a prefix, so multi-dir entries try directories in declaration order.)
-    out.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
+    out.sort_by_key(|b| std::cmp::Reverse(b.0.len()));
     out
 }
 

--- a/src/deps/mod.rs
+++ b/src/deps/mod.rs
@@ -39,12 +39,10 @@ use crate::deps::resolver::{build_suffix_index, resolve, ResolveCtx};
 /// runs in parallel.
 pub fn build_graph(root: &Path) -> Result<DepGraph, DepError> {
     let start = Instant::now();
-    let root_canon = root
-        .canonicalize()
-        .map_err(|e| DepError::Io {
-            path: root.to_path_buf(),
-            source: e,
-        })?;
+    let root_canon = root.canonicalize().map_err(|e| DepError::Io {
+        path: root.to_path_buf(),
+        source: e,
+    })?;
 
     let aliases = detect_aliases(&root_canon);
     let idx = build_suffix_index(&root_canon);

--- a/src/deps/render.rs
+++ b/src/deps/render.rs
@@ -132,7 +132,10 @@ pub fn render_graph_text(graph: &DepGraph, include_external: bool) -> String {
         for (file, externals) in &graph.external {
             let s = graph.rel(file);
             for ext in externals {
-                grouped.entry(s.clone()).or_default().push((ext.clone(), None));
+                grouped
+                    .entry(s.clone())
+                    .or_default()
+                    .push((ext.clone(), None));
             }
         }
     }

--- a/src/deps/resolver/build.rs
+++ b/src/deps/resolver/build.rs
@@ -152,7 +152,10 @@ pub fn build_suffix_index(root: &Path) -> SuffixIndex {
                         .map(|c| c.as_os_str().to_string_lossy().into_owned())
                         .collect::<Vec<_>>()
                         .join("/");
-                    idx.by_suffix.entry(key.clone()).or_default().push(path.to_path_buf());
+                    idx.by_suffix
+                        .entry(key.clone())
+                        .or_default()
+                        .push(path.to_path_buf());
                     // Also index just the package name (last segment).
                     if let Some(last) = key.rsplit('/').next() {
                         idx.by_suffix
@@ -168,7 +171,10 @@ pub fn build_suffix_index(root: &Path) -> SuffixIndex {
         if let Some(pkg) = package {
             for ty in &top_level_types {
                 let fqn = format!("{}.{}", pkg, ty).replace('.', "/");
-                idx.by_suffix.entry(fqn).or_default().push(path.to_path_buf());
+                idx.by_suffix
+                    .entry(fqn)
+                    .or_default()
+                    .push(path.to_path_buf());
                 // Also index just the type (commonly seen at top-level).
                 idx.by_suffix
                     .entry(ty.clone())
@@ -246,10 +252,7 @@ fn extract_package_and_types(path: &Path, lang: Lang) -> Option<(Option<String>,
                         .strip_prefix("namespace ")
                         .or_else(|| line.strip_prefix("internal namespace "))
                     {
-                        let p = rest
-                            .trim_end_matches(';')
-                            .trim_end_matches('{')
-                            .trim();
+                        let p = rest.trim_end_matches(';').trim_end_matches('{').trim();
                         if !p.is_empty() {
                             package = Some(p.to_string());
                         }
@@ -289,7 +292,12 @@ fn extract_package_and_types(path: &Path, lang: Lang) -> Option<(Option<String>,
                 if let Some(name) = pick_after(
                     line,
                     &[
-                        "class ", "object ", "trait ", "enum ", "case class ", "case object ",
+                        "class ",
+                        "object ",
+                        "trait ",
+                        "enum ",
+                        "case class ",
+                        "case object ",
                     ],
                 ) {
                     types.push(name);
@@ -299,7 +307,12 @@ fn extract_package_and_types(path: &Path, lang: Lang) -> Option<(Option<String>,
                 if let Some(name) = pick_after(
                     line,
                     &[
-                        "class ", "struct ", "interface ", "record ", "enum ", "delegate ",
+                        "class ",
+                        "struct ",
+                        "interface ",
+                        "record ",
+                        "enum ",
+                        "delegate ",
                     ],
                 ) {
                     types.push(name);

--- a/src/deps/resolver/resolve.rs
+++ b/src/deps/resolver/resolve.rs
@@ -57,21 +57,20 @@ pub fn resolve(spec: &str, ctx: &ResolveCtx<'_>, idx: &SuffixIndex) -> Option<Pa
     // Language-specific normalisation: `crate::x::y` → `x/y`,
     // `self::x` → relative-to-current-dir, `super::x` → ascend one.
     if ctx.lang == Lang::Rust {
-        let resolve_with_fallback =
-            |key: String| -> Option<PathBuf> {
-                if let Some(p) = pick_closest(idx.lookup(&key), ctx.from_file) {
+        let resolve_with_fallback = |key: String| -> Option<PathBuf> {
+            if let Some(p) = pick_closest(idx.lookup(&key), ctx.from_file) {
+                return Some(p);
+            }
+            let mut parts: Vec<&str> = key.split('/').collect();
+            while parts.len() > 1 {
+                parts.pop();
+                let trimmed = parts.join("/");
+                if let Some(p) = pick_closest(idx.lookup(&trimmed), ctx.from_file) {
                     return Some(p);
                 }
-                let mut parts: Vec<&str> = key.split('/').collect();
-                while parts.len() > 1 {
-                    parts.pop();
-                    let trimmed = parts.join("/");
-                    if let Some(p) = pick_closest(idx.lookup(&trimmed), ctx.from_file) {
-                        return Some(p);
-                    }
-                }
-                None
-            };
+            }
+            None
+        };
 
         if let Some(rest) = spec.strip_prefix("crate::") {
             return resolve_with_fallback(rest.replace("::", "/"));
@@ -100,19 +99,14 @@ pub fn resolve(spec: &str, ctx: &ResolveCtx<'_>, idx: &SuffixIndex) -> Option<Pa
     }
 
     // TS/JS relative: `./foo` / `../foo`.
-    if (matches!(
-        ctx.lang,
-        Lang::TypeScript | Lang::Tsx | Lang::JavaScript
-    )) && (spec.starts_with('.'))
+    if (matches!(ctx.lang, Lang::TypeScript | Lang::Tsx | Lang::JavaScript))
+        && (spec.starts_with('.'))
     {
         return resolve_relative_path(spec, ctx, idx);
     }
 
     // tsconfig path aliases.
-    if matches!(
-        ctx.lang,
-        Lang::TypeScript | Lang::Tsx | Lang::JavaScript
-    ) {
+    if matches!(ctx.lang, Lang::TypeScript | Lang::Tsx | Lang::JavaScript) {
         for (prefix, replacement) in ctx.path_aliases {
             if let Some(rest) = spec.strip_prefix(prefix.as_str()) {
                 let combined = format!("{}{}", replacement, rest);
@@ -224,11 +218,7 @@ pub fn resolve(spec: &str, ctx: &ResolveCtx<'_>, idx: &SuffixIndex) -> Option<Pa
 }
 
 /// Walk a relative `./x/y` style path against `from_file`'s directory.
-fn resolve_relative_path(
-    spec: &str,
-    ctx: &ResolveCtx<'_>,
-    idx: &SuffixIndex,
-) -> Option<PathBuf> {
+fn resolve_relative_path(spec: &str, ctx: &ResolveCtx<'_>, idx: &SuffixIndex) -> Option<PathBuf> {
     let parent = ctx.from_file.parent()?;
     let mut cur = parent.to_path_buf();
     let mut remaining = spec;
@@ -245,10 +235,7 @@ fn resolve_relative_path(
         return Some(target);
     }
     // Try common extensions for TS/JS.
-    if matches!(
-        ctx.lang,
-        Lang::TypeScript | Lang::Tsx | Lang::JavaScript
-    ) {
+    if matches!(ctx.lang, Lang::TypeScript | Lang::Tsx | Lang::JavaScript) {
         let ext_order: &[&str] = &[
             ".ts", ".tsx", ".mts", ".cts", ".d.ts", ".js", ".jsx", ".mjs", ".cjs", ".json",
         ];

--- a/src/deps/scc.rs
+++ b/src/deps/scc.rs
@@ -74,7 +74,7 @@ pub fn detect(graph: &DepGraph, min_size: usize) -> Vec<Cycle> {
             Some(Cycle { members })
         })
         .collect();
-    cycles.sort_by(|a, b| b.members.len().cmp(&a.members.len()));
+    cycles.sort_by_key(|b| std::cmp::Reverse(b.members.len()));
     cycles
 }
 

--- a/src/deps/traverse.rs
+++ b/src/deps/traverse.rs
@@ -49,13 +49,7 @@ pub fn reverse<F: Fn(&DepEdge) -> bool>(
     bfs(start, max_depth, limit, edges_at, predicate)
 }
 
-fn bfs<F, P>(
-    start: &Path,
-    max_depth: usize,
-    limit: usize,
-    edges_at: F,
-    predicate: P,
-) -> Vec<DepHit>
+fn bfs<F, P>(start: &Path, max_depth: usize, limit: usize, edges_at: F, predicate: P) -> Vec<DepHit>
 where
     F: Fn(&Path) -> Vec<DepEdge>,
     P: Fn(&DepEdge) -> bool,

--- a/src/file_filter.rs
+++ b/src/file_filter.rs
@@ -27,18 +27,38 @@ use std::sync::{Mutex, OnceLock};
 ///   - have a stable, conventional name
 pub const HARDCODED_IGNORE_DIRS: &[&str] = &[
     // VCS
-    ".git", ".hg", ".svn", ".jj",
+    ".git",
+    ".hg",
+    ".svn",
+    ".jj",
     // Python
-    "__pycache__", ".venv", "venv", ".tox",
-    ".mypy_cache", ".pytest_cache", ".ruff_cache",
+    "__pycache__",
+    ".venv",
+    "venv",
+    ".tox",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
     // JS/TS
-    "node_modules", ".next", ".nuxt", ".turbo", ".parcel-cache",
+    "node_modules",
+    ".next",
+    ".nuxt",
+    ".turbo",
+    ".parcel-cache",
     // Build outputs
-    "dist", "build", "out", ".eggs", "target",
+    "dist",
+    "build",
+    "out",
+    ".eggs",
+    "target",
     // Other
-    ".cache", ".gradle", ".idea", ".vscode",
+    ".cache",
+    ".gradle",
+    ".idea",
+    ".vscode",
     // Self (keep legacy name during transition)
-    ".ast-bro", ".ast-outline",
+    ".ast-bro",
+    ".ast-outline",
 ];
 
 /// Wire `.ast-bro-ignore` into a `WalkBuilder`.
@@ -124,16 +144,26 @@ pub fn should_skip_path(path: &Path, repo_root: &Path) -> bool {
 /// output. The unambiguous `integration-tests` / `integration_tests`
 /// forms are kept.
 const TEST_DIR_TOKENS: &[&str] = &[
-    "test", "tests", "__tests__", "e2e", "cypress", "playwright",
-    "integration-tests", "integration_tests", "test-fixtures", "fixtures",
-    "spec", "specs", "mocha", "jest",
+    "test",
+    "tests",
+    "__tests__",
+    "e2e",
+    "cypress",
+    "playwright",
+    "integration-tests",
+    "integration_tests",
+    "test-fixtures",
+    "fixtures",
+    "spec",
+    "specs",
+    "mocha",
+    "jest",
 ];
 
 /// File-stem suffixes (before the final extension) that mark test files.
 /// Checked against the lowered stem.
 const TEST_FILE_SUFFIXES: &[&str] = &[
-    "_test", ".test", "_spec", ".spec",
-    "_tests", ".tests", "_specs", ".specs",
+    "_test", ".test", "_spec", ".spec", "_tests", ".tests", "_specs", ".specs",
 ];
 
 /// Return `true` when `path` (relative to `repo_root`) looks like a test
@@ -184,29 +214,29 @@ pub fn detect_language(path: &Path) -> Option<ast_grep_language::SupportLang> {
     let mut file = fs::File::open(path).ok()?;
     let mut buffer = [0u8; 256];
     let bytes_read = file.read(&mut buffer).ok()?;
-    
+
     if bytes_read < 2 {
         return None;
     }
-    
+
     // Must start with #!
     if buffer[0] != b'#' || buffer[1] != b'!' {
         return None;
     }
-    
+
     // Find the first newline within the read bytes
     let newline_pos = buffer[..bytes_read]
         .iter()
         .position(|&b| b == b'\n')
         .unwrap_or(bytes_read);
-    
+
     // If the shebang line runs past the scan window, it's too long to be valid.
     // When the file fit entirely inside the window (`bytes_read < buffer.len()`),
     // EOF terminates the line just as well as a newline.
     if newline_pos == bytes_read && bytes_read == buffer.len() {
         return None;
     }
-    
+
     // Extract the first line as UTF-8
     let first_line = std::str::from_utf8(&buffer[..newline_pos]).ok()?;
 
@@ -257,7 +287,10 @@ mod tests {
     #[test]
     fn skip_node_modules_anywhere() {
         let root = PathBuf::from("/r");
-        assert!(should_skip_path(&root.join("node_modules/lodash/index.js"), &root));
+        assert!(should_skip_path(
+            &root.join("node_modules/lodash/index.js"),
+            &root
+        ));
         assert!(should_skip_path(
             &root.join("packages/foo/node_modules/lib.js"),
             &root,
@@ -267,13 +300,19 @@ mod tests {
     #[test]
     fn skip_target_dir() {
         let root = PathBuf::from("/r");
-        assert!(should_skip_path(&root.join("target/debug/build/x.rs"), &root));
+        assert!(should_skip_path(
+            &root.join("target/debug/build/x.rs"),
+            &root
+        ));
     }
 
     #[test]
     fn skip_self_managed_index() {
         let root = PathBuf::from("/r");
-        assert!(should_skip_path(&root.join(".ast-bro/index/meta.json"), &root));
+        assert!(should_skip_path(
+            &root.join(".ast-bro/index/meta.json"),
+            &root
+        ));
     }
 
     #[test]
@@ -287,16 +326,25 @@ mod tests {
     fn allow_paths_outside_root() {
         let root = PathBuf::from("/r");
         // strip_prefix fails → not skipped (let caller decide).
-        assert!(!should_skip_path(&PathBuf::from("/elsewhere/node_modules/x"), &root));
+        assert!(!should_skip_path(
+            &PathBuf::from("/elsewhere/node_modules/x"),
+            &root
+        ));
     }
 
     #[test]
     fn test_detection_directory_components() {
         let root = PathBuf::from("/r");
         assert!(is_test_file(&root.join("tests/foo.rs"), &root));
-        assert!(is_test_file(&root.join("src/features/__tests__/a.ts"), &root));
+        assert!(is_test_file(
+            &root.join("src/features/__tests__/a.ts"),
+            &root
+        ));
         assert!(is_test_file(&root.join("e2e/signup.spec.ts"), &root));
-        assert!(is_test_file(&root.join("cypress/integration/login.js"), &root));
+        assert!(is_test_file(
+            &root.join("cypress/integration/login.js"),
+            &root
+        ));
     }
 
     #[test]
@@ -320,7 +368,10 @@ mod tests {
         assert!(!is_test_file(&root.join("lib/auth.py"), &root));
         assert!(!is_test_file(&root.join("src/test_utils.rs"), &root));
         // Production integration code must not be classified as tests.
-        assert!(!is_test_file(&root.join("src/integration/stripe.rs"), &root));
+        assert!(!is_test_file(
+            &root.join("src/integration/stripe.rs"),
+            &root
+        ));
         // ...but explicit integration-test directories still are.
         assert!(is_test_file(&root.join("integration-tests/api.rs"), &root));
         assert!(is_test_file(&root.join("integration_tests/api.rs"), &root));

--- a/src/graph_cache/cache.rs
+++ b/src/graph_cache/cache.rs
@@ -17,8 +17,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::fs;
 use std::io::Write;
-use std::sync::{Mutex, OnceLock};
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 
 pub const CACHE_SCHEMA: &str = JSON_SCHEMA_GRAPH_INDEX;
 /// Legacy schema from pre-rename installs — still readable.
@@ -178,11 +178,7 @@ pub fn load_or_build_with_records(
 
 /// Persist a graph + file fingerprints atomically. Writes via `.tmp` +
 /// rename, holds an advisory exclusive lock during the write.
-pub fn save(
-    root: &Path,
-    graph: &UnifiedGraph,
-    files: &[FileRecord],
-) -> std::io::Result<()> {
+pub fn save(root: &Path, graph: &UnifiedGraph, files: &[FileRecord]) -> std::io::Result<()> {
     let dir = cache_dir(root);
     fs::create_dir_all(&dir)?;
     write_gitignore(&dir)?;
@@ -199,8 +195,7 @@ pub fn save(
         graph: graph.clone(),
         files: files.to_vec(),
     };
-    let bytes = encode_to_vec(&cf, bincode::config::standard())
-        .map_err(std::io::Error::other)?;
+    let bytes = encode_to_vec(&cf, bincode::config::standard()).map_err(std::io::Error::other)?;
 
     let final_path = cache_path(root);
     let tmp = final_path.with_extension("bin.tmp");
@@ -306,7 +301,10 @@ mod tests {
         let bytes = fs::read(cache_path(root)).expect("read cold cache");
         let (cf, _): (CacheFile, _) =
             decode_from_slice(&bytes, bincode::config::standard()).expect("decode cold");
-        assert!(cf.graph.calls.is_none(), "on-disk cold cache should be calls: None");
+        assert!(
+            cf.graph.calls.is_none(),
+            "on-disk cold cache should be calls: None"
+        );
 
         // 2. Promote and re-read the bytes from disk.
         shared::promote_calls(root, |g| {

--- a/src/graph_cache/delta.rs
+++ b/src/graph_cache/delta.rs
@@ -121,12 +121,7 @@ pub fn apply_delta_to_deps(
 /// changed files, re-extract added/modified files, splice the new qns +
 /// edges back in. `deps` is the *already-patched* deps graph so pass C's
 /// dep-closure filter sees post-update state.
-pub fn apply_delta_to_calls(
-    calls: &mut CallGraph,
-    deps: &DepGraph,
-    root: &Path,
-    delta: &Delta,
-) {
+pub fn apply_delta_to_calls(calls: &mut CallGraph, deps: &DepGraph, root: &Path, delta: &Delta) {
     // Build the set of relative POSIX paths whose qn-bearing entries we
     // need to invalidate. `Qn::file()` returns this same form, so the
     // membership check is a single string lookup.
@@ -147,17 +142,13 @@ pub fn apply_delta_to_calls(
     //    will be detected as stale after step 6 once we know which qns
     //    actually exist post-update. Demoting eagerly would cost the
     //    `Exact` confidence tag for edges whose target wasn't renamed.
-    calls
-        .forward
-        .retain(|qn, _| !changed.contains(qn.file()));
+    calls.forward.retain(|qn, _| !changed.contains(qn.file()));
 
     // 3. Drop changed-file qns from per-callable + per-type metadata.
     calls
         .callable_meta
         .retain(|qn, _| !changed.contains(qn.file()));
-    calls
-        .types
-        .retain(|qn, _| !changed.contains(qn.file()));
+    calls.types.retain(|qn, _| !changed.contains(qn.file()));
 
     // 4. Drop changed-file entries from the inverted indices and prune
     //    empty buckets so subsequent callers don't see ghost keys.
@@ -234,7 +225,8 @@ pub fn apply_delta_to_calls(
         calls.callable_meta.keys().cloned().collect();
     for edges in calls.forward.values_mut() {
         for e in edges.iter_mut() {
-            let demote = matches!(&e.target, CallTarget::Resolved(qn) if !known_callable.contains(qn));
+            let demote =
+                matches!(&e.target, CallTarget::Resolved(qn) if !known_callable.contains(qn));
             if demote {
                 let bare = e.target.name_or_raw();
                 e.target = CallTarget::Bare(bare);
@@ -254,8 +246,12 @@ pub fn apply_delta_to_calls(
     //    that the cold build deliberately leaves Bare.
     for edges in calls.forward.values_mut() {
         for e in edges.iter_mut() {
-            let CallTarget::Bare(name) = &e.target else { continue };
-            let Some(cands) = calls.symbol_table.get(name) else { continue };
+            let CallTarget::Bare(name) = &e.target else {
+                continue;
+            };
+            let Some(cands) = calls.symbol_table.get(name) else {
+                continue;
+            };
             let has_receiver = e
                 .receiver
                 .as_deref()
@@ -279,11 +275,7 @@ pub fn apply_delta_to_calls(
 /// after a partial update. Entries for removed files are dropped; added
 /// and modified entries are re-stat-and-hashed; mtime-only entries get
 /// their mtime refreshed without a re-hash; unchanged entries pass through.
-pub fn refresh_records(
-    prev: Vec<FileRecord>,
-    root: &Path,
-    delta: &Delta,
-) -> Vec<FileRecord> {
+pub fn refresh_records(prev: Vec<FileRecord>, root: &Path, delta: &Delta) -> Vec<FileRecord> {
     let removed: HashSet<&str> = delta.removed.iter().map(|s| s.as_str()).collect();
     let touched: HashSet<String> = delta
         .added
@@ -345,9 +337,7 @@ fn rel_posix(root: &Path, path: &Path) -> String {
 }
 
 fn mtime_nanos(meta: &std::fs::Metadata) -> i128 {
-    let mtime = meta
-        .modified()
-        .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+    let mtime = meta.modified().unwrap_or(std::time::SystemTime::UNIX_EPOCH);
     match mtime.duration_since(std::time::SystemTime::UNIX_EPOCH) {
         Ok(d) => d.as_nanos() as i128,
         Err(e) => -(e.duration().as_nanos() as i128),

--- a/src/graph_cache/mod.rs
+++ b/src/graph_cache/mod.rs
@@ -60,5 +60,7 @@ pub fn ensure_with_calls(
     if unified.calls.is_some() {
         return Ok(unified);
     }
-    promote_calls(root, |g| crate::calls::build::build_call_graph(root, &g.deps))
+    promote_calls(root, |g| {
+        crate::calls::build::build_call_graph(root, &g.deps)
+    })
 }

--- a/src/graph_cache/shared.rs
+++ b/src/graph_cache/shared.rs
@@ -51,7 +51,10 @@ fn registry() -> &'static Registry {
 }
 
 fn store(key: PathBuf, graph: Arc<UnifiedGraph>, records: Arc<Vec<FileRecord>>) {
-    registry().write().unwrap().insert(key, Entry { graph, records });
+    registry()
+        .write()
+        .unwrap()
+        .insert(key, Entry { graph, records });
 }
 
 /// Get the unified graph for `root`, building (and persisting) it if no

--- a/src/hook/decide.rs
+++ b/src/hook/decide.rs
@@ -100,10 +100,7 @@ mod tests {
 
     #[test]
     fn pass_through_for_unsupported_extension() {
-        let d = decide(
-            &ev("Read", Some(PathBuf::from("img.png")), false),
-            &opts(),
-        );
+        let d = decide(&ev("Read", Some(PathBuf::from("img.png")), false), &opts());
         assert!(matches!(d, Decision::PassThrough));
     }
 

--- a/src/hook/gemini.rs
+++ b/src/hook/gemini.rs
@@ -69,9 +69,6 @@ mod tests {
         let json = r#"{"tool_name":"read_file","tool_input":{"absolute_path":"/x/a.rs"}}"#;
         let e: InputEvent = serde_json::from_str(json).unwrap();
         assert_eq!(e.tool_name, "read_file");
-        assert_eq!(
-            e.tool_input.absolute_path,
-            Some(PathBuf::from("/x/a.rs"))
-        );
+        assert_eq!(e.tool_input.absolute_path, Some(PathBuf::from("/x/a.rs")));
     }
 }

--- a/src/hook/mod.rs
+++ b/src/hook/mod.rs
@@ -1,8 +1,8 @@
-pub mod event;
-pub mod decide;
-pub mod io;
 pub mod claude_code;
+pub mod decide;
+pub mod event;
 pub mod gemini;
+pub mod io;
 
 use decide::DecideOpts;
 

--- a/src/impact.rs
+++ b/src/impact.rs
@@ -84,12 +84,7 @@ pub struct ImpactReport {
     pub test_count: usize,
 }
 
-pub fn run_impact(
-    target: &str,
-    path: &Path,
-    opts: &ImpactOptions,
-    rebuild: bool,
-) -> i32 {
+pub fn run_impact(target: &str, path: &Path, opts: &ImpactOptions, rebuild: bool) -> i32 {
     let root = match crate::project_root::find_root_for(path) {
         Ok(r) => r,
         Err(e) => {
@@ -154,14 +149,21 @@ fn compute_impact(
     let (file_path, target_line, target_kind) = match c.kind {
         SymbolKind::Callable => {
             let meta = calls.callable_meta.get(&c.qn);
-            let file = meta.map(|m| m.file.clone()).unwrap_or_else(|| PathBuf::from(c.qn.file()));
+            let file = meta
+                .map(|m| m.file.clone())
+                .unwrap_or_else(|| PathBuf::from(c.qn.file()));
             let line = meta.map(|m| m.line).unwrap_or(0);
-            let kind = meta.map(|m| m.kind.as_str()).unwrap_or("function").to_string();
+            let kind = meta
+                .map(|m| m.kind.as_str())
+                .unwrap_or("function")
+                .to_string();
             (file, line, kind)
         }
         SymbolKind::Type => {
             let tmeta = calls.types.get(&c.qn);
-            let file = tmeta.map(|m| m.file.clone()).unwrap_or_else(|| PathBuf::from(c.qn.file()));
+            let file = tmeta
+                .map(|m| m.file.clone())
+                .unwrap_or_else(|| PathBuf::from(c.qn.file()));
             let line = tmeta.map(|m| m.line).unwrap_or(0);
             let kind = tmeta.map(|m| m.kind.as_str()).unwrap_or("type").to_string();
             (file, line, kind)
@@ -188,7 +190,9 @@ fn compute_impact(
 
     if matches!(opts.mode, ImpactMode::Dependents | ImpactMode::All) {
         sections.push(build_callers_section(c, calls, opts, root));
-        sections.push(build_file_reverse_deps_section(&file_path, deps, root, opts));
+        sections.push(build_file_reverse_deps_section(
+            &file_path, deps, root, opts,
+        ));
     }
 
     let mut transitive = BTreeMap::new();
@@ -259,56 +263,56 @@ fn compute_impact(
         //   depth 2: callers of those constructors; callables constructing
         //            an implementor
         //   depth 3+: `traverse::callers` from each construction site.
-        let mut seen_transitive: std::collections::HashSet<Qn> =
-            std::collections::HashSet::new();
-        let add_transitive = |depth: usize,
-                                  source: &Qn,
-                                  file: &Path,
-                                  line: u32,
-                                  confidence: Confidence,
-                                  is_test: bool,
-                                  transitive: &mut BTreeMap<usize, Vec<ImpactEntry>>,
-                                  test_calls: &mut Vec<CallHit>,
-                                  seen: &mut std::collections::HashSet<Qn>| {
-            if opts.exclude_tests && is_test {
-                return;
-            }
-            if opts.tests && !is_test {
-                return;
-            }
-            // Dedup before the test push too — the same source reached via
-            // several construction sites must appear once in both sections.
-            if !seen.insert(source.clone()) {
-                return;
-            }
-            if is_test {
-                test_calls.push(CallHit {
-                    depth,
-                    edge: CallEdge {
-                        source: source.clone(),
-                        target: CallTarget::Resolved(c.qn.clone()),
-                        kind: crate::calls::graph::CallKindCompat::Construct,
-                        line,
-                        file: file.to_path_buf(),
-                        confidence,
-                        receiver: None,
-                        candidates: Vec::new(),
-                    },
+        let mut seen_transitive: std::collections::HashSet<Qn> = std::collections::HashSet::new();
+        let add_transitive =
+            |depth: usize,
+             source: &Qn,
+             file: &Path,
+             line: u32,
+             confidence: Confidence,
+             is_test: bool,
+             transitive: &mut BTreeMap<usize, Vec<ImpactEntry>>,
+             test_calls: &mut Vec<CallHit>,
+             seen: &mut std::collections::HashSet<Qn>| {
+                if opts.exclude_tests && is_test {
+                    return;
+                }
+                if opts.tests && !is_test {
+                    return;
+                }
+                // Dedup before the test push too — the same source reached via
+                // several construction sites must appear once in both sections.
+                if !seen.insert(source.clone()) {
+                    return;
+                }
+                if is_test {
+                    test_calls.push(CallHit {
+                        depth,
+                        edge: CallEdge {
+                            source: source.clone(),
+                            target: CallTarget::Resolved(c.qn.clone()),
+                            kind: crate::calls::graph::CallKindCompat::Construct,
+                            line,
+                            file: file.to_path_buf(),
+                            confidence,
+                            receiver: None,
+                            candidates: Vec::new(),
+                        },
+                    });
+                }
+                transitive.entry(depth).or_default().push(ImpactEntry {
+                    qn: source.as_str().to_string(),
+                    file: file.display().to_string(),
+                    line,
+                    kind: calls
+                        .callable_meta
+                        .get(source)
+                        .map(|m| m.kind.clone())
+                        .unwrap_or_else(|| "function".into()),
+                    confidence: Some(confidence.as_str().to_string()),
+                    depth: Some(depth),
                 });
-            }
-            transitive.entry(depth).or_default().push(ImpactEntry {
-                qn: source.as_str().to_string(),
-                file: file.display().to_string(),
-                line,
-                kind: calls
-                    .callable_meta
-                    .get(source)
-                    .map(|m| m.kind.clone())
-                    .unwrap_or_else(|| "function".into()),
-                confidence: Some(confidence.as_str().to_string()),
-                depth: Some(depth),
-            });
-        };
+            };
 
         // Same predicate as the callable traversal above — filtering inside
         // the BFS keeps excluded edges from consuming --limit, and ambiguous
@@ -395,7 +399,9 @@ fn compute_impact(
         if let Some(impls) = calls.implementors.get(c.qn.name()) {
             for qn in impls {
                 let meta = calls.types.get(qn);
-                let file = meta.map(|m| m.file.clone()).unwrap_or_else(|| PathBuf::from(qn.file()));
+                let file = meta
+                    .map(|m| m.file.clone())
+                    .unwrap_or_else(|| PathBuf::from(qn.file()));
                 let line = meta.map(|m| m.line).unwrap_or(0);
                 let abs = root.join(&file);
                 // Implementors (depth 1) are shown in the callers section and
@@ -424,8 +430,7 @@ fn compute_impact(
                         // Skip ambiguous construction seeds when hidden, so
                         // they don't leak into depth-2 transitive/test output
                         // (matches build_callers_section's retain).
-                        if !opts.include_ambiguous
-                            && matches!(e.confidence, Confidence::Ambiguous)
+                        if !opts.include_ambiguous && matches!(e.confidence, Confidence::Ambiguous)
                         {
                             continue;
                         }
@@ -481,7 +486,10 @@ fn compute_impact(
         let total: usize = transitive.values().map(|v| v.len()).sum();
         report.transitive_count = total;
         let mut section = ImpactSection {
-            title: format!("! {} symbols transitively affected (depth {})", total, opts.depth),
+            title: format!(
+                "! {} symbols transitively affected (depth {})",
+                total, opts.depth
+            ),
             entries: Vec::new(),
         };
         for (depth, entries) in &transitive {
@@ -534,7 +542,10 @@ fn compute_impact(
                     .collect(),
             )
         };
-        sections.push(ImpactSection { title: display, entries });
+        sections.push(ImpactSection {
+            title: display,
+            entries,
+        });
     }
 
     report
@@ -563,9 +574,7 @@ fn build_callees_section(
     if c.kind == SymbolKind::Callable {
         let one_hop = traverse::callees_one_hop(calls, &c.qn);
         for e in one_hop {
-            if !opts.include_ambiguous
-                && matches!(e.confidence, Confidence::Ambiguous)
-            {
+            if !opts.include_ambiguous && matches!(e.confidence, Confidence::Ambiguous) {
                 continue;
             }
             edges.push(e);
@@ -574,35 +583,32 @@ fn build_callees_section(
     let entries: Vec<ImpactEntry> = edges
         .into_iter()
         .filter_map(|e| {
-                let (qn, file, line) = match &e.target {
-                    CallTarget::Resolved(q) => {
-                        let meta = calls.callable_meta.get(q);
-                        (
-                            q.as_str().to_string(),
-                            meta.map(|m| m.file.clone()).unwrap_or_else(|| e.file.clone()),
-                            meta.map(|m| m.line).unwrap_or(e.line),
-                        )
-                    }
-                    CallTarget::External(s) => {
-                        (format!("[external] {s}"), e.file.clone(), e.line)
-                    }
-                    CallTarget::Bare(s) => {
-                        (format!("[unresolved] {s}"), e.file.clone(), e.line)
-                    }
-                };
-                if !passes_test_flags(&file, root, opts) {
-                    return None;
+            let (qn, file, line) = match &e.target {
+                CallTarget::Resolved(q) => {
+                    let meta = calls.callable_meta.get(q);
+                    (
+                        q.as_str().to_string(),
+                        meta.map(|m| m.file.clone())
+                            .unwrap_or_else(|| e.file.clone()),
+                        meta.map(|m| m.line).unwrap_or(e.line),
+                    )
                 }
-                Some(ImpactEntry {
-                    qn,
-                    file: file.display().to_string(),
-                    line,
-                    kind: e.kind.as_str().to_string(),
-                    confidence: Some(e.confidence.as_str().to_string()),
-                    depth: None,
-                })
+                CallTarget::External(s) => (format!("[external] {s}"), e.file.clone(), e.line),
+                CallTarget::Bare(s) => (format!("[unresolved] {s}"), e.file.clone(), e.line),
+            };
+            if !passes_test_flags(&file, root, opts) {
+                return None;
+            }
+            Some(ImpactEntry {
+                qn,
+                file: file.display().to_string(),
+                line,
+                kind: e.kind.as_str().to_string(),
+                confidence: Some(e.confidence.as_str().to_string()),
+                depth: None,
             })
-            .collect();
+        })
+        .collect();
     ImpactSection {
         title: format!("→ calls ({})", entries.len()),
         entries,
@@ -774,7 +780,11 @@ fn render_text(reports: &[ImpactReport], candidate_count: usize) -> String {
             "{} {} {} ({}:{})\n",
             "⊕".bold(),
             r.target_kind.dimmed(),
-            r.target_qn.split("::").last().unwrap_or(&r.target_qn).yellow(),
+            r.target_qn
+                .split("::")
+                .last()
+                .unwrap_or(&r.target_qn)
+                .yellow(),
             colorize_file(&r.target_file),
             colorize_line(r.target_line),
         ));
@@ -855,11 +865,17 @@ fn colorize_confidence(c: &str) -> String {
 fn colorize_file_path(qn: &str, file: &str) -> String {
     let display = if qn.contains("::") {
         let parts: Vec<&str> = qn.splitn(2, "::").collect();
-        if parts.len() == 2 { parts[0] } else { file }
+        if parts.len() == 2 {
+            parts[0]
+        } else {
+            file
+        }
     } else {
         file
     };
-    format!(" ({})", display).truecolor(100, 100, 100).to_string()
+    format!(" ({})", display)
+        .truecolor(100, 100, 100)
+        .to_string()
 }
 
 /// Terminal `::` segment of a qn, or the string unchanged when it's a
@@ -907,16 +923,22 @@ pub mod mcp {
             #[serde(default)]
             json: bool,
         }
-        fn default_dot() -> PathBuf { PathBuf::from(".") }
-        fn default_two() -> usize { 2 }
-        fn default_limit() -> usize { 200 }
-        fn default_mode() -> String { "all".into() }
+        fn default_dot() -> PathBuf {
+            PathBuf::from(".")
+        }
+        fn default_two() -> usize {
+            2
+        }
+        fn default_limit() -> usize {
+            200
+        }
+        fn default_mode() -> String {
+            "all".into()
+        }
 
         let a: Args = match serde_json::from_value(args) {
             Ok(v) => v,
-            Err(e) => {
-                return crate::mcp::tools::CallResult::Error(format!("bad args: {e}"))
-            }
+            Err(e) => return crate::mcp::tools::CallResult::Error(format!("bad args: {e}")),
         };
         let mode = match ImpactMode::parse(&a.mode) {
             Some(m) => m,
@@ -933,18 +955,12 @@ pub mod mcp {
         };
         let graph = match graph_cache::ensure_with_calls(&root, false) {
             Ok(g) => g,
-            Err(e) => {
-                return crate::mcp::tools::CallResult::Error(format!(
-                    "# error: {}", e
-                ))
-            }
+            Err(e) => return crate::mcp::tools::CallResult::Error(format!("# error: {}", e)),
         };
         let calls = match &graph.calls {
             Some(c) => c,
             None => {
-                return crate::mcp::tools::CallResult::Error(
-                    "# error: call graph is empty".into(),
-                )
+                return crate::mcp::tools::CallResult::Error("# error: call graph is empty".into())
             }
         };
         let candidates = resolve_target_full(calls, &a.target);

--- a/src/installers/claude_code.rs
+++ b/src/installers/claude_code.rs
@@ -125,7 +125,12 @@ impl Installer for ClaudeCode {
                 "Explore" => EXPLORE_FRONTMATTER,
                 _ => "",
             };
-            changes.push(common::install_subagent_in(&path, frontmatter, agent_prompt(), opts)?);
+            changes.push(common::install_subagent_in(
+                &path,
+                frontmatter,
+                agent_prompt(),
+                opts,
+            )?);
         }
         Ok(changes)
     }
@@ -150,9 +155,12 @@ impl Installer for ClaudeCode {
         if let Some(c) = common::uninstall_prompt_in(&self.prompt_path(scope)?, opts)? {
             changes.push(c);
         }
-        if let Some(c) =
-            common::uninstall_json_hook_in(&self.settings_path(scope)?, HOOK_PATH, matches_entry, opts)?
-        {
+        if let Some(c) = common::uninstall_json_hook_in(
+            &self.settings_path(scope)?,
+            HOOK_PATH,
+            matches_entry,
+            opts,
+        )? {
             changes.push(c);
         }
         for name in SHADOWED_SUBAGENTS {
@@ -314,14 +322,20 @@ mod tests {
         let s1 = ClaudeCode.status(&scope);
         assert!(s1.prompt_installed);
         assert!(s1.hook_installed);
-        assert_eq!(s1.prompt_version.as_deref(), Some(env!("CARGO_PKG_VERSION")));
+        assert_eq!(
+            s1.prompt_version.as_deref(),
+            Some(env!("CARGO_PKG_VERSION"))
+        );
     }
 
     #[test]
     fn dry_run_does_not_write() {
         let dir = TempDir::new().unwrap();
         let scope = local_scope(&dir);
-        let opts = InstallOpts { dry_run: true, ..Default::default() };
+        let opts = InstallOpts {
+            dry_run: true,
+            ..Default::default()
+        };
         ClaudeCode.install_prompt(&scope, &opts).unwrap();
         assert!(!dir.path().join("CLAUDE.md").exists());
     }
@@ -337,7 +351,10 @@ mod tests {
         assert!(matches!(changes[0], Change::Created(_)));
         let path = dir.path().join(".claude/agents/Explore.md");
         let contents = std::fs::read_to_string(&path).unwrap();
-        assert!(contents.starts_with("---\nname: Explore\n"), "frontmatter must be at offset 0");
+        assert!(
+            contents.starts_with("---\nname: Explore\n"),
+            "frontmatter must be at offset 0"
+        );
         assert!(contents.contains("<!-- ast-bro:begin"));
         assert!(contents.contains("ast-bro"));
     }
@@ -407,7 +424,9 @@ mod tests {
         let opts = InstallOpts::default();
         ClaudeCode.install_subagents(&scope, &opts).unwrap();
         let removed = ClaudeCode.uninstall(&scope, &opts).unwrap();
-        assert!(removed.iter().any(|c| matches!(c, Change::Removed(p) if p.ends_with("Explore.md"))));
+        assert!(removed
+            .iter()
+            .any(|c| matches!(c, Change::Removed(p) if p.ends_with("Explore.md"))));
         let contents = std::fs::read_to_string(&agent_path).unwrap();
         assert!(!contents.contains("ast-bro:begin"));
         assert!(contents.contains("Keep me."));
@@ -419,14 +438,19 @@ mod tests {
         let scope = local_scope(&dir);
         let opts = InstallOpts::default();
         let removed = ClaudeCode.uninstall(&scope, &opts).unwrap();
-        assert!(removed.iter().all(|c| !matches!(c, Change::Removed(p) if p.ends_with("Explore.md"))));
+        assert!(removed
+            .iter()
+            .all(|c| !matches!(c, Change::Removed(p) if p.ends_with("Explore.md"))));
     }
 
     #[test]
     fn install_subagents_dry_run_does_not_write() {
         let dir = TempDir::new().unwrap();
         let scope = local_scope(&dir);
-        let opts = InstallOpts { dry_run: true, ..Default::default() };
+        let opts = InstallOpts {
+            dry_run: true,
+            ..Default::default()
+        };
         ClaudeCode.install_subagents(&scope, &opts).unwrap();
         assert!(!dir.path().join(".claude/agents/Explore.md").exists());
     }
@@ -492,8 +516,7 @@ mod tests {
         ClaudeCode
             .install_mcp(&scope, &InstallOpts::default())
             .unwrap();
-        let v: Value =
-            serde_json::from_str(&std::fs::read_to_string(&mcp_path).unwrap()).unwrap();
+        let v: Value = serde_json::from_str(&std::fs::read_to_string(&mcp_path).unwrap()).unwrap();
         for i in 0..50 {
             assert_eq!(v[format!("key_{:02}", i)], json!(i), "key_{:02} lost", i);
         }
@@ -504,7 +527,10 @@ mod tests {
     fn install_mcp_dry_run_does_not_write() {
         let dir = TempDir::new().unwrap();
         let scope = local_scope(&dir);
-        let opts = InstallOpts { dry_run: true, ..Default::default() };
+        let opts = InstallOpts {
+            dry_run: true,
+            ..Default::default()
+        };
         ClaudeCode.install_mcp(&scope, &opts).unwrap();
         assert!(!dir.path().join(".mcp.json").exists());
     }
@@ -518,8 +544,7 @@ mod tests {
             .unwrap();
         assert!(matches!(change, Change::Created(_)));
         let contents =
-            std::fs::read_to_string(dir.path().join(".claude/skills/ast-bro/SKILL.md"))
-                .unwrap();
+            std::fs::read_to_string(dir.path().join(".claude/skills/ast-bro/SKILL.md")).unwrap();
         assert!(contents.starts_with("---\n"));
         assert!(contents.contains("name: ast-bro"));
         assert!(contents.contains("user-invocable: true"));
@@ -556,7 +581,10 @@ mod tests {
     fn install_skills_dry_run_does_not_write() {
         let dir = TempDir::new().unwrap();
         let scope = local_scope(&dir);
-        let opts = InstallOpts { dry_run: true, ..Default::default() };
+        let opts = InstallOpts {
+            dry_run: true,
+            ..Default::default()
+        };
         ClaudeCode.install_skills(&scope, &opts).unwrap();
         assert!(!dir.path().join(".claude/skills/ast-bro/SKILL.md").exists());
     }
@@ -574,8 +602,7 @@ mod tests {
         let opts = InstallOpts::default();
         ClaudeCode.install_mcp(&scope, &opts).unwrap();
         ClaudeCode.uninstall(&scope, &opts).unwrap();
-        let v: Value =
-            serde_json::from_str(&std::fs::read_to_string(&mcp_path).unwrap()).unwrap();
+        let v: Value = serde_json::from_str(&std::fs::read_to_string(&mcp_path).unwrap()).unwrap();
         assert!(v["mcpServers"].get("ast-bro").is_none());
         assert_eq!(v["mcpServers"]["other"]["command"], "x");
     }
@@ -591,7 +618,7 @@ mod tests {
         ClaudeCode.uninstall(&scope, &opts).unwrap();
         assert!(!skill_dir.join("SKILL.md").exists());
         assert!(!skill_dir.exists()); // empty parent removed
-        // .claude/skills/ stays intact (might be host to other skills).
+                                      // .claude/skills/ stays intact (might be host to other skills).
         assert!(dir.path().join(".claude/skills").exists());
     }
 

--- a/src/installers/codex.rs
+++ b/src/installers/codex.rs
@@ -126,8 +126,7 @@ impl Installer for Codex {
         if let Ok(cp) = self.config_path(scope) {
             if let Ok(Some(contents)) = super::io::read_optional(&cp) {
                 if let Ok(doc) = contents.parse::<DocumentMut>() {
-                    s.mcp_installed =
-                        toml_object::is_installed(&doc, MCP_PARENT, MCP_SERVER_NAME);
+                    s.mcp_installed = toml_object::is_installed(&doc, MCP_PARENT, MCP_SERVER_NAME);
                 }
             }
         }
@@ -162,11 +161,8 @@ mod tests {
     fn install_mcp_writes_codex_config_toml() {
         let dir = TempDir::new().unwrap();
         let scope = Scope::Local(dir.path().to_path_buf());
-        Codex
-            .install_mcp(&scope, &InstallOpts::default())
-            .unwrap();
-        let contents =
-            std::fs::read_to_string(dir.path().join(".codex/config.toml")).unwrap();
+        Codex.install_mcp(&scope, &InstallOpts::default()).unwrap();
+        let contents = std::fs::read_to_string(dir.path().join(".codex/config.toml")).unwrap();
         assert!(contents.contains("[mcp_servers.ast-bro]"));
         assert!(contents.contains("command = \"ast-bro\""));
         assert!(contents.contains("\"mcp\""));
@@ -183,9 +179,7 @@ mod tests {
         )
         .unwrap();
         let scope = Scope::Local(dir.path().to_path_buf());
-        Codex
-            .install_mcp(&scope, &InstallOpts::default())
-            .unwrap();
+        Codex.install_mcp(&scope, &InstallOpts::default()).unwrap();
         let out = std::fs::read_to_string(&p).unwrap();
         assert!(out.contains("# my codex config"), "comment lost: {}", out);
         assert!(out.contains("model = \"gpt-5\""));
@@ -201,10 +195,8 @@ mod tests {
             .install_skills(&scope, &InstallOpts::default())
             .unwrap();
         assert!(matches!(change, Change::Created(_)));
-        let contents = std::fs::read_to_string(
-            dir.path().join(".agents/skills/ast-bro/SKILL.md"),
-        )
-        .unwrap();
+        let contents =
+            std::fs::read_to_string(dir.path().join(".agents/skills/ast-bro/SKILL.md")).unwrap();
         assert!(contents.starts_with("---\n"));
         assert!(contents.contains("name: ast-bro"));
         assert!(contents.contains("## Use `sb` (the `ast-bro` toolkit) to explore the code"));

--- a/src/installers/common.rs
+++ b/src/installers/common.rs
@@ -16,11 +16,7 @@ use toml_edit::{DocumentMut, Table};
 /// ghost entries from older installs are cleaned up.
 pub const OLD_MCP_SERVER_NAME: &str = "ast-outline";
 
-pub fn install_prompt_in(
-    path: &Path,
-    snippet: &str,
-    opts: &InstallOpts,
-) -> Result<Change, String> {
+pub fn install_prompt_in(path: &Path, snippet: &str, opts: &InstallOpts) -> Result<Change, String> {
     let existing = read_optional(path)?.unwrap_or_default();
 
     let body = snippet.trim_end_matches('\n').to_string() + "\n";
@@ -79,7 +75,11 @@ pub fn install_subagent_in(
     let is_new = on_disk.is_empty();
     // When the file doesn't exist yet, seed `existing` with the frontmatter so
     // marker_block::apply appends the block after it rather than at offset 0.
-    let existing = if is_new { frontmatter.to_string() } else { on_disk.clone() };
+    let existing = if is_new {
+        frontmatter.to_string()
+    } else {
+        on_disk.clone()
+    };
 
     let body = snippet.trim_end_matches('\n').to_string() + "\n";
     let (new_contents, outcome) = marker_block::apply(
@@ -140,8 +140,8 @@ where
     F: Fn(&Value) -> bool,
 {
     let existing = read_optional(path)?.unwrap_or_else(|| "{}".into());
-    let mut root: Value = serde_json::from_str(&existing)
-        .map_err(|e| format!("parse {}: {}", path.display(), e))?;
+    let mut root: Value =
+        serde_json::from_str(&existing).map_err(|e| format!("parse {}: {}", path.display(), e))?;
     let modified = json_hook::upsert(&mut root, hook_path, entry, matches);
     if !modified {
         return Ok(Change::Skipped {
@@ -186,8 +186,8 @@ where
     let Some(existing) = read_optional(path)? else {
         return Ok(None);
     };
-    let mut root: Value = serde_json::from_str(&existing)
-        .map_err(|e| format!("parse {}: {}", path.display(), e))?;
+    let mut root: Value =
+        serde_json::from_str(&existing).map_err(|e| format!("parse {}: {}", path.display(), e))?;
     if !json_hook::remove(&mut root, hook_path, matches) {
         return Ok(None);
     }
@@ -207,8 +207,8 @@ pub fn install_mcp_in(
     opts: &InstallOpts,
 ) -> Result<Change, String> {
     let existing = read_optional(path)?.unwrap_or_else(|| "{}".into());
-    let mut root: Value = serde_json::from_str(&existing)
-        .map_err(|e| format!("parse {}: {}", path.display(), e))?;
+    let mut root: Value =
+        serde_json::from_str(&existing).map_err(|e| format!("parse {}: {}", path.display(), e))?;
 
     let mut modified = false;
     // Remove old name if it exists (migration)
@@ -246,8 +246,8 @@ pub fn uninstall_json_object_in(
     let Some(existing) = read_optional(path)? else {
         return Ok(None);
     };
-    let mut root: Value = serde_json::from_str(&existing)
-        .map_err(|e| format!("parse {}: {}", path.display(), e))?;
+    let mut root: Value =
+        serde_json::from_str(&existing).map_err(|e| format!("parse {}: {}", path.display(), e))?;
     if !json_object::remove(&mut root, key_path, key) {
         return Ok(None);
     }
@@ -363,8 +363,7 @@ pub fn uninstall_plain_file_in(
         return Ok(None);
     }
     if !opts.dry_run {
-        std::fs::remove_file(path)
-            .map_err(|e| format!("remove {}: {}", path.display(), e))?;
+        std::fs::remove_file(path).map_err(|e| format!("remove {}: {}", path.display(), e))?;
         if let Some(parent) = path.parent() {
             let _ = std::fs::remove_dir(parent); // succeeds only if empty
         }
@@ -432,7 +431,10 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("CLAUDE.md");
         std::fs::write(&path, "Use `ast-bro` to explore.\n").unwrap();
-        let opts = InstallOpts { force: true, ..Default::default() };
+        let opts = InstallOpts {
+            force: true,
+            ..Default::default()
+        };
         let change = install_prompt_in(&path, "## Snippet\n", &opts).unwrap();
         assert!(matches!(change, Change::Updated(_)));
         let after = std::fs::read_to_string(&path).unwrap();

--- a/src/installers/copilot.rs
+++ b/src/installers/copilot.rs
@@ -87,9 +87,12 @@ impl Installer for Copilot {
                 changes.push(c);
             }
             // Also remove legacy name from pre-rename installs
-            if let Some(c) =
-                common::uninstall_json_object_in(&path, MCP_KEY_PATH, common::OLD_MCP_SERVER_NAME, opts)?
-            {
+            if let Some(c) = common::uninstall_json_object_in(
+                &path,
+                MCP_KEY_PATH,
+                common::OLD_MCP_SERVER_NAME,
+                opts,
+            )? {
                 changes.push(c);
             }
         }
@@ -155,7 +158,11 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let p = dir.path().join(".vscode/mcp.json");
         std::fs::create_dir_all(p.parent().unwrap()).unwrap();
-        std::fs::write(&p, r#"{"servers":{"docs":{"type":"http","url":"https://x"}}}"#).unwrap();
+        std::fs::write(
+            &p,
+            r#"{"servers":{"docs":{"type":"http","url":"https://x"}}}"#,
+        )
+        .unwrap();
         let scope = Scope::Local(dir.path().to_path_buf());
         Copilot
             .install_mcp(&scope, &InstallOpts::default())

--- a/src/installers/cursor.rs
+++ b/src/installers/cursor.rs
@@ -137,9 +137,7 @@ mod tests {
     fn install_mcp_writes_cursor_mcp_json() {
         let dir = TempDir::new().unwrap();
         let scope = Scope::Local(dir.path().to_path_buf());
-        let change = Cursor
-            .install_mcp(&scope, &InstallOpts::default())
-            .unwrap();
+        let change = Cursor.install_mcp(&scope, &InstallOpts::default()).unwrap();
         assert!(matches!(change, Change::Created(_)));
         let v: Value = serde_json::from_str(
             &std::fs::read_to_string(dir.path().join(".cursor/mcp.json")).unwrap(),

--- a/src/installers/gemini.rs
+++ b/src/installers/gemini.rs
@@ -108,9 +108,12 @@ impl Installer for Gemini {
         if let Some(c) = common::uninstall_prompt_in(&self.prompt_path(scope)?, opts)? {
             changes.push(c);
         }
-        if let Some(c) =
-            common::uninstall_json_hook_in(&self.settings_path(scope)?, HOOK_PATH, matches_entry, opts)?
-        {
+        if let Some(c) = common::uninstall_json_hook_in(
+            &self.settings_path(scope)?,
+            HOOK_PATH,
+            matches_entry,
+            opts,
+        )? {
             changes.push(c);
         }
         // Remove current MCP server name

--- a/src/installers/io.rs
+++ b/src/installers/io.rs
@@ -24,21 +24,15 @@ pub fn atomic_write(path: &Path, contents: &str) -> Result<(), String> {
     }
     let tmp = path.with_extension(tmp_extension(path));
     {
-        let mut f = fs::File::create(&tmp)
-            .map_err(|e| format!("create temp {}: {}", tmp.display(), e))?;
+        let mut f =
+            fs::File::create(&tmp).map_err(|e| format!("create temp {}: {}", tmp.display(), e))?;
         f.write_all(contents.as_bytes())
             .map_err(|e| format!("write temp {}: {}", tmp.display(), e))?;
         f.sync_all()
             .map_err(|e| format!("fsync temp {}: {}", tmp.display(), e))?;
     }
-    fs::rename(&tmp, path).map_err(|e| {
-        format!(
-            "rename temp {} -> {}: {}",
-            tmp.display(),
-            path.display(),
-            e
-        )
-    })?;
+    fs::rename(&tmp, path)
+        .map_err(|e| format!("rename temp {} -> {}: {}", tmp.display(), path.display(), e))?;
     Ok(())
 }
 

--- a/src/installers/json_hook.rs
+++ b/src/installers/json_hook.rs
@@ -66,9 +66,13 @@ fn ensure_array<'a>(root: &'a mut Value, path: &[&str]) -> &'a mut Vec<Value> {
     for (i, key) in path.iter().enumerate() {
         let is_last = i + 1 == path.len();
         let obj = current.as_object_mut().unwrap();
-        let entry = obj
-            .entry((*key).to_string())
-            .or_insert_with(|| if is_last { json!([]) } else { json!({}) });
+        let entry = obj.entry((*key).to_string()).or_insert_with(|| {
+            if is_last {
+                json!([])
+            } else {
+                json!({})
+            }
+        });
         if is_last {
             if !entry.is_array() {
                 *entry = json!([]);
@@ -203,7 +207,9 @@ mod tests {
     #[test]
     fn matches_any_marker_accepts_legacy_and_current() {
         assert!(matches_any_marker("ast-bro hook --protocol claude-code"));
-        assert!(matches_any_marker("ast-outline hook --protocol claude-code"));
+        assert!(matches_any_marker(
+            "ast-outline hook --protocol claude-code"
+        ));
         assert!(!matches_any_marker("echo hi"));
     }
 

--- a/src/installers/json_object.rs
+++ b/src/installers/json_object.rs
@@ -37,9 +37,7 @@ fn ensure_object<'a>(root: &'a mut Value, path: &[&str]) -> &'a mut Map<String, 
     let mut current = root;
     for key in path {
         let obj = current.as_object_mut().unwrap();
-        let entry = obj
-            .entry((*key).to_string())
-            .or_insert_with(|| json!({}));
+        let entry = obj.entry((*key).to_string()).or_insert_with(|| json!({}));
         if !entry.is_object() {
             *entry = json!({});
         }
@@ -56,7 +54,10 @@ fn navigate_object<'a>(root: &'a Value, path: &[&str]) -> Option<&'a Map<String,
     current.as_object()
 }
 
-fn navigate_object_mut<'a>(root: &'a mut Value, path: &[&str]) -> Option<&'a mut Map<String, Value>> {
+fn navigate_object_mut<'a>(
+    root: &'a mut Value,
+    path: &[&str],
+) -> Option<&'a mut Map<String, Value>> {
     let mut current = root;
     for key in path {
         current = current.as_object_mut()?.get_mut(*key)?;
@@ -158,9 +159,7 @@ mod tests {
     fn key_insertion_order_preserved() {
         let mut root = Value::Object(Map::new());
         for name in ["alpha", "beta", "gamma"] {
-            root.as_object_mut()
-                .unwrap()
-                .insert(name.into(), json!({}));
+            root.as_object_mut().unwrap().insert(name.into(), json!({}));
         }
         upsert(&mut root, &["mcpServers"], "ast-bro", entry());
         let keys: Vec<&String> = root.as_object().unwrap().keys().collect();

--- a/src/installers/marker_block.rs
+++ b/src/installers/marker_block.rs
@@ -29,7 +29,10 @@ pub fn apply(
         let current_body = &file_contents[start.body_start..end.body_end];
         if !force && current_body.trim() != expected_block_body.trim() {
             let diff = simple_diff(current_body, new_block_body);
-            return (file_contents.to_string(), ApplyOutcome::UserEditsBlocked(diff));
+            return (
+                file_contents.to_string(),
+                ApplyOutcome::UserEditsBlocked(diff),
+            );
         }
         let mut out = String::with_capacity(file_contents.len());
         out.push_str(&file_contents[..start.line_start]);

--- a/src/installers/mod.rs
+++ b/src/installers/mod.rs
@@ -1,17 +1,17 @@
-pub mod paths;
+pub mod aider;
+pub mod claude_code;
+pub mod codex;
+pub mod common;
+pub mod copilot;
+pub mod cursor;
+pub mod gemini;
 pub mod io;
-pub mod marker_block;
 pub mod json_hook;
 pub mod json_object;
-pub mod toml_object;
-pub mod common;
-pub mod claude_code;
-pub mod gemini;
+pub mod marker_block;
+pub mod paths;
 pub mod tabnine;
-pub mod cursor;
-pub mod aider;
-pub mod codex;
-pub mod copilot;
+pub mod toml_object;
 
 use std::path::PathBuf;
 
@@ -68,7 +68,11 @@ pub trait Installer: Sync + Send {
     fn detect(&self, scope: &Scope) -> Detection;
     fn install_prompt(&self, scope: &Scope, opts: &InstallOpts) -> Result<Change, String>;
     fn install_hook(&self, scope: &Scope, opts: &InstallOpts) -> Result<Change, String>;
-    fn install_subagents(&self, _scope: &Scope, _opts: &InstallOpts) -> Result<Vec<Change>, String> {
+    fn install_subagents(
+        &self,
+        _scope: &Scope,
+        _opts: &InstallOpts,
+    ) -> Result<Vec<Change>, String> {
         Ok(Vec::new())
     }
     fn install_mcp(&self, _scope: &Scope, _opts: &InstallOpts) -> Result<Change, String> {

--- a/src/installers/tabnine.rs
+++ b/src/installers/tabnine.rs
@@ -105,9 +105,12 @@ impl Installer for Tabnine {
         if let Some(c) = common::uninstall_prompt_in(&self.old_prompt_path(scope)?, opts)? {
             changes.push(c);
         }
-        if let Some(c) =
-            common::uninstall_json_hook_in(&self.settings_path(scope)?, HOOK_PATH, matches_entry, opts)?
-        {
+        if let Some(c) = common::uninstall_json_hook_in(
+            &self.settings_path(scope)?,
+            HOOK_PATH,
+            matches_entry,
+            opts,
+        )? {
             changes.push(c);
         }
         Ok(changes)

--- a/src/main_helpers.rs
+++ b/src/main_helpers.rs
@@ -110,9 +110,12 @@ pub fn parse_file_for_hook(path: &Path) -> Option<ParseResult> {
             source.as_bytes(),
             lang.ast_grep(source.clone()).root(),
         ),
-        SupportLang::TypeScript | SupportLang::Tsx | SupportLang::JavaScript => {
-            TypeScriptAdapter.parse(path, source.as_bytes(), lang.ast_grep(source.clone()).root())
-        }
+        SupportLang::TypeScript | SupportLang::Tsx | SupportLang::JavaScript => TypeScriptAdapter
+            .parse(
+                path,
+                source.as_bytes(),
+                lang.ast_grep(source.clone()).root(),
+            ),
         SupportLang::CSharp => CSharpAdapter.parse(
             path,
             source.as_bytes(),

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -13,9 +13,7 @@ pub(crate) mod tools;
 use serde_json::{json, Value};
 use std::io::{BufRead, Write};
 
-use protocol::{
-    Request, Response, INTERNAL_ERROR, INVALID_PARAMS, METHOD_NOT_FOUND, PARSE_ERROR,
-};
+use protocol::{Request, Response, INTERNAL_ERROR, INVALID_PARAMS, METHOD_NOT_FOUND, PARSE_ERROR};
 
 /// MCP protocol revision we advertise. Matches the spec at the time of
 /// implementation; bump when adopting newer revisions.
@@ -49,11 +47,7 @@ pub fn run() -> i32 {
                 }
             }
             Err(e) => {
-                let resp = Response::err(
-                    Value::Null,
-                    PARSE_ERROR,
-                    format!("parse error: {}", e),
-                );
+                let resp = Response::err(Value::Null, PARSE_ERROR, format!("parse error: {}", e));
                 if let Err(e) = write_message(&mut out, &resp) {
                     eprintln!("ast-bro mcp: stdout write error: {}", e);
                     return 1;
@@ -129,11 +123,13 @@ fn tools_call(params: Value) -> Result<Value, (i32, String)> {
         .and_then(|v| v.as_str())
         .ok_or((INVALID_PARAMS, "missing `name`".into()))?
         .to_string();
-    let args = params.get("arguments").cloned().unwrap_or(Value::Object(Default::default()));
+    let args = params
+        .get("arguments")
+        .cloned()
+        .unwrap_or(Value::Object(Default::default()));
 
-    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        tools::call(&name, args)
-    }));
+    let result =
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| tools::call(&name, args)));
 
     match result {
         Ok(tools::CallResult::Text(text)) => Ok(json!({
@@ -147,4 +143,3 @@ fn tools_call(params: Value) -> Result<Value, (i32, String)> {
         Err(_) => Err((INTERNAL_ERROR, format!("tool `{}` panicked", name))),
     }
 }
-

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -4,9 +4,7 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 use std::path::PathBuf;
 
-use crate::core::{
-    self, DigestOptions, MapOptions,
-};
+use crate::core::{self, DigestOptions, MapOptions};
 
 /// Static descriptors returned to clients via `tools/list`.
 pub fn list() -> Value {
@@ -335,25 +333,25 @@ pub enum CallResult {
 
 pub fn call(name: &str, args: Value) -> CallResult {
     match name {
-        "map"          => run_map(args),
-        "digest"       => run_digest(args),
-        "show"         => run_show(args),
-        "implements"   => run_implements(args),
-        "surface"      => run_surface(args),
-        "deps"         => run_deps(args),
+        "map" => run_map(args),
+        "digest" => run_digest(args),
+        "show" => run_show(args),
+        "implements" => run_implements(args),
+        "surface" => run_surface(args),
+        "deps" => run_deps(args),
         "reverse_deps" => run_reverse_deps(args),
-        "cycles"       => run_cycles(args),
-        "graph"        => run_graph(args),
-        "search"       => crate::search::mcp::run_search(args),
+        "cycles" => run_cycles(args),
+        "graph" => run_graph(args),
+        "search" => crate::search::mcp::run_search(args),
         "find_related" => crate::search::mcp::run_find_related(args),
-        "index"        => crate::search::mcp::run_index(args),
-        "callers"      => run_callers(args),
-        "callees"      => run_callees(args),
-        "trace"        => run_trace(args),
-        "impact"       => crate::impact::mcp::run_impact(args),
-        "context"      => crate::context::mcp::run_context(args),
-        "run"          => run_run(args),
-        "squeeze"      => run_squeeze(args),
+        "index" => crate::search::mcp::run_index(args),
+        "callers" => run_callers(args),
+        "callees" => run_callees(args),
+        "trace" => run_trace(args),
+        "impact" => crate::impact::mcp::run_impact(args),
+        "context" => crate::context::mcp::run_context(args),
+        "run" => run_run(args),
+        "squeeze" => run_squeeze(args),
         other => CallResult::Error(format!("unknown tool: {}", other)),
     }
 }
@@ -390,9 +388,15 @@ struct CalleesArgs {
     json: bool,
 }
 
-fn default_one() -> usize { 1 }
-fn default_two_hundred() -> usize { 200 }
-fn default_dot() -> PathBuf { PathBuf::from(".") }
+fn default_one() -> usize {
+    1
+}
+fn default_two_hundred() -> usize {
+    200
+}
+fn default_dot() -> PathBuf {
+    PathBuf::from(".")
+}
 
 /// Back-compat shim for renamed boolean args. Pre-rename clients sent
 /// `include_ambiguous` / `external` / `include_external` (true = show);
@@ -439,7 +443,8 @@ fn run_callees(mut args: Value) -> CallResult {
         Ok(r) => r,
         Err(e) => return CallResult::Error(e),
     };
-    let out = crate::calls::mcp::run_callees_text(&a.target, &root, a.depth, !a.hide_external, a.json);
+    let out =
+        crate::calls::mcp::run_callees_text(&a.target, &root, a.depth, !a.hide_external, a.json);
     CallResult::Text(out)
 }
 
@@ -455,7 +460,9 @@ struct TraceArgs {
     json: bool,
 }
 
-fn default_trace_depth() -> usize { 12 }
+fn default_trace_depth() -> usize {
+    12
+}
 
 fn run_trace(args: Value) -> CallResult {
     let a: TraceArgs = match serde_json::from_value(args) {
@@ -473,13 +480,20 @@ fn run_trace(args: Value) -> CallResult {
 #[derive(Deserialize, Default)]
 struct MapArgs {
     paths: Vec<PathBuf>,
-    #[serde(default)] no_private: bool,
-    #[serde(default)] no_fields: bool,
-    #[serde(default)] no_docs: bool,
-    #[serde(default)] no_attrs: bool,
-    #[serde(default)] no_lines: bool,
-    #[serde(default)] glob: Option<String>,
-    #[serde(default)] json: bool,
+    #[serde(default)]
+    no_private: bool,
+    #[serde(default)]
+    no_fields: bool,
+    #[serde(default)]
+    no_docs: bool,
+    #[serde(default)]
+    no_attrs: bool,
+    #[serde(default)]
+    no_lines: bool,
+    #[serde(default)]
+    glob: Option<String>,
+    #[serde(default)]
+    json: bool,
 }
 
 fn run_map(args: Value) -> CallResult {
@@ -515,13 +529,19 @@ fn run_map(args: Value) -> CallResult {
 #[derive(Deserialize, Default)]
 struct DigestArgs {
     paths: Vec<PathBuf>,
-    #[serde(default)] include_private: bool,
-    #[serde(default)] include_fields: bool,
-    #[serde(default = "default_max_members")] max_members: usize,
-    #[serde(default)] json: bool,
+    #[serde(default)]
+    include_private: bool,
+    #[serde(default)]
+    include_fields: bool,
+    #[serde(default = "default_max_members")]
+    max_members: usize,
+    #[serde(default)]
+    json: bool,
 }
 
-fn default_max_members() -> usize { 50 }
+fn default_max_members() -> usize {
+    50
+}
 
 fn run_digest(args: Value) -> CallResult {
     let a: DigestArgs = match serde_json::from_value(args) {
@@ -563,7 +583,8 @@ fn run_digest(args: Value) -> CallResult {
 struct ShowArgs {
     path: PathBuf,
     symbols: Vec<String>,
-    #[serde(default)] json: bool,
+    #[serde(default)]
+    json: bool,
 }
 
 fn run_show(args: Value) -> CallResult {
@@ -597,7 +618,11 @@ fn run_show(args: Value) -> CallResult {
         for m in &all {
             out.push_str(&format!(
                 "# {}:{}-{} {} ({})\n",
-                res.path.display(), m.start_line, m.end_line, m.qualified_name, m.kind
+                res.path.display(),
+                m.start_line,
+                m.end_line,
+                m.qualified_name,
+                m.kind
             ));
             if !m.ancestor_signatures.is_empty() {
                 out.push_str(&format!("# in: {}\n", m.ancestor_signatures.join(" → ")));
@@ -613,20 +638,28 @@ fn run_show(args: Value) -> CallResult {
 struct ImplementsArgs {
     target: String,
     paths: Vec<PathBuf>,
-    #[serde(default)] direct: bool,
-    #[serde(default)] json: bool,
+    #[serde(default)]
+    direct: bool,
+    #[serde(default)]
+    json: bool,
 }
 
 #[derive(Deserialize, Default)]
 struct SurfaceArgs {
     #[serde(default = "default_surface_path")]
     path: PathBuf,
-    #[serde(default)] tree: bool,
-    #[serde(default)] include_chain: bool,
-    #[serde(default = "default_surface_max_depth")] max_depth: usize,
-    #[serde(default)] include_private: bool,
-    #[serde(default)] lang: Option<String>,
-    #[serde(default)] json: bool,
+    #[serde(default)]
+    tree: bool,
+    #[serde(default)]
+    include_chain: bool,
+    #[serde(default = "default_surface_max_depth")]
+    max_depth: usize,
+    #[serde(default)]
+    include_private: bool,
+    #[serde(default)]
+    lang: Option<String>,
+    #[serde(default)]
+    json: bool,
 }
 
 fn default_surface_path() -> PathBuf {
@@ -663,9 +696,11 @@ fn run_surface(args: Value) -> CallResult {
         lang_override,
     };
     match crate::surface::resolve_surface(&a.path, &opts) {
-        Ok(entries) => {
-            CallResult::Text(crate::surface::render::render(&entries, output, a.include_chain))
-        }
+        Ok(entries) => CallResult::Text(crate::surface::render::render(
+            &entries,
+            output,
+            a.include_chain,
+        )),
         Err(e) => CallResult::Error(format!("{e}")),
     }
 }
@@ -683,11 +718,14 @@ fn run_implements(args: Value) -> CallResult {
     let matches = core::find_implementations(&results, &a.target, transitive);
 
     if a.json {
-        CallResult::Text(core::render_json_implements(&a.target, &matches, transitive, true))
+        CallResult::Text(core::render_json_implements(
+            &a.target, &matches, transitive, true,
+        ))
     } else {
         let mut out = format!(
             "# {} match(es) for '{}' (incl. transitive):\n",
-            matches.len(), a.target
+            matches.len(),
+            a.target
         );
         for m in &matches {
             let via = if m.via.is_empty() {
@@ -695,7 +733,10 @@ fn run_implements(args: Value) -> CallResult {
             } else {
                 format!(" [via {}]", m.via.last().unwrap())
             };
-            out.push_str(&format!("{}:{}  {} {}{}\n", m.path, m.start_line, m.kind, m.name, via));
+            out.push_str(&format!(
+                "{}:{}  {} {}{}\n",
+                m.path, m.start_line, m.kind, m.name, via
+            ));
         }
         CallResult::Text(out)
     }
@@ -706,41 +747,65 @@ fn run_implements(args: Value) -> CallResult {
 #[derive(Deserialize, Default)]
 struct DepsArgs {
     file: PathBuf,
-    #[serde(default = "default_depth")] depth: usize,
-    #[serde(default)] hide_external: bool,
-    #[serde(default)] rebuild: bool,
-    #[serde(default)] json: bool,
+    #[serde(default = "default_depth")]
+    depth: usize,
+    #[serde(default)]
+    hide_external: bool,
+    #[serde(default)]
+    rebuild: bool,
+    #[serde(default)]
+    json: bool,
 }
 
 #[derive(Deserialize, Default)]
 struct ReverseDepsArgs {
     file: PathBuf,
-    #[serde(default = "default_depth")] depth: usize,
-    #[serde(default = "default_limit")] limit: usize,
-    #[serde(default)] rebuild: bool,
-    #[serde(default)] json: bool,
+    #[serde(default = "default_depth")]
+    depth: usize,
+    #[serde(default = "default_limit")]
+    limit: usize,
+    #[serde(default)]
+    rebuild: bool,
+    #[serde(default)]
+    json: bool,
 }
 
 #[derive(Deserialize, Default)]
 struct CyclesArgs {
-    #[serde(default = "default_path")] path: PathBuf,
-    #[serde(default = "default_min_size")] min_size: usize,
-    #[serde(default)] rebuild: bool,
-    #[serde(default)] json: bool,
+    #[serde(default = "default_path")]
+    path: PathBuf,
+    #[serde(default = "default_min_size")]
+    min_size: usize,
+    #[serde(default)]
+    rebuild: bool,
+    #[serde(default)]
+    json: bool,
 }
 
 #[derive(Deserialize, Default)]
 struct GraphArgs {
-    #[serde(default = "default_path")] path: PathBuf,
-    #[serde(default)] json: bool,
-    #[serde(default)] hide_external: bool,
-    #[serde(default)] rebuild: bool,
+    #[serde(default = "default_path")]
+    path: PathBuf,
+    #[serde(default)]
+    json: bool,
+    #[serde(default)]
+    hide_external: bool,
+    #[serde(default)]
+    rebuild: bool,
 }
 
-fn default_depth() -> usize { 3 }
-fn default_limit() -> usize { 200 }
-fn default_min_size() -> usize { 2 }
-fn default_path() -> PathBuf { PathBuf::from(".") }
+fn default_depth() -> usize {
+    3
+}
+fn default_limit() -> usize {
+    200
+}
+fn default_min_size() -> usize {
+    2
+}
+fn default_path() -> PathBuf {
+    PathBuf::from(".")
+}
 
 fn run_deps(mut args: Value) -> CallResult {
     translate_renamed_bool(&mut args, "external", "hide_external");
@@ -767,9 +832,20 @@ fn run_deps(mut args: Value) -> CallResult {
     };
     let hits = crate::deps::traverse::forward(&graph, &canon, a.depth.max(1));
     if a.json {
-        CallResult::Text(crate::deps::render::render_deps_json(&graph, &canon, &hits, !a.hide_external, true))
+        CallResult::Text(crate::deps::render::render_deps_json(
+            &graph,
+            &canon,
+            &hits,
+            !a.hide_external,
+            true,
+        ))
     } else {
-        CallResult::Text(crate::deps::render::render_deps_text(&graph, &canon, &hits, !a.hide_external))
+        CallResult::Text(crate::deps::render::render_deps_text(
+            &graph,
+            &canon,
+            &hits,
+            !a.hide_external,
+        ))
     }
 }
 
@@ -797,9 +873,13 @@ fn run_reverse_deps(args: Value) -> CallResult {
     };
     let hits = crate::deps::traverse::reverse(&graph, &canon, a.depth.max(1), a.limit, |_| true);
     if a.json {
-        CallResult::Text(crate::deps::render::render_reverse_deps_json(&graph, &canon, &hits, true))
+        CallResult::Text(crate::deps::render::render_reverse_deps_json(
+            &graph, &canon, &hits, true,
+        ))
     } else {
-        CallResult::Text(crate::deps::render::render_reverse_deps_text(&graph, &canon, &hits))
+        CallResult::Text(crate::deps::render::render_reverse_deps_text(
+            &graph, &canon, &hits,
+        ))
     }
 }
 
@@ -823,7 +903,9 @@ fn run_cycles(args: Value) -> CallResult {
     };
     let cycles = crate::deps::scc::detect(&graph, a.min_size);
     if a.json {
-        CallResult::Text(crate::deps::render::render_cycles_json(&graph, &cycles, true))
+        CallResult::Text(crate::deps::render::render_cycles_json(
+            &graph, &cycles, true,
+        ))
     } else {
         CallResult::Text(crate::deps::render::render_cycles_text(&graph, &cycles))
     }
@@ -915,7 +997,7 @@ fn run_run(args: Value) -> CallResult {
         a.paths
     };
     let files = crate::walk_paths(&search_paths, a.glob.as_deref());
-    
+
     #[derive(serde::Serialize)]
     struct RewriteRecord {
         file: String,
@@ -940,7 +1022,10 @@ fn run_run(args: Value) -> CallResult {
     // Cache compiled patterns per language when lang is auto-detected,
     // so files of the same language reuse the compiled pattern.
     // Stores Result<Pattern, String> — Err when the pattern is invalid for that language.
-    let mut pattern_cache: std::collections::HashMap<ast_grep_language::SupportLang, Result<ast_grep_core::Pattern, String>> = std::collections::HashMap::new();
+    let mut pattern_cache: std::collections::HashMap<
+        ast_grep_language::SupportLang,
+        Result<ast_grep_core::Pattern, String>,
+    > = std::collections::HashMap::new();
 
     for path in &files {
         // Detect language first to avoid reading non-source files.
@@ -999,7 +1084,7 @@ fn run_run(args: Value) -> CallResult {
                 }
                 error_count += 1;
                 continue;
-            },
+            }
         };
 
         // Search-only mode (no rewrite template)
@@ -1160,15 +1245,16 @@ fn run_run(args: Value) -> CallResult {
                 cap_limit: MCP_REWRITE_MAX_FILES,
                 files: &rewrite_records,
             };
-            return CallResult::Text(
-                serde_json::to_string_pretty(&doc).unwrap_or_default(),
-            );
+            return CallResult::Text(serde_json::to_string_pretty(&doc).unwrap_or_default());
         }
         if rewrite_count == 0 && !rewrite_capped && error_count == 0 {
             output.push_str("No matches found for rewrite.");
         }
         if rewrite_capped {
-            output.push_str(&format!("\n# warning: reached safety cap of {} files; remaining files were not processed.", MCP_REWRITE_MAX_FILES));
+            output.push_str(&format!(
+                "\n# warning: reached safety cap of {} files; remaining files were not processed.",
+                MCP_REWRITE_MAX_FILES
+            ));
         }
         if error_count > 0 {
             output.push_str(&format!("\n({} files had errors)", error_count));
@@ -1202,10 +1288,17 @@ fn run_run(args: Value) -> CallResult {
         } else {
             let matched_files: std::collections::HashSet<&str> =
                 all_matches.iter().map(|m| m.file.as_str()).collect();
-            output.push_str(&format!("Found {} matches in {} files:\n", all_matches.len(), matched_files.len()));
+            output.push_str(&format!(
+                "Found {} matches in {} files:\n",
+                all_matches.len(),
+                matched_files.len()
+            ));
             for m in all_matches {
                 let first_line = m.matched_text.lines().next().unwrap_or("");
-                output.push_str(&format!("{}:{}:{}-{}:{}: {}\n", m.file, m.start_line, m.start_col, m.end_line, m.end_col, first_line));
+                output.push_str(&format!(
+                    "{}:{}:{}-{}:{}: {}\n",
+                    m.file, m.start_line, m.start_col, m.end_line, m.end_col, first_line
+                ));
             }
         }
         if !search_errors.is_empty() {
@@ -1230,10 +1323,14 @@ fn run_run(args: Value) -> CallResult {
 #[derive(Deserialize)]
 struct SqueezeArgs {
     path: PathBuf,
-    #[serde(default)] start: Option<usize>,
-    #[serde(default)] end: Option<usize>,
-    #[serde(default)] raw: bool,
-    #[serde(default)] json: bool,
+    #[serde(default)]
+    start: Option<usize>,
+    #[serde(default)]
+    end: Option<usize>,
+    #[serde(default)]
+    raw: bool,
+    #[serde(default)]
+    json: bool,
 }
 
 fn run_squeeze(args: Value) -> CallResult {

--- a/src/project_root.rs
+++ b/src/project_root.rs
@@ -60,7 +60,10 @@ pub fn resolve_home(path_arg: &Path, cwd: &Path, marker: Marker) -> (PathBuf, bo
     let start_dir: PathBuf = if abs_path.is_dir() {
         abs_path.clone()
     } else {
-        abs_path.parent().map(Path::to_path_buf).unwrap_or(abs_path.clone())
+        abs_path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or(abs_path.clone())
     };
 
     let mut cur = start_dir.as_path();
@@ -123,9 +126,7 @@ pub fn find_root_for(file: &Path) -> Result<PathBuf, String> {
     loop {
         // Guard: with a manifest in hand, never treat $HOME or its
         // ancestors as a candidate root.
-        if nearest_manifest.is_some()
-            && home.as_deref().is_some_and(|h| h.starts_with(cur))
-        {
+        if nearest_manifest.is_some() && home.as_deref().is_some_and(|h| h.starts_with(cur)) {
             break;
         }
         if cur.join(".git").exists() {
@@ -151,9 +152,7 @@ pub fn find_root_for(file: &Path) -> Result<PathBuf, String> {
     Ok(if abs.is_dir() {
         abs
     } else {
-        abs.parent()
-            .ok_or("no parent directory")?
-            .to_path_buf()
+        abs.parent().ok_or("no parent directory")?.to_path_buf()
     })
 }
 
@@ -362,10 +361,7 @@ mod tests {
 
     #[test]
     fn compare_corpus_subset_explicit() {
-        assert_eq!(
-            compare_corpus("packages", "packages/a"),
-            CorpusRel::Subset
-        );
+        assert_eq!(compare_corpus("packages", "packages/a"), CorpusRel::Subset);
         assert_eq!(compare_corpus("packages", "packages"), CorpusRel::Subset);
     }
 
@@ -410,23 +406,13 @@ mod tests {
         let dir = tempdir().unwrap();
         let cwd = dir.path();
         fs::create_dir_all(cwd.join(".ast-bro").join("index")).unwrap();
-        fs::write(
-            cwd.join(".ast-bro").join("index").join("meta.json"),
-            "{}",
-        )
-        .unwrap();
+        fs::write(cwd.join(".ast-bro").join("index").join("meta.json"), "{}").unwrap();
         fs::create_dir_all(cwd.join("packages").join("xyz")).unwrap();
 
-        let (home, found) = resolve_home(
-            &cwd.join("packages").join("xyz"),
-            cwd,
-            Marker::SearchIndex,
-        );
+        let (home, found) =
+            resolve_home(&cwd.join("packages").join("xyz"), cwd, Marker::SearchIndex);
         assert!(found);
-        assert_eq!(
-            home.canonicalize().unwrap(),
-            cwd.canonicalize().unwrap()
-        );
+        assert_eq!(home.canonicalize().unwrap(), cwd.canonicalize().unwrap());
     }
 
     #[test]
@@ -438,10 +424,7 @@ mod tests {
         let (home, found) =
             resolve_home(&cwd.join("packages").join("xyz"), cwd, Marker::SearchIndex);
         assert!(!found);
-        assert_eq!(
-            home.canonicalize().unwrap(),
-            cwd.canonicalize().unwrap()
-        );
+        assert_eq!(home.canonicalize().unwrap(), cwd.canonicalize().unwrap());
     }
 
     #[test]
@@ -451,21 +434,13 @@ mod tests {
         let dir = tempdir().unwrap();
         let outer = dir.path();
         fs::create_dir_all(outer.join(".ast-bro").join("index")).unwrap();
-        fs::write(
-            outer.join(".ast-bro").join("index").join("meta.json"),
-            "{}",
-        )
-        .unwrap();
+        fs::write(outer.join(".ast-bro").join("index").join("meta.json"), "{}").unwrap();
         let inner = outer.join("inner");
         fs::create_dir_all(inner.join("sub")).unwrap();
 
-        let (home, found) =
-            resolve_home(&inner.join("sub"), &inner, Marker::SearchIndex);
+        let (home, found) = resolve_home(&inner.join("sub"), &inner, Marker::SearchIndex);
         assert!(!found);
-        assert_eq!(
-            home.canonicalize().unwrap(),
-            inner.canonicalize().unwrap()
-        );
+        assert_eq!(home.canonicalize().unwrap(), inner.canonicalize().unwrap());
     }
 
     #[test]
@@ -475,8 +450,7 @@ mod tests {
         let cwd = cwd_dir.path();
         fs::create_dir_all(outer.path().join("a")).unwrap();
 
-        let (home, found) =
-            resolve_home(&outer.path().join("a"), cwd, Marker::SearchIndex);
+        let (home, found) = resolve_home(&outer.path().join("a"), cwd, Marker::SearchIndex);
         assert!(!found);
         // Resolves to the path arg itself (canonicalized), not cwd.
         assert_eq!(

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -102,7 +102,11 @@ mod tests {
     #[test]
     fn round_trip_matches_skill_md() {
         let expected = strip_frontmatter(SKILL_MD);
-        assert_eq!(agent_prompt(), expected, "memoized value must equal fresh strip");
+        assert_eq!(
+            agent_prompt(),
+            expected,
+            "memoized value must equal fresh strip"
+        );
         assert!(
             SKILL_MD.contains(expected),
             "stripped body must appear verbatim inside SKILL.md"

--- a/src/run/cli.rs
+++ b/src/run/cli.rs
@@ -67,7 +67,10 @@ pub fn run(
         (None, None)
     };
     // Cache compiled patterns per language when lang is auto-detected.
-    let mut pattern_cache: std::collections::HashMap<ast_grep_language::SupportLang, Result<ast_grep_core::Pattern, String>> = std::collections::HashMap::new();
+    let mut pattern_cache: std::collections::HashMap<
+        ast_grep_language::SupportLang,
+        Result<ast_grep_core::Pattern, String>,
+    > = std::collections::HashMap::new();
 
     for path in &files {
         // Detect language first to avoid reading non-source files.
@@ -100,7 +103,7 @@ pub fn run(
                 eprintln!("{}: read failed: {}", path.display(), e);
                 error_count += 1;
                 continue;
-            },
+            }
         };
 
         if let Some(replacement) = rewrite_template {
@@ -179,7 +182,7 @@ pub fn run(
                         eprintln!("{}: {}", path.display(), e);
                     }
                     error_count += 1;
-                },
+                }
             }
         } else {
             let result = if let Some(ref compiled) = compiled_pattern {
@@ -206,14 +209,15 @@ pub fn run(
                         if json {
                             json_matches.push(m);
                         } else {
-                            let first_line = m
-                                .matched_text
-                                .lines()
-                                .next()
-                                .unwrap_or("");
+                            let first_line = m.matched_text.lines().next().unwrap_or("");
                             println!(
                                 "{}:{}:{}-{}:{}: {}",
-                                m.file, m.start_line, m.start_col, m.end_line, m.end_col, first_line
+                                m.file,
+                                m.start_line,
+                                m.start_col,
+                                m.end_line,
+                                m.end_col,
+                                first_line
                             );
                         }
                     }
@@ -221,7 +225,7 @@ pub fn run(
                 Err(e) => {
                     eprintln!("{}: {}", path.display(), e);
                     error_count += 1;
-                },
+                }
             }
         }
     }
@@ -285,9 +289,7 @@ pub fn run(
     // misconfiguration. Suppressed in JSON mode so machine consumers get a
     // clean stream.
     if attempted_files == 0 && !json {
-        eprintln!(
-            "ast-bro run: no source files processed (check paths, --glob, or --lang)"
-        );
+        eprintln!("ast-bro run: no source files processed (check paths, --glob, or --lang)");
     }
 
     // Exit code semantics:

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -31,14 +31,10 @@ pub fn detect_lang(path: &Path) -> Option<SupportLang> {
 
 /// Search for pattern matches in source.
 #[allow(dead_code)] // public API; prefer search_with_pattern in loops
-pub fn search(
-    source: &str,
-    lang: SupportLang,
-    pattern: &str,
-) -> Result<Vec<RunMatch>, String> {
+pub fn search(source: &str, lang: SupportLang, pattern: &str) -> Result<Vec<RunMatch>, String> {
     use ast_grep_core::Pattern;
-    let compiled = Pattern::try_new(pattern, lang)
-        .map_err(|e| format!("invalid pattern: {}", e))?;
+    let compiled =
+        Pattern::try_new(pattern, lang).map_err(|e| format!("invalid pattern: {}", e))?;
     search_with_pattern(source, lang, &compiled)
 }
 
@@ -200,8 +196,8 @@ pub fn rewrite(
     replacement: &str,
 ) -> Result<Option<String>, String> {
     use ast_grep_core::Pattern;
-    let compiled = Pattern::try_new(pattern, lang)
-        .map_err(|e| format!("invalid pattern: {}", e))?;
+    let compiled =
+        Pattern::try_new(pattern, lang).map_err(|e| format!("invalid pattern: {}", e))?;
     rewrite_with_pattern(source, lang, &compiled, replacement)
 }
 

--- a/src/search/bm25.rs
+++ b/src/search/bm25.rs
@@ -198,7 +198,10 @@ mod tests {
             vec![s("foo"), s("foo"), s("foo"), s("bar")],
         ]);
         let scores = idx.get_scores(&[s("foo")], None);
-        assert!(scores[1] > scores[0], "more 'foo' occurrences should score higher");
+        assert!(
+            scores[1] > scores[0],
+            "more 'foo' occurrences should score higher"
+        );
     }
 
     #[test]
@@ -206,8 +209,8 @@ mod tests {
         // BM25 length normalization: between two docs each containing one "foo",
         // the shorter doc should rank higher.
         let idx = Bm25Index::build(vec![
-            vec![s("foo")],                                     // dl=1
-            vec![s("foo"), s("a"), s("b"), s("c"), s("d")],     // dl=5
+            vec![s("foo")],                                 // dl=1
+            vec![s("foo"), s("a"), s("b"), s("c"), s("d")], // dl=5
         ]);
         let scores = idx.get_scores(&[s("foo")], None);
         assert!(scores[0] > scores[1], "shorter doc must score higher");

--- a/src/search/cache.rs
+++ b/src/search/cache.rs
@@ -83,11 +83,7 @@ impl Delta {
 ///
 /// Honours `.gitignore` etc. via `ignore::WalkBuilder` and only considers
 /// files that pass `is_indexable`.
-pub fn compute_delta(
-    walk_root: &Path,
-    strip_root: &Path,
-    cached_files: &[FileRecord],
-) -> Delta {
+pub fn compute_delta(walk_root: &Path, strip_root: &Path, cached_files: &[FileRecord]) -> Delta {
     let cached: HashMap<&str, &FileRecord> =
         cached_files.iter().map(|r| (r.path.as_str(), r)).collect();
 
@@ -259,8 +255,8 @@ mod tests {
         let path = touch(dir.path(), "f.rs", "fn x() {}");
         let record = FileRecord {
             path: "f.rs".to_string(),
-            mtime_ns: 0, // forces hash check
-            size: 999,   // mismatch on size too
+            mtime_ns: 0,      // forces hash check
+            size: 999,        // mismatch on size too
             content_hash: 42, // wrong hash
             chunk_start: 0,
             chunk_end: 1,

--- a/src/search/chunker.rs
+++ b/src/search/chunker.rs
@@ -176,13 +176,27 @@ fn pack(source: &str, file_path: &str, lang_name: &str, split_points: &[usize]) 
         } else if cur_size + region_size <= MAX_CHARS {
             cur_end = w[1];
         } else {
-            push_chunk(source, file_path, lang_name, cur_start, cur_end, &mut chunks);
+            push_chunk(
+                source,
+                file_path,
+                lang_name,
+                cur_start,
+                cur_end,
+                &mut chunks,
+            );
             cur_start = w[0];
             cur_end = w[1];
         }
     }
     if cur_end > cur_start {
-        push_chunk(source, file_path, lang_name, cur_start, cur_end, &mut chunks);
+        push_chunk(
+            source,
+            file_path,
+            lang_name,
+            cur_start,
+            cur_end,
+            &mut chunks,
+        );
     }
 
     chunks
@@ -304,7 +318,11 @@ mod tests {
             "fn one() {{\n{big_body}}}\nfn two() {{\n{big_body}}}\nfn three() {{\n{big_body}}}\n"
         );
         let chunks = rust(&src);
-        assert!(chunks.len() >= 2, "expected packer to split, got {}", chunks.len());
+        assert!(
+            chunks.len() >= 2,
+            "expected packer to split, got {}",
+            chunks.len()
+        );
         for c in &chunks {
             assert!(!c.content.trim().is_empty());
         }
@@ -376,7 +394,11 @@ content c
         let big: String = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. ".repeat(40);
         let src = format!("# A\n{big}\n\n# B\n{big}\n\n# C\n{big}\n");
         let chunks = md(&src);
-        assert!(chunks.len() >= 2, "expected splitting, got {}", chunks.len());
+        assert!(
+            chunks.len() >= 2,
+            "expected splitting, got {}",
+            chunks.len()
+        );
     }
 
     #[test]

--- a/src/search/cli.rs
+++ b/src/search/cli.rs
@@ -84,9 +84,7 @@ pub fn run_find_related(
                 println!("{}", render_related_json(file_path, line, &[], pretty));
                 return 0;
             }
-            eprintln!(
-                "ast-bro: no chunk at {file_path}:{line} (was the file indexed?)"
-            );
+            eprintln!("ast-bro: no chunk at {file_path}:{line} (was the file indexed?)");
             return 2;
         }
     };
@@ -217,10 +215,7 @@ fn peek_recorded_corpus(home: &Path) -> Option<String> {
         #[serde(default)]
         indexed_corpus: String,
     }
-    let meta_path = home
-        .join(".ast-bro")
-        .join("index")
-        .join("meta.json");
+    let meta_path = home.join(".ast-bro").join("index").join("meta.json");
     let bytes = std::fs::read(&meta_path).ok()?;
     let m: PeekMeta = serde_json::from_slice(&bytes).ok()?;
     Some(m.indexed_corpus)
@@ -285,10 +280,7 @@ mod tests {
                  "indexed_corpus": "packages" }"#,
         )
         .unwrap();
-        assert_eq!(
-            peek_recorded_corpus(home).as_deref(),
-            Some("packages")
-        );
+        assert_eq!(peek_recorded_corpus(home).as_deref(), Some("packages"));
     }
 
     #[test]

--- a/src/search/download.rs
+++ b/src/search/download.rs
@@ -117,9 +117,17 @@ pub fn cache_root() -> io::Result<PathBuf> {
     MIGRATED.get_or_init(|| {
         if old_dir.exists() && !new_dir.exists() {
             if let Err(e) = std::fs::rename(&old_dir, &new_dir) {
-                eprintln!("warning: could not rename {} -> {}: {e}", old_dir.display(), new_dir.display());
+                eprintln!(
+                    "warning: could not rename {} -> {}: {e}",
+                    old_dir.display(),
+                    new_dir.display()
+                );
             } else {
-                eprintln!("info: auto-renamed {} -> {}", old_dir.display(), new_dir.display());
+                eprintln!(
+                    "info: auto-renamed {} -> {}",
+                    old_dir.display(),
+                    new_dir.display()
+                );
             }
         }
     });
@@ -238,14 +246,11 @@ fn build_client(timeout: Duration) -> io::Result<reqwest::blocking::Client> {
 
     // Add an extra CA bundle if the user pointed us at one. Useful behind corp
     // TLS-intercepting proxies whose root is exported as a PEM file.
-    let ca_bundle = std::env::var("AST_BRO_CA_BUNDLE")
-        .or_else(|_| std::env::var("AST_OUTLINE_CA_BUNDLE"));
+    let ca_bundle =
+        std::env::var("AST_BRO_CA_BUNDLE").or_else(|_| std::env::var("AST_OUTLINE_CA_BUNDLE"));
     if let Ok(bundle) = ca_bundle {
-        let pem = fs::read(&bundle).map_err(|e| {
-            io::Error::other(
-                format!("AST_BRO_CA_BUNDLE={bundle}: {e}"),
-            )
-        })?;
+        let pem = fs::read(&bundle)
+            .map_err(|e| io::Error::other(format!("AST_BRO_CA_BUNDLE={bundle}: {e}")))?;
         for cert in reqwest::Certificate::from_pem_bundle(&pem)
             .map_err(|e| io::Error::other(format!("invalid CA bundle: {e}")))?
         {
@@ -265,9 +270,7 @@ fn build_client(timeout: Duration) -> io::Result<reqwest::blocking::Client> {
         builder = builder.danger_accept_invalid_certs(true);
     }
 
-    builder
-        .build()
-        .map_err(io::Error::other)
+    builder.build().map_err(io::Error::other)
 }
 
 /// Check whether TLS strict mode is enabled via `AST_BRO_TLS_STRICT` or
@@ -308,9 +311,10 @@ fn download_to(client: &reqwest::blocking::Client, url: &str, dest: &Path) -> io
         io::Error::other(msg)
     })?;
     if !resp.status().is_success() {
-        return Err(io::Error::other(
-            format!("GET {url} returned HTTP {}", resp.status()),
-        ));
+        return Err(io::Error::other(format!(
+            "GET {url} returned HTTP {}",
+            resp.status()
+        )));
     }
 
     let tmp = dest.with_extension("tmp");
@@ -320,9 +324,7 @@ fn download_to(client: &reqwest::blocking::Client, url: &str, dest: &Path) -> io
     let mut reader = resp;
     let mut buf = [0u8; 64 * 1024];
     loop {
-        let n = reader
-            .read(&mut buf)
-            .map_err(io::Error::other)?;
+        let n = reader.read(&mut buf).map_err(io::Error::other)?;
         if n == 0 {
             break;
         }
@@ -350,8 +352,7 @@ fn manifest_path(dir: &Path) -> PathBuf {
 }
 
 fn write_manifest(dir: &Path, manifest: &Manifest) -> io::Result<()> {
-    let json = serde_json::to_vec_pretty(manifest)
-        .map_err(io::Error::other)?;
+    let json = serde_json::to_vec_pretty(manifest).map_err(io::Error::other)?;
     fs::write(manifest_path(dir), json)
 }
 
@@ -388,9 +389,7 @@ fn cache_is_valid(dir: &Path, info: &ModelInfo) -> io::Result<bool> {
         };
         let actual = sha256_file(&path)?;
         if &actual != expected {
-            eprintln!(
-                "ast-bro: cached {file} failed integrity check, will re-download"
-            );
+            eprintln!("ast-bro: cached {file} failed integrity check, will re-download");
             return Ok(false);
         }
     }

--- a/src/search/embed.rs
+++ b/src/search/embed.rs
@@ -61,9 +61,7 @@ impl Embedder {
         let tensor = st.tensor(EMBEDDINGS_TENSOR).map_err(|e| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!(
-                    "safetensors missing '{EMBEDDINGS_TENSOR}' tensor (have: {names:?}): {e}"
-                ),
+                format!("safetensors missing '{EMBEDDINGS_TENSOR}' tensor (have: {names:?}): {e}"),
             )
         })?;
         if tensor.dtype() != Dtype::F32 {
@@ -104,10 +102,7 @@ impl Embedder {
         );
 
         let tokenizer = Tokenizer::from_file(&tokenizer_path).map_err(|e| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("tokenizer.json: {e}"),
-            )
+            io::Error::new(io::ErrorKind::InvalidData, format!("tokenizer.json: {e}"))
         })?;
 
         Ok(Self {
@@ -127,9 +122,7 @@ impl Embedder {
     fn all_rows(&self) -> &[f32] {
         // SAFETY: `embeddings_ptr` is valid for `vocab_size * DIM` f32s for the
         // lifetime of `self._mmap`.
-        unsafe {
-            std::slice::from_raw_parts(self.embeddings_ptr, self.vocab_size * DIM)
-        }
+        unsafe { std::slice::from_raw_parts(self.embeddings_ptr, self.vocab_size * DIM) }
     }
 
     /// Look up the embedding row for a single token id. OOV ids are clamped
@@ -181,7 +174,6 @@ impl Embedder {
         }
         out
     }
-
 }
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -215,7 +207,11 @@ pub fn cosine_topk(
     use rayon::prelude::*;
 
     let n = embeddings.len() / DIM;
-    debug_assert_eq!(embeddings.len() % DIM, 0, "embeddings length not a multiple of DIM");
+    debug_assert_eq!(
+        embeddings.len() % DIM,
+        0,
+        "embeddings length not a multiple of DIM"
+    );
     if let Some(m) = mask {
         debug_assert_eq!(m.len(), n, "mask length must equal row count");
     }
@@ -261,7 +257,11 @@ pub fn cosine_topk(
     top.into_iter()
         .filter_map(|i| {
             let s = scores[i as usize];
-            if s.is_finite() { Some((i, s)) } else { None }
+            if s.is_finite() {
+                Some((i, s))
+            } else {
+                None
+            }
         })
         .collect()
 }

--- a/src/search/format.rs
+++ b/src/search/format.rs
@@ -83,12 +83,7 @@ fn render_hit_body(hit: &SearchHit) -> String {
     out
 }
 
-pub fn render_related_json(
-    file_path: &str,
-    line: u32,
-    hits: &[SearchHit],
-    pretty: bool,
-) -> String {
+pub fn render_related_json(file_path: &str, line: u32, hits: &[SearchHit], pretty: bool) -> String {
     let v = json!({
         "schema": JSON_SCHEMA_RELATED,
         "source": { "path": file_path, "line": line },
@@ -267,7 +262,10 @@ mod tests {
         let meta = Meta {
             schema: "ast-bro.search-index.v1".to_string(),
             ast_bro_version: "0.0.0".to_string(),
-            model: ModelMeta { id: "m".into(), dim: 256 },
+            model: ModelMeta {
+                id: "m".into(),
+                dim: 256,
+            },
             created_unix: 42,
             chunk_count: 7,
             embedding_dtype: "f32_le".to_string(),
@@ -290,7 +288,10 @@ mod tests {
         let meta = Meta {
             schema: "ast-bro.search-index.v1".to_string(),
             ast_bro_version: "0.0.0".to_string(),
-            model: ModelMeta { id: "m".into(), dim: 256 },
+            model: ModelMeta {
+                id: "m".into(),
+                dim: 256,
+            },
             created_unix: 0,
             chunk_count: 0,
             embedding_dtype: "f32_le".to_string(),

--- a/src/search/index.rs
+++ b/src/search/index.rs
@@ -80,7 +80,8 @@ impl IndexPaths {
         // Inter-process races are not covered — fs::rename is atomic on most
         // platforms so the loser simply gets an error, but a filesystem-level
         // lock would be needed for full cross-process safety.
-        static MIGRATED: OnceLock<std::sync::Mutex<std::collections::HashSet<PathBuf>>> = OnceLock::new();
+        static MIGRATED: OnceLock<std::sync::Mutex<std::collections::HashSet<PathBuf>>> =
+            OnceLock::new();
         let set = MIGRATED.get_or_init(|| std::sync::Mutex::new(std::collections::HashSet::new()));
         let mut guard = set.lock().unwrap();
         if guard.insert(repo_root.to_path_buf()) && old_dir.exists() && !new_dir.exists() {
@@ -231,11 +232,7 @@ impl Index {
                             total_chunks,
                             compaction_ratio() * 100.0,
                         );
-                        return Self::build_with_corpus(
-                            path_arg,
-                            cwd,
-                            &loaded.meta.indexed_corpus,
-                        );
+                        return Self::build_with_corpus(path_arg, cwd, &loaded.meta.indexed_corpus);
                     }
 
                     let corpus_dir = corpus_walk_dir(&paths.root, &loaded.meta.indexed_corpus);
@@ -286,11 +283,7 @@ impl Index {
     /// Force a full rebuild with an explicit corpus. Used by the corpus
     /// reconciliation logic in `run_index` and by `Index::open` when
     /// rebuilding a stale index (preserves the recorded corpus).
-    pub fn build_with_corpus(
-        path_arg: &Path,
-        cwd: &Path,
-        corpus: &str,
-    ) -> io::Result<Self> {
+    pub fn build_with_corpus(path_arg: &Path, cwd: &Path, corpus: &str) -> io::Result<Self> {
         let (home, _) = resolve_home(path_arg, cwd, Marker::SearchIndex);
         let paths = IndexPaths::from_repo(&home);
         fs::create_dir_all(&paths.index_dir)?;
@@ -321,7 +314,7 @@ impl Index {
         // 2. Build flat chunks vec + per-file chunk_range.
         let mut chunks = Vec::new();
         let mut files: Vec<FileRecord> = Vec::with_capacity(file_paths.len());
-        for (path, file_chunks) in file_paths.iter().zip(chunks_per_file.into_iter()) {
+        for (path, file_chunks) in file_paths.iter().zip(chunks_per_file) {
             let rel = match path.strip_prefix(&paths.root) {
                 Ok(r) => normalise_path(r),
                 Err(_) => continue,
@@ -440,8 +433,7 @@ impl Index {
 
         // --- 1. Identify which existing FileRecords get tombstoned ---
         // Keys: home-relative POSIX paths (FileRecord.path).
-        let removed_keys: HashSet<&str> =
-            delta.removed.iter().map(|s| s.as_str()).collect();
+        let removed_keys: HashSet<&str> = delta.removed.iter().map(|s| s.as_str()).collect();
         let modified_keys: HashSet<String> = delta
             .modified
             .iter()
@@ -491,9 +483,8 @@ impl Index {
         //         (embedder is cheap per call but its internal state isn't
         //          shared across threads in our wrapper). Append in stable
         //          input order so chunk_range is contiguous per file. ---
-        let mut to_index: Vec<PathBuf> = Vec::with_capacity(
-            delta.modified.len() + delta.added.len(),
-        );
+        let mut to_index: Vec<PathBuf> =
+            Vec::with_capacity(delta.modified.len() + delta.added.len());
         to_index.extend(delta.modified.iter().cloned());
         to_index.extend(delta.added.iter().cloned());
         // Deterministic ordering for reproducible chunk ids.
@@ -596,10 +587,16 @@ impl Index {
     fn load_unlocked(paths: &IndexPaths) -> io::Result<Self> {
         let meta: Meta = read_meta(&paths.meta_json)?;
         // Accept current schema and the older legacy schemas.
-        if meta.schema != SCHEMA && meta.schema != SCHEMA_V1_LEGACY && meta.schema != SCHEMA_V2_LEGACY {
+        if meta.schema != SCHEMA
+            && meta.schema != SCHEMA_V1_LEGACY
+            && meta.schema != SCHEMA_V2_LEGACY
+        {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("schema {} not in [{SCHEMA}, {SCHEMA_V1_LEGACY}, {SCHEMA_V2_LEGACY}]", meta.schema),
+                format!(
+                    "schema {} not in [{SCHEMA}, {SCHEMA_V1_LEGACY}, {SCHEMA_V2_LEGACY}]",
+                    meta.schema
+                ),
             ));
         }
         if meta.model.dim as usize != DIM {
@@ -731,12 +728,8 @@ impl Index {
 
         // Semantic top-N.
         let q_embed = self.embedder.encode_one(query);
-        let semantic_scored = cosine_topk(
-            &q_embed,
-            &self.embeddings,
-            mask.as_deref(),
-            candidate_count,
-        );
+        let semantic_scored =
+            cosine_topk(&q_embed, &self.embeddings, mask.as_deref(), candidate_count);
 
         // BM25 top-N.
         let query_tokens = tokenize(query);
@@ -758,7 +751,12 @@ impl Index {
         let scored = apply_query_boost(scored, query, &self.chunks);
 
         // Final top-k with path penalties + saturation decay.
-        let ranked = rerank_topk(&scored, &self.chunks, opts.top_k, /* penalise_paths */ true);
+        let ranked = rerank_topk(
+            &scored,
+            &self.chunks,
+            opts.top_k,
+            /* penalise_paths */ true,
+        );
         ranked
             .into_iter()
             .map(|(id, score)| SearchHit {
@@ -777,7 +775,9 @@ impl Index {
                 return slot.clone();
             }
         }
-        let loaded = crate::graph_cache::shared::get_or_init(&self.paths.root).ok().map(|u| u.deps.clone());
+        let loaded = crate::graph_cache::shared::get_or_init(&self.paths.root)
+            .ok()
+            .map(|u| u.deps.clone());
         if let Ok(mut w) = self.dep_graph.write() {
             *w = Some(loaded.clone());
         }
@@ -788,12 +788,7 @@ impl Index {
     /// Filters to chunks of the same language and excludes the source itself.
     /// When a fresh dep-graph cache exists, also applies a multiplicative
     /// boost to chunks in the importer/importee neighbourhood.
-    pub fn find_related(
-        &self,
-        file_path: &str,
-        line: u32,
-        top_k: usize,
-    ) -> Option<Vec<SearchHit>> {
+    pub fn find_related(&self, file_path: &str, line: u32, top_k: usize) -> Option<Vec<SearchHit>> {
         self.find_related_opts(
             file_path, line, top_k, /* dep_boost */ true, /* dep_depth */ 2, None,
         )
@@ -831,7 +826,8 @@ impl Index {
             if let Some(graph) = self.dep_graph_cached() {
                 let abs_source = self.paths.root.join(&source.file_path);
                 let abs_source = abs_source.canonicalize().unwrap_or(abs_source);
-                let depths = crate::deps::traverse::neighbourhood_depths(&graph, &abs_source, dep_depth);
+                let depths =
+                    crate::deps::traverse::neighbourhood_depths(&graph, &abs_source, dep_depth);
                 if !depths.is_empty() {
                     for (id, score) in scored.iter_mut() {
                         let chunk = &self.chunks[*id as usize];
@@ -846,7 +842,8 @@ impl Index {
                             };
                         }
                     }
-                    scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+                    scored
+                        .sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
                     scored.truncate(top_k);
                 }
             }
@@ -1025,10 +1022,7 @@ fn resolve_chunk(chunks: &[Chunk], file_path: &str, line: u32) -> Option<u32> {
 /// Append file path components to chunk content to boost path-based queries.
 fn enrich_for_bm25(chunk: &Chunk) -> String {
     let path = Path::new(&chunk.file_path);
-    let stem = path
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or("");
+    let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
     let dir_parts: Vec<&str> = path
         .parent()
         .map(|p| {
@@ -1055,7 +1049,11 @@ fn enrich_for_bm25(chunk: &Chunk) -> String {
 /// Chunk `file_path` strings are stored relative to `strip_root` so that a
 /// corpus-narrowed walk still produces stable paths relative to the index
 /// home (used by `query_scope` filtering at search time).
-fn walk_and_chunk(walk_root: &Path, strip_root: &Path, repo_root: &Path) -> (Vec<PathBuf>, Vec<Vec<Chunk>>) {
+fn walk_and_chunk(
+    walk_root: &Path,
+    strip_root: &Path,
+    repo_root: &Path,
+) -> (Vec<PathBuf>, Vec<Vec<Chunk>>) {
     // Collect indexable paths first so chunking can run in parallel.
     let mut paths: Vec<PathBuf> = Vec::new();
     let mut builder = WalkBuilder::new(walk_root);
@@ -1123,17 +1121,14 @@ fn acquire_lock(paths: &IndexPaths) -> io::Result<fs::File> {
         .write(true)
         .truncate(false)
         .open(&paths.lock)?;
-    lock_file.lock_exclusive().map_err(|e| {
-        io::Error::other(
-            format!("could not acquire index lock: {e}"),
-        )
-    })?;
+    lock_file
+        .lock_exclusive()
+        .map_err(|e| io::Error::other(format!("could not acquire index lock: {e}")))?;
     Ok(lock_file)
 }
 
 fn write_meta(path: &Path, meta: &Meta) -> io::Result<()> {
-    let json = serde_json::to_vec_pretty(meta)
-        .map_err(io::Error::other)?;
+    let json = serde_json::to_vec_pretty(meta).map_err(io::Error::other)?;
     write_atomic(path, &json)
 }
 
@@ -1317,7 +1312,10 @@ mod tests {
         let meta = Meta {
             schema: SCHEMA.to_string(),
             ast_bro_version: env!("CARGO_PKG_VERSION").to_string(),
-            model: ModelMeta { id: "m".into(), dim: DIM as u32 },
+            model: ModelMeta {
+                id: "m".into(),
+                dim: DIM as u32,
+            },
             created_unix: 0,
             chunk_count: 1,
             embedding_dtype: "f32_le".to_string(),
@@ -1417,7 +1415,9 @@ mod tests {
             .expect("source chunk not found");
         assert!(!related.is_empty());
         // The source chunk itself must be excluded.
-        assert!(related.iter().all(|h| !h.chunk.file_path.contains("login.rs")));
+        assert!(related
+            .iter()
+            .all(|h| !h.chunk.file_path.contains("login.rs")));
 
         // Re-open from cache: should detect no changes and skip rebuild.
         let reopened = Index::open(dir.path(), dir.path()).expect("re-open failed");
@@ -1516,14 +1516,12 @@ mod tests {
             mk("src/auth/logout.rs"),
         ];
         // path: keeps only the auth dir.
-        let mask =
-            build_combined_mask(&chunks, None, None, None, &["auth".to_string()], &[])
-                .expect("path filter active");
+        let mask = build_combined_mask(&chunks, None, None, None, &["auth".to_string()], &[])
+            .expect("path filter active");
         assert_eq!(mask, vec![true, false, true]);
         // name: matches the file basename only (not the dir).
-        let mask =
-            build_combined_mask(&chunks, None, None, None, &[], &["login".to_string()])
-                .expect("name filter active");
+        let mask = build_combined_mask(&chunks, None, None, None, &[], &["login".to_string()])
+            .expect("name filter active");
         assert_eq!(mask, vec![true, false, false]);
     }
 

--- a/src/search/ranking.rs
+++ b/src/search/ranking.rs
@@ -25,20 +25,40 @@ const FILE_SATURATION_THRESHOLD: usize = 1;
 const FILE_SATURATION_DECAY: f32 = 0.5;
 
 const STOPWORDS: &[&str] = &[
-    "a", "an", "and", "are", "as", "at", "be", "by", "do", "does", "for", "from",
-    "has", "have", "how", "if", "in", "is", "it", "not", "of", "on", "or", "the",
-    "to", "was", "what", "when", "where", "which", "who", "why", "with",
+    "a", "an", "and", "are", "as", "at", "be", "by", "do", "does", "for", "from", "has", "have",
+    "how", "if", "in", "is", "it", "not", "of", "on", "or", "the", "to", "was", "what", "when",
+    "where", "which", "who", "why", "with",
 ];
 
 const DEFINITION_KEYWORDS: &[&str] = &[
-    "class", "module", "defmodule", "def", "interface", "struct", "enum",
-    "trait", "type", "func", "function", "object", "abstract class",
-    "data class", "fn", "fun", "package", "namespace", "protocol",
-    "record", "typedef",
+    "class",
+    "module",
+    "defmodule",
+    "def",
+    "interface",
+    "struct",
+    "enum",
+    "trait",
+    "type",
+    "func",
+    "function",
+    "object",
+    "abstract class",
+    "data class",
+    "fn",
+    "fun",
+    "package",
+    "namespace",
+    "protocol",
+    "record",
+    "typedef",
 ];
 
 const SQL_DEFINITION_KEYWORDS: &[&str] = &[
-    "CREATE TABLE", "CREATE VIEW", "CREATE PROCEDURE", "CREATE FUNCTION",
+    "CREATE TABLE",
+    "CREATE VIEW",
+    "CREATE PROCEDURE",
+    "CREATE FUNCTION",
 ];
 
 const REEXPORT_FILENAMES: &[&str] = &["__init__.py", "package-info.java"];
@@ -72,34 +92,72 @@ fn test_file_re() -> &'static Regex {
         let pattern = concat!(
             r"(?:^|/)(?:",
             // Python
-            r"test_[^/]*\.py", "|", r"[^/]*_test\.py",
+            r"test_[^/]*\.py",
+            "|",
+            r"[^/]*_test\.py",
             // Go
-            "|", r"[^/]*_test\.go",
+            "|",
+            r"[^/]*_test\.go",
             // Java
-            "|", r"[^/]*Tests?\.java",
+            "|",
+            r"[^/]*Tests?\.java",
             // PHP
-            "|", r"[^/]*Test\.php",
+            "|",
+            r"[^/]*Test\.php",
             // Ruby
-            "|", r"[^/]*_spec\.rb", "|", r"[^/]*_test\.rb",
+            "|",
+            r"[^/]*_spec\.rb",
+            "|",
+            r"[^/]*_test\.rb",
             // JS/TS
-            "|", r"[^/]*\.test\.[jt]sx?", "|", r"[^/]*\.spec\.[jt]sx?",
+            "|",
+            r"[^/]*\.test\.[jt]sx?",
+            "|",
+            r"[^/]*\.spec\.[jt]sx?",
             // Kotlin
-            "|", r"[^/]*Tests?\.kt", "|", r"[^/]*Spec\.kt",
+            "|",
+            r"[^/]*Tests?\.kt",
+            "|",
+            r"[^/]*Spec\.kt",
             // Swift
-            "|", r"[^/]*Tests?\.swift", "|", r"[^/]*Spec\.swift",
+            "|",
+            r"[^/]*Tests?\.swift",
+            "|",
+            r"[^/]*Spec\.swift",
             // C#
-            "|", r"[^/]*Tests?\.cs",
+            "|",
+            r"[^/]*Tests?\.cs",
             // C / C++
-            "|", r"test_[^/]*\.cpp", "|", r"[^/]*_test\.cpp",
-            "|", r"test_[^/]*\.c", "|", r"[^/]*_test\.c",
+            "|",
+            r"test_[^/]*\.cpp",
+            "|",
+            r"[^/]*_test\.cpp",
+            "|",
+            r"test_[^/]*\.c",
+            "|",
+            r"[^/]*_test\.c",
             // Scala
-            "|", r"[^/]*Spec\.scala", "|", r"[^/]*Suite\.scala", "|", r"[^/]*Test\.scala",
+            "|",
+            r"[^/]*Spec\.scala",
+            "|",
+            r"[^/]*Suite\.scala",
+            "|",
+            r"[^/]*Test\.scala",
             // Dart
-            "|", r"[^/]*_test\.dart", "|", r"test_[^/]*\.dart",
+            "|",
+            r"[^/]*_test\.dart",
+            "|",
+            r"test_[^/]*\.dart",
             // Lua
-            "|", r"[^/]*_spec\.lua", "|", r"[^/]*_test\.lua", "|", r"test_[^/]*\.lua",
+            "|",
+            r"[^/]*_spec\.lua",
+            "|",
+            r"[^/]*_test\.lua",
+            "|",
+            r"test_[^/]*\.lua",
             // Helpers
-            "|", r"test_helpers?[^/]*\.\w+",
+            "|",
+            r"test_helpers?[^/]*\.\w+",
             ")$",
         );
         Regex::new(pattern).expect("test_file_re")
@@ -181,9 +239,7 @@ fn definition_pattern(symbol_name: &str) -> DefnPair {
     // whitespace into the match, which is fine because we only need a match,
     // not the offset.
     let prefix = r"(?:^|\s)(?:";
-    let suffix = format!(
-        r")\s+(?:[A-Za-z_][A-Za-z0-9_]*(?:\.|::))*{escaped}(?:\s|[<({{:\[;]|$)",
-    );
+    let suffix = format!(r")\s+(?:[A-Za-z_][A-Za-z0-9_]*(?:\.|::))*{escaped}(?:\s|[<({{:\[;]|$)",);
     let general_body: String = DEFINITION_KEYWORDS
         .iter()
         .map(|k| regex::escape(k))
@@ -310,7 +366,9 @@ fn definition_tier(content: &str, file_path: &str, names: &[&str], boost_unit: f
         .and_then(|s| s.to_str())
         .unwrap_or("")
         .to_ascii_lowercase();
-    let stem_match = names.iter().any(|n| stem_matches(&stem, &n.to_ascii_lowercase()));
+    let stem_match = names
+        .iter()
+        .any(|n| stem_matches(&stem, &n.to_ascii_lowercase()));
     boost_unit * if stem_match { 1.5 } else { 1.0 }
 }
 
@@ -374,8 +432,7 @@ fn boost_embedded_symbols(
         return;
     }
     let names_ref: Vec<&str> = names.iter().map(String::as_str).collect();
-    let boost_unit =
-        max_score * DEFINITION_BOOST_MULTIPLIER * EMBEDDED_SYMBOL_BOOST_SCALE;
+    let boost_unit = max_score * DEFINITION_BOOST_MULTIPLIER * EMBEDDED_SYMBOL_BOOST_SCALE;
 
     let candidate_ids: Vec<u32> = boosted.keys().copied().collect();
     for id in &candidate_ids {
@@ -460,7 +517,11 @@ fn boost_stem_matches(
             let stem = p.file_stem().and_then(|s| s.to_str()).unwrap_or("");
             parts.insert(stem.to_ascii_lowercase());
             parts.extend(split_identifier(stem));
-            if let Some(parent) = p.parent().and_then(|d| d.file_name()).and_then(|s| s.to_str()) {
+            if let Some(parent) = p
+                .parent()
+                .and_then(|d| d.file_name())
+                .and_then(|s| s.to_str())
+            {
                 if !matches!(parent, "" | "." | "/" | "..") {
                     parts.insert(parent.to_ascii_lowercase());
                     parts.extend(split_identifier(parent));
@@ -541,9 +602,7 @@ pub fn rerank_topk(
 
     // Sort by penalised score descending (stable on ties — preserves insertion
     // order, matching Python's stable `sorted`).
-    penalised.sort_by(|a, b| {
-        b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal)
-    });
+    penalised.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
 
     // Greedy selection with file-saturation decay. We only need to walk far
     // enough to find top_k results that survive the decay.
@@ -570,10 +629,12 @@ pub fn rerank_topk(
         }
     }
 
-    selected.sort_by(|a, b| {
-        b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal)
-    });
-    selected.into_iter().take(top_k).map(|(s, id)| (id, s)).collect()
+    selected.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+    selected
+        .into_iter()
+        .take(top_k)
+        .map(|(s, id)| (id, s))
+        .collect()
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -615,9 +676,9 @@ mod tests {
     #[test]
     fn stem_matches_variants() {
         assert!(stem_matches("foo", "foo"));
-        assert!(stem_matches("my_func", "myfunc"));   // snake collapsed
-        assert!(stem_matches("foos", "foo"));          // plural
-        assert!(stem_matches("my_funcs", "myfunc"));   // plural + snake
+        assert!(stem_matches("my_func", "myfunc")); // snake collapsed
+        assert!(stem_matches("foos", "foo")); // plural
+        assert!(stem_matches("my_funcs", "myfunc")); // plural + snake
         assert!(!stem_matches("bar", "foo"));
     }
 
@@ -632,13 +693,22 @@ mod tests {
 
     #[test]
     fn defines_namespaced() {
-        assert!(chunk_defines_symbol("defmodule Phoenix.Router do\nend", "Router"));
+        assert!(chunk_defines_symbol(
+            "defmodule Phoenix.Router do\nend",
+            "Router"
+        ));
     }
 
     #[test]
     fn defines_sql_case_insensitive() {
-        assert!(chunk_defines_symbol("CREATE TABLE users (id INT);", "users"));
-        assert!(chunk_defines_symbol("create table Users (id int);", "Users"));
+        assert!(chunk_defines_symbol(
+            "CREATE TABLE users (id INT);",
+            "users"
+        ));
+        assert!(chunk_defines_symbol(
+            "create table Users (id int);",
+            "Users"
+        ));
     }
 
     #[test]
@@ -726,10 +796,7 @@ mod tests {
 
     #[test]
     fn rerank_applies_path_penalties() {
-        let chunks = vec![
-            ck(0, "src/main.rs", ""),
-            ck(1, "tests/test_foo.py", ""),
-        ];
+        let chunks = vec![ck(0, "src/main.rs", ""), ck(1, "tests/test_foo.py", "")];
         let scores: HashMap<u32, f32> = [(0u32, 1.0f32), (1u32, 1.5f32)].into_iter().collect();
         // Without penalties, id 1 wins.
         let no_pen = rerank_topk(&scores, &chunks, 2, /* penalise_paths */ false);
@@ -777,8 +844,8 @@ mod tests {
     #[test]
     fn boost_promotes_definition_for_symbol_query() {
         let chunks = vec![
-            ck(0, "src/handler.rs", "fn use_handler() { stack.handle() }"),  // uses
-            ck(1, "src/stack.rs", "struct HandlerStack { items: Vec<u32> }"),  // defines
+            ck(0, "src/handler.rs", "fn use_handler() { stack.handle() }"), // uses
+            ck(1, "src/stack.rs", "struct HandlerStack { items: Vec<u32> }"), // defines
         ];
         let scores: HashMap<u32, f32> = [(0u32, 0.5f32), (1u32, 0.3f32)].into_iter().collect();
         let boosted = apply_query_boost(scores, "HandlerStack", &chunks);

--- a/src/search/tokens.rs
+++ b/src/search/tokens.rs
@@ -186,8 +186,14 @@ mod tests {
             toks,
             vec![
                 "def",
-                "getuserbyid", "get", "user", "by", "id",
-                "user_id", "user", "id"
+                "getuserbyid",
+                "get",
+                "user",
+                "by",
+                "id",
+                "user_id",
+                "user",
+                "id"
             ]
         );
     }

--- a/src/squeeze/mod.rs
+++ b/src/squeeze/mod.rs
@@ -377,10 +377,8 @@ impl Compressor {
 
         // Scale the diminishing-returns cutoff to this pass's input size, but
         // never below the absolute floor (so small inputs behave exactly as before).
-        let min_savings = std::cmp::max(
-            BPE_MIN_SAVINGS,
-            (text.len() / BPE_MIN_SAVINGS_RATIO) as i32,
-        );
+        let min_savings =
+            std::cmp::max(BPE_MIN_SAVINGS, (text.len() / BPE_MIN_SAVINGS_RATIO) as i32);
 
         let (part_strs, seps) = strategy.split_text_with_separators(&text);
         let mut parts: Vec<Vec<u32>> = part_strs
@@ -389,7 +387,11 @@ impl Compressor {
                 if p.is_empty() {
                     vec![]
                 } else {
-                    strategy.tokenize(p).into_iter().map(&mut get_or_add).collect()
+                    strategy
+                        .tokenize(p)
+                        .into_iter()
+                        .map(&mut get_or_add)
+                        .collect()
                 }
             })
             .collect();

--- a/src/squeeze/render.rs
+++ b/src/squeeze/render.rs
@@ -347,7 +347,10 @@ mod tests {
             "repetitive input should squeeze, got header in:\n{}",
             txt.lines().next().unwrap_or("")
         );
-        assert!(txt.contains("# legend:"), "squeezed output must have a legend");
+        assert!(
+            txt.contains("# legend:"),
+            "squeezed output must have a legend"
+        );
 
         // JSON view confirms the decision + that the emitted body shrank.
         let json = render_json(&r, false);

--- a/src/surface/fallback.rs
+++ b/src/surface/fallback.rs
@@ -70,8 +70,10 @@ fn _walk(
         });
     }
 
-    let next_prefix = if matches!(decl.kind, Namespace | Class | Struct | Interface | Record | Enum)
-    {
+    let next_prefix = if matches!(
+        decl.kind,
+        Namespace | Class | Struct | Interface | Record | Enum
+    ) {
         qname
     } else {
         prefix.to_string()

--- a/src/surface/imports.rs
+++ b/src/surface/imports.rs
@@ -493,7 +493,10 @@ fn _consume_export<'a, D: Doc>(node: &Node<'a, D>, src: &str, out: &mut Vec<TsEx
     for c in node.children() {
         if c.kind() == "string" {
             let raw = c.text().into_owned();
-            from_module = Some(raw.trim_matches(|ch: char| ch == '\'' || ch == '"').to_string());
+            from_module = Some(
+                raw.trim_matches(|ch: char| ch == '\'' || ch == '"')
+                    .to_string(),
+            );
             break;
         }
     }
@@ -616,8 +619,12 @@ fn _consume_export<'a, D: Doc>(node: &Node<'a, D>, src: &str, out: &mut Vec<TsEx
         };
         let kind = c.kind();
         match kind.as_ref() {
-            "class_declaration" | "abstract_class_declaration" | "interface_declaration"
-            | "enum_declaration" | "type_alias_declaration" | "function_declaration"
+            "class_declaration"
+            | "abstract_class_declaration"
+            | "interface_declaration"
+            | "enum_declaration"
+            | "type_alias_declaration"
+            | "function_declaration"
             | "function_signature" => {
                 if let Some(n) = c.field("name") {
                     out.push(TsExportItem::Local {
@@ -855,4 +862,3 @@ fn _parse_dunder_all<'a, D: Doc>(assignment: &Node<'a, D>) -> Option<Vec<String>
     }
     Some(out)
 }
-

--- a/src/surface/options.rs
+++ b/src/surface/options.rs
@@ -59,9 +59,18 @@ impl Default for SurfaceOptions {
 
 #[derive(Debug)]
 pub enum SurfaceError {
-    NoEntryPoint { path: PathBuf, hint: String },
-    Io { path: PathBuf, source: std::io::Error },
-    Parse { path: PathBuf, message: String },
+    NoEntryPoint {
+        path: PathBuf,
+        hint: String,
+    },
+    Io {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    Parse {
+        path: PathBuf,
+        message: String,
+    },
     #[allow(dead_code)]
     BadOverride(String),
 }

--- a/src/surface/python.rs
+++ b/src/surface/python.rs
@@ -62,10 +62,7 @@ impl Walker {
         let src = std::str::from_utf8(&parse.source).unwrap_or("").to_string();
         let imports = imports::extract_python_imports(&src);
 
-        let pkg_dir = init_file
-            .parent()
-            .unwrap_or(Path::new("."))
-            .to_path_buf();
+        let pkg_dir = init_file.parent().unwrap_or(Path::new(".")).to_path_buf();
 
         // Determine the public set.
         let public: PublicSet = match &imports.dunder_all {
@@ -122,7 +119,12 @@ impl Walker {
                     sub_walker.walk_package(&sub_init, &sub_segments, depth + 1);
                     // Re-publish into our segments with a glob hop.
                     for e in sub_walker.entries {
-                        let last = e.qualified_path.rsplit('.').next().unwrap_or("").to_string();
+                        let last = e
+                            .qualified_path
+                            .rsplit('.')
+                            .next()
+                            .unwrap_or("")
+                            .to_string();
                         let mut chain = e.re_export_chain.clone();
                         chain.insert(0, hop.clone());
                         self._publish_external(segments, &last, &e, chain);
@@ -182,8 +184,8 @@ impl Walker {
             };
             // If the import statement was `from . import submod`, we don't
             // search by name — the imported name IS a sub-module reference.
-            let want_module_itself =
-                fi.module.is_empty() && cand.file_name().and_then(|s| s.to_str()) == Some("__init__.py");
+            let want_module_itself = fi.module.is_empty()
+                && cand.file_name().and_then(|s| s.to_str()) == Some("__init__.py");
             if want_module_itself {
                 // Re-export every public symbol from that module.
                 let src = std::str::from_utf8(&parse.source).unwrap_or("").to_string();
@@ -219,7 +221,10 @@ impl Walker {
                     continue;
                 }
                 for sub_name in &sub_fi.names {
-                    let local = sub_name.alias.clone().unwrap_or_else(|| sub_name.name.clone());
+                    let local = sub_name
+                        .alias
+                        .clone()
+                        .unwrap_or_else(|| sub_name.name.clone());
                     if local != source_name {
                         continue;
                     }
@@ -329,4 +334,3 @@ fn _ascend(start: &Path, levels: usize) -> Option<PathBuf> {
     }
     Some(cur)
 }
-

--- a/src/surface/render.rs
+++ b/src/surface/render.rs
@@ -67,7 +67,11 @@ pub fn render_tree(entries: &[SurfaceEntry]) -> String {
         for it in items {
             let leaf = _leaf(&it.qualified_path);
             let kind = it.kind.to_string();
-            let glob = if it.via_glob { " [via *]".cyan().to_string() } else { String::new() };
+            let glob = if it.via_glob {
+                " [via *]".cyan().to_string()
+            } else {
+                String::new()
+            };
             out.push_str(&format!(
                 "  ├─ {} {}  {}{}\n",
                 kind.dimmed(),

--- a/src/surface/scala.rs
+++ b/src/surface/scala.rs
@@ -249,7 +249,10 @@ fn _index_children(
 
 fn _is_object_like(d: &Declaration) -> bool {
     use DeclarationKind::*;
-    matches!(d.kind, Class | Interface | Struct | Record | Enum | Namespace)
+    matches!(
+        d.kind,
+        Class | Interface | Struct | Record | Enum | Namespace
+    )
 }
 
 fn _is_public(d: &Declaration) -> bool {

--- a/src/surface/typescript.rs
+++ b/src/surface/typescript.rs
@@ -30,7 +30,10 @@ pub fn resolve(
     opts: &SurfaceOptions,
 ) -> Result<Vec<SurfaceEntry>, SurfaceError> {
     let (root_file, pkg_name) = match entry {
-        EntryPoint::TsPackage { root_file, pkg_name } => (root_file.clone(), pkg_name.clone()),
+        EntryPoint::TsPackage {
+            root_file,
+            pkg_name,
+        } => (root_file.clone(), pkg_name.clone()),
         _ => {
             return Err(SurfaceError::NoEntryPoint {
                 path: PathBuf::from("."),
@@ -62,13 +65,7 @@ struct FileSnapshot {
 }
 
 impl Walker {
-    fn walk_file(
-        &mut self,
-        file: &Path,
-        prefix: &[String],
-        depth: usize,
-        chain: Vec<ReExportHop>,
-    ) {
+    fn walk_file(&mut self, file: &Path, prefix: &[String], depth: usize, chain: Vec<ReExportHop>) {
         if depth > self.max_depth {
             return;
         }
@@ -211,7 +208,15 @@ impl Walker {
                 continue;
             }
             // Re-exported by target?
-            self._chase_indirect(target, prefix, &b.name, &exposed, &exports, depth, chain.clone());
+            self._chase_indirect(
+                target,
+                prefix,
+                &b.name,
+                &exposed,
+                &exports,
+                depth,
+                chain.clone(),
+            );
         }
     }
 
@@ -260,7 +265,11 @@ impl Walker {
                         }
                     }
                 }
-                TsExportItem::StarFrom { from, line, statement } => {
+                TsExportItem::StarFrom {
+                    from,
+                    line,
+                    statement,
+                } => {
                     if let Some(target) = _resolve_module(from_file, from) {
                         let hop = ReExportHop {
                             file: from_file.to_path_buf(),
@@ -273,7 +282,14 @@ impl Walker {
                         if let Some(s) = snap {
                             if let Some(d) = s.decls.iter().find(|d| d.name == source_name).cloned()
                             {
-                                self._emit(prefix, exposed, &d, &target, _push(chain.clone(), hop), true);
+                                self._emit(
+                                    prefix,
+                                    exposed,
+                                    &d,
+                                    &target,
+                                    _push(chain.clone(), hop),
+                                    true,
+                                );
                                 return;
                             }
                             let exports2 = s.exports.clone();

--- a/tests/calls_e2e.rs
+++ b/tests/calls_e2e.rs
@@ -35,7 +35,10 @@ fn rust_callers_finds_cross_file_caller() {
     let root = tmp.path();
 
     // Minimal Cargo project so the dep resolver detects this as a project root.
-    write(&root.join("Cargo.toml"), "[package]\nname = \"smoke\"\nversion = \"0.0.0\"\nedition = \"2021\"\n");
+    write(
+        &root.join("Cargo.toml"),
+        "[package]\nname = \"smoke\"\nversion = \"0.0.0\"\nedition = \"2021\"\n",
+    );
     write(
         &root.join("src/lib.rs"),
         r#"
@@ -67,7 +70,10 @@ pub fn greet() {
 fn rust_callees_lists_local_call() {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();
-    write(&root.join("Cargo.toml"), "[package]\nname = \"smoke\"\nversion = \"0.0.0\"\nedition = \"2021\"\n");
+    write(
+        &root.join("Cargo.toml"),
+        "[package]\nname = \"smoke\"\nversion = \"0.0.0\"\nedition = \"2021\"\n",
+    );
     write(
         &root.join("src/lib.rs"),
         r#"
@@ -95,10 +101,7 @@ fn python_callers_finds_cross_file_caller() {
         &root.join("pyproject.toml"),
         "[project]\nname = \"smoke\"\nversion = \"0.0.0\"\n",
     );
-    write(
-        &root.join("smoke/__init__.py"),
-        "",
-    );
+    write(&root.join("smoke/__init__.py"), "");
     write(
         &root.join("smoke/helper.py"),
         "def greet():\n    print('hi')\n",
@@ -295,7 +298,10 @@ fn typescript_callers_includes_arrow_const() {
 fn callers_with_file_filter_narrows_match() {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();
-    write(&root.join("Cargo.toml"), "[package]\nname=\"x\"\nversion=\"0.0.0\"\nedition=\"2021\"\n");
+    write(
+        &root.join("Cargo.toml"),
+        "[package]\nname=\"x\"\nversion=\"0.0.0\"\nedition=\"2021\"\n",
+    );
     // Two functions named `helper` in different files. `use` brings each
     // into scope so pass A resolves the calls precisely (no receiver).
     write(
@@ -337,12 +343,17 @@ pub mod consumer_b;
 fn callers_with_flag_form_matches_positional_form() {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();
-    write(&root.join("Cargo.toml"), "[package]\nname=\"x\"\nversion=\"0.0.0\"\nedition=\"2021\"\n");
-    write(&root.join("src/lib.rs"), "pub mod h;\nuse crate::h::greet;\npub fn run() { greet(); }\n");
+    write(
+        &root.join("Cargo.toml"),
+        "[package]\nname=\"x\"\nversion=\"0.0.0\"\nedition=\"2021\"\n",
+    );
+    write(
+        &root.join("src/lib.rs"),
+        "pub mod h;\nuse crate::h::greet;\npub fn run() { greet(); }\n",
+    );
     write(&root.join("src/h.rs"), "pub fn greet() {}\n");
 
-    let (positional_out, code1) =
-        run_in(root, &["callers", "src/h.rs:greet", ".", "--rebuild"]);
+    let (positional_out, code1) = run_in(root, &["callers", "src/h.rs:greet", ".", "--rebuild"]);
     assert_eq!(code1, 0);
 
     // `--file` / `--symbol` form. Note: omit the trailing positional path
@@ -350,16 +361,29 @@ fn callers_with_flag_form_matches_positional_form() {
     // optional-target when both are present, same shape as `find-related`.
     let (flag_out, code2) = run_in(
         root,
-        &["callers", "--file", "src/h.rs", "--symbol", "greet", "--rebuild"],
+        &[
+            "callers",
+            "--file",
+            "src/h.rs",
+            "--symbol",
+            "greet",
+            "--rebuild",
+        ],
     );
     assert_eq!(code2, 0);
 
     // Strip the header line which differs ("for 'X:Y'" vs "for 'X:Y'") —
     // both spell the target the same way after compose_target, so they
     // should match exactly. We compare the body lines for safety.
-    let body_pos: Vec<&str> = positional_out.lines().filter(|l| l.starts_with("src/")).collect();
+    let body_pos: Vec<&str> = positional_out
+        .lines()
+        .filter(|l| l.starts_with("src/"))
+        .collect();
     let body_flag: Vec<&str> = flag_out.lines().filter(|l| l.starts_with("src/")).collect();
-    assert_eq!(body_pos, body_flag, "flag form should match positional form");
+    assert_eq!(
+        body_pos, body_flag,
+        "flag form should match positional form"
+    );
     assert!(
         body_pos.iter().any(|l| l.contains("run")),
         "expected `run` in callers output, got:\n{}",
@@ -371,7 +395,10 @@ fn callers_with_flag_form_matches_positional_form() {
 fn callers_file_filter_unknown_path_errors() {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();
-    write(&root.join("Cargo.toml"), "[package]\nname=\"x\"\nversion=\"0.0.0\"\nedition=\"2021\"\n");
+    write(
+        &root.join("Cargo.toml"),
+        "[package]\nname=\"x\"\nversion=\"0.0.0\"\nedition=\"2021\"\n",
+    );
     write(&root.join("src/lib.rs"), "pub fn foo() {}\n");
     let out = Command::new(bin())
         .args(["callers", "src/nope.rs:foo", "."])
@@ -379,7 +406,11 @@ fn callers_file_filter_unknown_path_errors() {
         .env("NO_COLOR", "1")
         .output()
         .expect("run");
-    assert_eq!(out.status.code(), Some(2), "expected exit 2 when file filter has no matches");
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "expected exit 2 when file filter has no matches"
+    );
 }
 
 #[test]
@@ -389,14 +420,17 @@ fn passing_subdir_as_path_walks_up_to_project_root() {
     // `src/main.rs::run`. The `<file>:<symbol>` filter then silently missed.
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();
-    write(&root.join("Cargo.toml"), "[package]\nname=\"x\"\nversion=\"0.0.0\"\nedition=\"2021\"\n");
-    write(&root.join("src/lib.rs"), "pub mod h;\nuse crate::h::greet;\npub fn run() { greet(); }\n");
+    write(
+        &root.join("Cargo.toml"),
+        "[package]\nname=\"x\"\nversion=\"0.0.0\"\nedition=\"2021\"\n",
+    );
+    write(
+        &root.join("src/lib.rs"),
+        "pub mod h;\nuse crate::h::greet;\npub fn run() { greet(); }\n",
+    );
     write(&root.join("src/h.rs"), "pub fn greet() {}\n");
 
-    let (out, code) = run_in(
-        root,
-        &["callers", "src/h.rs:greet", "./src", "--rebuild"],
-    );
+    let (out, code) = run_in(root, &["callers", "src/h.rs:greet", "./src", "--rebuild"]);
     assert_eq!(code, 0, "callers exited non-zero: {}", out);
     assert!(
         out.contains("run"),
@@ -409,7 +443,10 @@ fn passing_subdir_as_path_walks_up_to_project_root() {
 fn rust_callers_on_trait_returns_implementations() {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();
-    write(&root.join("Cargo.toml"), "[package]\nname=\"x\"\nversion=\"0.0.0\"\nedition=\"2021\"\n");
+    write(
+        &root.join("Cargo.toml"),
+        "[package]\nname=\"x\"\nversion=\"0.0.0\"\nedition=\"2021\"\n",
+    );
     write(
         &root.join("src/lib.rs"),
         r#"
@@ -440,7 +477,10 @@ impl Animal for Cat { fn speak(&self) { println!("meow"); } }
 fn rust_callers_on_struct_returns_constructions() {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();
-    write(&root.join("Cargo.toml"), "[package]\nname=\"x\"\nversion=\"0.0.0\"\nedition=\"2021\"\n");
+    write(
+        &root.join("Cargo.toml"),
+        "[package]\nname=\"x\"\nversion=\"0.0.0\"\nedition=\"2021\"\n",
+    );
     write(
         &root.join("src/lib.rs"),
         r#"
@@ -475,7 +515,10 @@ fn callees_on_subtype_walks_to_ancestor_and_lists_its_methods() {
     // bases + the methods declared on those bases.
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();
-    write(&root.join("Cargo.toml"), "[package]\nname=\"x\"\nversion=\"0.0.0\"\nedition=\"2021\"\n");
+    write(
+        &root.join("Cargo.toml"),
+        "[package]\nname=\"x\"\nversion=\"0.0.0\"\nedition=\"2021\"\n",
+    );
     write(
         &root.join("src/lib.rs"),
         r#"
@@ -516,13 +559,20 @@ fn callees_on_root_type_reports_no_ancestors() {
     // without `impl X for` blocks) returns gracefully without errors.
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();
-    write(&root.join("Cargo.toml"), "[package]\nname=\"x\"\nversion=\"0.0.0\"\nedition=\"2021\"\n");
+    write(
+        &root.join("Cargo.toml"),
+        "[package]\nname=\"x\"\nversion=\"0.0.0\"\nedition=\"2021\"\n",
+    );
     write(
         &root.join("src/lib.rs"),
         "pub trait Animal { fn speak(&self); }\n",
     );
     let (out, code) = run_in(root, &["callees", "Animal", ".", "--rebuild"]);
-    assert_eq!(code, 0, "callees on root type should not error, got exit {}", code);
+    assert_eq!(
+        code, 0,
+        "callees on root type should not error, got exit {}",
+        code
+    );
     assert!(
         out.contains("no ancestors"),
         "expected `no ancestors` notice, got:\n{}",
@@ -773,7 +823,15 @@ int run() {
     );
     let (out, code) = run_in(
         root,
-        &["callees", "run", ".", "--rebuild", "--external", "--json", "--compact"],
+        &[
+            "callees",
+            "run",
+            ".",
+            "--rebuild",
+            "--external",
+            "--json",
+            "--compact",
+        ],
     );
     assert_eq!(code, 0, "callees exited non-zero: {}", out);
     let v: serde_json::Value = serde_json::from_str(out.trim())
@@ -785,9 +843,9 @@ int run() {
     // whose name is a *type* never gets resolved to that type's constructors.
     // If the resolver is later taught to map type names → constructors, this
     // assertion will need to switch to the resolved qn.
-    let has_construct = matches.iter().any(|m| {
-        m["kind"] == "construct" && m["target"].as_str() == Some("[unresolved] Greeter")
-    });
+    let has_construct = matches
+        .iter()
+        .any(|m| m["kind"] == "construct" && m["target"].as_str() == Some("[unresolved] Greeter"));
     assert!(
         has_construct,
         "expected a construct edge targeting `Greeter`, got:\n{}",
@@ -922,16 +980,24 @@ function run(): int {
     );
     let (out, code) = run_in(
         root,
-        &["callees", "run", ".", "--rebuild", "--external", "--json", "--compact"],
+        &[
+            "callees",
+            "run",
+            ".",
+            "--rebuild",
+            "--external",
+            "--json",
+            "--compact",
+        ],
     );
     assert_eq!(code, 0, "callees exited non-zero: {}", out);
     let v: serde_json::Value = serde_json::from_str(out.trim())
         .unwrap_or_else(|e| panic!("invalid JSON ({}):\n{}", e, out));
     let matches = v["matches"].as_array().expect("matches array");
 
-    let has_construct = matches.iter().any(|m| {
-        m["kind"] == "construct" && m["target"].as_str() == Some("[unresolved] Greeter")
-    });
+    let has_construct = matches
+        .iter()
+        .any(|m| m["kind"] == "construct" && m["target"].as_str() == Some("[unresolved] Greeter"));
     assert!(
         has_construct,
         "expected a construct edge targeting `Greeter`, got:\n{}",
@@ -939,8 +1005,7 @@ function run(): int {
     );
 
     let has_member_call = matches.iter().any(|m| {
-        m["kind"] == "call"
-            && m["target"].as_str() == Some("src/Demo.php::Greeter::greet")
+        m["kind"] == "call" && m["target"].as_str() == Some("src/Demo.php::Greeter::greet")
     });
     assert!(
         has_member_call,
@@ -949,8 +1014,7 @@ function run(): int {
     );
 
     let has_scoped_call = matches.iter().any(|m| {
-        m["kind"] == "call"
-            && m["target"].as_str() == Some("src/Demo.php::Greeter::greetStatic")
+        m["kind"] == "call" && m["target"].as_str() == Some("src/Demo.php::Greeter::greetStatic")
     });
     assert!(
         has_scoped_call,
@@ -1014,16 +1078,24 @@ end
     );
     let (out, code) = run_in(
         root,
-        &["callees", "run", ".", "--rebuild", "--external", "--json", "--compact"],
+        &[
+            "callees",
+            "run",
+            ".",
+            "--rebuild",
+            "--external",
+            "--json",
+            "--compact",
+        ],
     );
     assert_eq!(code, 0, "callees exited non-zero: {}", out);
     let v: serde_json::Value = serde_json::from_str(out.trim())
         .unwrap_or_else(|e| panic!("invalid JSON ({}):\n{}", e, out));
     let matches = v["matches"].as_array().expect("matches array");
 
-    let has_construct = matches.iter().any(|m| {
-        m["kind"] == "construct" && m["target"].as_str() == Some("[unresolved] Greeter")
-    });
+    let has_construct = matches
+        .iter()
+        .any(|m| m["kind"] == "construct" && m["target"].as_str() == Some("[unresolved] Greeter"));
     assert!(
         has_construct,
         "expected a construct edge targeting `Greeter`, got:\n{}",
@@ -1090,7 +1162,15 @@ function run(): void {
     );
     let (out, code) = run_in(
         root,
-        &["callees", "run", ".", "--rebuild", "--external", "--json", "--compact"],
+        &[
+            "callees",
+            "run",
+            ".",
+            "--rebuild",
+            "--external",
+            "--json",
+            "--compact",
+        ],
     );
     assert_eq!(code, 0, "callees exited non-zero: {}", out);
     let v: serde_json::Value = serde_json::from_str(out.trim())
@@ -1175,7 +1255,15 @@ function run(): int {
     );
     let (out, code) = run_in(
         root,
-        &["callees", "run", ".", "--rebuild", "--external", "--json", "--compact"],
+        &[
+            "callees",
+            "run",
+            ".",
+            "--rebuild",
+            "--external",
+            "--json",
+            "--compact",
+        ],
     );
     assert_eq!(code, 0, "callees exited non-zero: {}", out);
     let v: serde_json::Value = serde_json::from_str(out.trim())
@@ -1188,10 +1276,10 @@ function run(): int {
         .any(|m| m["target"].as_str() == Some("src/Demo.php::helper"));
     assert!(has_helper, "expected `helper` callee, got:\n{}", out);
 
-    let has_dollar_target = matches
-        .iter()
-        .any(|m| m["name"].as_str().is_some_and(|s| s.contains('$'))
-            || m["target"].as_str().is_some_and(|s| s.contains('$')));
+    let has_dollar_target = matches.iter().any(|m| {
+        m["name"].as_str().is_some_and(|s| s.contains('$'))
+            || m["target"].as_str().is_some_and(|s| s.contains('$'))
+    });
     assert!(
         !has_dollar_target,
         "no edge should reference a `$variable` callable, got:\n{}",
@@ -1234,7 +1322,14 @@ class Greeter extends Base {
     // verify by counting the callees of `caller`.
     let (out, code) = run_in(
         root,
-        &["callees", "caller", ".", "--external", "--json", "--compact"],
+        &[
+            "callees",
+            "caller",
+            ".",
+            "--external",
+            "--json",
+            "--compact",
+        ],
     );
     assert_eq!(code, 0, "callees exited non-zero: {}", out);
     let v: serde_json::Value = serde_json::from_str(out.trim()).expect("json");
@@ -1270,7 +1365,15 @@ function run(): object {
     );
     let (out, code) = run_in(
         root,
-        &["callees", "run", ".", "--rebuild", "--external", "--json", "--compact"],
+        &[
+            "callees",
+            "run",
+            ".",
+            "--rebuild",
+            "--external",
+            "--json",
+            "--compact",
+        ],
     );
     assert_eq!(code, 0, "callees exited non-zero: {}", out);
     let v: serde_json::Value = serde_json::from_str(out.trim()).expect("json");
@@ -1375,7 +1478,15 @@ class Greeter {
     );
     let (out, code) = run_in(
         root,
-        &["callees", "caller", ".", "--rebuild", "--external", "--json", "--compact"],
+        &[
+            "callees",
+            "caller",
+            ".",
+            "--rebuild",
+            "--external",
+            "--json",
+            "--compact",
+        ],
     );
     assert_eq!(code, 0, "callees exited non-zero: {}", out);
     let v: serde_json::Value = serde_json::from_str(out.trim()).expect("json");
@@ -1415,7 +1526,15 @@ end
     );
     let (out, code) = run_in(
         root,
-        &["callees", "caller_method", ".", "--rebuild", "--external", "--json", "--compact"],
+        &[
+            "callees",
+            "caller_method",
+            ".",
+            "--rebuild",
+            "--external",
+            "--json",
+            "--compact",
+        ],
     );
     assert_eq!(code, 0, "callees exited non-zero: {}", out);
     let v: serde_json::Value = serde_json::from_str(out.trim()).expect("json");
@@ -1476,7 +1595,10 @@ int Greeter::greet() { return 42; }
 fn callers_unknown_symbol_returns_error() {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();
-    write(&root.join("Cargo.toml"), "[package]\nname=\"x\"\nversion=\"0.0.0\"\nedition=\"2021\"\n");
+    write(
+        &root.join("Cargo.toml"),
+        "[package]\nname=\"x\"\nversion=\"0.0.0\"\nedition=\"2021\"\n",
+    );
     write(&root.join("src/lib.rs"), "pub fn a() {}\n");
     let out = Command::new(bin())
         .args(["callers", "nonexistent_sym_xyz", "."])
@@ -1484,7 +1606,11 @@ fn callers_unknown_symbol_returns_error() {
         .env("NO_COLOR", "1")
         .output()
         .expect("run");
-    assert_eq!(out.status.code(), Some(2), "expected exit 2 for unknown symbol");
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "expected exit 2 for unknown symbol"
+    );
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
         stderr.contains("no symbol matches"),
@@ -1518,7 +1644,10 @@ fn cache_mtime(root: &std::path::Path) -> Option<std::time::SystemTime> {
 fn deps_partial_invalidation_picks_up_new_import() {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();
-    write(&root.join("Cargo.toml"), "[package]\nname=\"x\"\nversion=\"0.0.0\"\nedition=\"2021\"\n");
+    write(
+        &root.join("Cargo.toml"),
+        "[package]\nname=\"x\"\nversion=\"0.0.0\"\nedition=\"2021\"\n",
+    );
     write(&root.join("src/lib.rs"), "pub mod a; pub mod b;\n");
     write(&root.join("src/a.rs"), "pub fn ping() {}\n");
     write(&root.join("src/b.rs"), "// no imports yet\n");
@@ -1529,7 +1658,10 @@ fn deps_partial_invalidation_picks_up_new_import() {
     let cache_before = cache_mtime(root).expect("cache should exist after first call");
 
     // Edit b.rs to import a. Bump mtime so delta detection fires reliably.
-    write(&root.join("src/b.rs"), "use crate::a;\npub fn pong() { a::ping(); }\n");
+    write(
+        &root.join("src/b.rs"),
+        "use crate::a;\npub fn pong() { a::ping(); }\n",
+    );
 
     // Same query without --rebuild should pick up the new edge.
     let (out2, code2) = run_in(root, &["deps", "src/b.rs"]);
@@ -1549,9 +1681,15 @@ fn deps_partial_invalidation_picks_up_new_import() {
 fn deps_partial_invalidation_drops_removed_file() {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();
-    write(&root.join("Cargo.toml"), "[package]\nname=\"x\"\nversion=\"0.0.0\"\nedition=\"2021\"\n");
+    write(
+        &root.join("Cargo.toml"),
+        "[package]\nname=\"x\"\nversion=\"0.0.0\"\nedition=\"2021\"\n",
+    );
     write(&root.join("src/lib.rs"), "pub mod a; pub mod gone;\n");
-    write(&root.join("src/a.rs"), "use crate::gone;\npub fn run() { gone::say(); }\n");
+    write(
+        &root.join("src/a.rs"),
+        "use crate::gone;\npub fn run() { gone::say(); }\n",
+    );
     write(&root.join("src/gone.rs"), "pub fn say() {}\n");
 
     // Prime + verify the edge exists.
@@ -1565,14 +1703,20 @@ fn deps_partial_invalidation_drops_removed_file() {
     // Re-query reverse-deps on a.rs — the partial update should have dropped
     // gone.rs entirely; asking reverse-deps for it should error out.
     let (_, code) = run_in(root, &["reverse-deps", "src/gone.rs"]);
-    assert_eq!(code, 2, "removed file should not be part of dep graph anymore");
+    assert_eq!(
+        code, 2,
+        "removed file should not be part of dep graph anymore"
+    );
 }
 
 #[test]
 fn calls_partial_invalidation_demotes_stale_target() {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();
-    write(&root.join("Cargo.toml"), "[package]\nname=\"x\"\nversion=\"0.0.0\"\nedition=\"2021\"\n");
+    write(
+        &root.join("Cargo.toml"),
+        "[package]\nname=\"x\"\nversion=\"0.0.0\"\nedition=\"2021\"\n",
+    );
     write(&root.join("src/lib.rs"), "pub mod a; pub mod b;\n");
     write(&root.join("src/a.rs"), "pub fn helper() {}\n");
     write(
@@ -1606,14 +1750,23 @@ fn calls_partial_invalidation_demotes_stale_target() {
 fn calls_partial_invalidation_picks_up_new_caller() {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();
-    write(&root.join("Cargo.toml"), "[package]\nname=\"x\"\nversion=\"0.0.0\"\nedition=\"2021\"\n");
+    write(
+        &root.join("Cargo.toml"),
+        "[package]\nname=\"x\"\nversion=\"0.0.0\"\nedition=\"2021\"\n",
+    );
     write(&root.join("src/lib.rs"), "pub mod a;\n");
-    write(&root.join("src/a.rs"), "pub fn helper() {}\npub fn first() { helper(); }\n");
+    write(
+        &root.join("src/a.rs"),
+        "pub fn helper() {}\npub fn first() { helper(); }\n",
+    );
 
     // Prime — `helper` has one caller.
     let (out, _) = run_in(root, &["callers", "helper", "."]);
     assert!(out.contains("first"), "baseline missing first: {out}");
-    assert!(!out.contains("second"), "second should not exist yet: {out}");
+    assert!(
+        !out.contains("second"),
+        "second should not exist yet: {out}"
+    );
 
     // Add a second caller in the same file.
     write(
@@ -1636,7 +1789,10 @@ fn rust_callers_on_struct_finds_struct_literal_construction() {
     // covered above.
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();
-    write(&root.join("Cargo.toml"), "[package]\nname=\"x\"\nversion=\"0.0.0\"\nedition=\"2021\"\n");
+    write(
+        &root.join("Cargo.toml"),
+        "[package]\nname=\"x\"\nversion=\"0.0.0\"\nedition=\"2021\"\n",
+    );
     write(
         &root.join("src/lib.rs"),
         r#"
@@ -1669,7 +1825,10 @@ fn callers_tests_flag_reaches_tests_through_production_intermediate() {
     // output, not reachability.
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();
-    write(&root.join("Cargo.toml"), "[package]\nname=\"x\"\nversion=\"0.0.0\"\nedition=\"2021\"\n");
+    write(
+        &root.join("Cargo.toml"),
+        "[package]\nname=\"x\"\nversion=\"0.0.0\"\nedition=\"2021\"\n",
+    );
     write(
         &root.join("src/lib.rs"),
         "pub fn target() {}\npub fn wrapper() { target(); }\n",
@@ -1680,7 +1839,15 @@ fn callers_tests_flag_reaches_tests_through_production_intermediate() {
     );
     let (out, code) = run_in(
         root,
-        &["callers", "target", ".", "--depth", "2", "--tests", "--rebuild"],
+        &[
+            "callers",
+            "target",
+            ".",
+            "--depth",
+            "2",
+            "--tests",
+            "--rebuild",
+        ],
     );
     assert_eq!(code, 0, "callers exited non-zero: {}", out);
     assert!(

--- a/tests/cli_ergonomics.rs
+++ b/tests/cli_ergonomics.rs
@@ -65,11 +65,7 @@ fn digest_typo_path_exits_zero_with_note() {
 
 #[test]
 fn implements_typo_path_exits_zero_with_note() {
-    let (ok, stdout, _) = run(&[
-        "implements",
-        "Foo",
-        "/tmp/ast-bro-does-not-exist-xyz",
-    ]);
+    let (ok, stdout, _) = run(&["implements", "Foo", "/tmp/ast-bro-does-not-exist-xyz"]);
     assert!(ok, "must exit 0");
     assert!(
         stdout.contains("# note: path not found:"),
@@ -79,11 +75,7 @@ fn implements_typo_path_exits_zero_with_note() {
 
 #[test]
 fn show_missing_path_exits_zero_with_note() {
-    let (ok, stdout, _) = run(&[
-        "show",
-        "/tmp/ast-bro-does-not-exist-xyz",
-        "Foo",
-    ]);
+    let (ok, stdout, _) = run(&["show", "/tmp/ast-bro-does-not-exist-xyz", "Foo"]);
     assert!(ok, "must exit 0");
     assert!(
         stdout.contains("# note: path not found:"),

--- a/tests/context_e2e.rs
+++ b/tests/context_e2e.rs
@@ -57,16 +57,48 @@ fn large_budget_includes_target_body_and_neighbours() {
 
     let (out, code) = run_in(
         root,
-        &["context", "target_fn", ".", "--budget", "8000", "--json", "--rebuild"],
+        &[
+            "context",
+            "target_fn",
+            ".",
+            "--budget",
+            "8000",
+            "--json",
+            "--rebuild",
+        ],
     );
     assert_eq!(code, 0, "context exited non-zero: {}", out);
 
-    assert!(out.contains(r#""label": "target""#), "expected full-body target entry, got:\n{}", out);
-    assert!(out.contains("helper_dep() + 1"), "expected target body inline, got:\n{}", out);
-    assert!(out.contains("helper_dep"), "expected direct dependency helper_dep, got:\n{}", out);
-    assert!(out.contains("top_caller"), "expected direct dependent top_caller, got:\n{}", out);
-    assert!(out.contains(r#""truncated": false"#), "nothing should be truncated at 8000 tokens, got:\n{}", out);
-    assert!(out.contains(r#""target_omitted": false"#), "target must not be omitted, got:\n{}", out);
+    assert!(
+        out.contains(r#""label": "target""#),
+        "expected full-body target entry, got:\n{}",
+        out
+    );
+    assert!(
+        out.contains("helper_dep() + 1"),
+        "expected target body inline, got:\n{}",
+        out
+    );
+    assert!(
+        out.contains("helper_dep"),
+        "expected direct dependency helper_dep, got:\n{}",
+        out
+    );
+    assert!(
+        out.contains("top_caller"),
+        "expected direct dependent top_caller, got:\n{}",
+        out
+    );
+    assert!(
+        out.contains(r#""truncated": false"#),
+        "nothing should be truncated at 8000 tokens, got:\n{}",
+        out
+    );
+    assert!(
+        out.contains(r#""target_omitted": false"#),
+        "target must not be omitted, got:\n{}",
+        out
+    );
 }
 
 #[test]
@@ -89,10 +121,22 @@ pub fn target_fn() -> String {
 
     let (out, code) = run_in(
         root,
-        &["context", "target_fn", ".", "--budget", "10", "--json", "--rebuild"],
+        &[
+            "context",
+            "target_fn",
+            ".",
+            "--budget",
+            "10",
+            "--json",
+            "--rebuild",
+        ],
     );
     assert_eq!(code, 0, "context exited non-zero: {}", out);
-    assert!(out.contains(r#""target_omitted": true"#), "expected target body omitted, got:\n{}", out);
+    assert!(
+        out.contains(r#""target_omitted": true"#),
+        "expected target body omitted, got:\n{}",
+        out
+    );
     assert!(
         out.contains("signature only — budget"),
         "expected signature-only degradation label, got:\n{}",
@@ -125,10 +169,22 @@ pub fn target_fn() -> u64 {
 
     let (out, code) = run_in(
         root,
-        &["context", "target_fn", ".", "--budget", "40", "--json", "--rebuild"],
+        &[
+            "context",
+            "target_fn",
+            ".",
+            "--budget",
+            "40",
+            "--json",
+            "--rebuild",
+        ],
     );
     assert_eq!(code, 0, "context exited non-zero: {}", out);
-    assert!(out.contains(r#""truncated": true"#), "expected truncated=true when the callee can't fit, got:\n{}", out);
+    assert!(
+        out.contains(r#""truncated": true"#),
+        "expected truncated=true when the callee can't fit, got:\n{}",
+        out
+    );
 }
 
 #[test]
@@ -152,7 +208,15 @@ pub fn target_fn(n: u32) -> u32 {
 
     let (out, code) = run_in(
         root,
-        &["context", "target_fn", ".", "--budget", "8000", "--json", "--rebuild"],
+        &[
+            "context",
+            "target_fn",
+            ".",
+            "--budget",
+            "8000",
+            "--json",
+            "--rebuild",
+        ],
     );
     assert_eq!(code, 0, "context exited non-zero: {}", out);
     let occurrences = out.matches(r#""qn": "src/lib.rs::buddy""#).count();

--- a/tests/cpp_adapter.rs
+++ b/tests/cpp_adapter.rs
@@ -51,7 +51,10 @@ fn struct_fields_and_class_field_surfaced() {
     let s = run(&["map", FIXTURE]);
     assert!(s.contains("int x"), "struct field x missing:\n{s}");
     assert!(s.contains("int y"), "struct field y missing:\n{s}");
-    assert!(s.contains("int sides_"), "private class field missing:\n{s}");
+    assert!(
+        s.contains("int sides_"),
+        "private class field missing:\n{s}"
+    );
 }
 
 #[test]

--- a/tests/deps_e2e.rs
+++ b/tests/deps_e2e.rs
@@ -27,7 +27,9 @@ fn run_ok(args: &[&str]) -> String {
     assert!(
         code == 0,
         "expected exit 0, got {}\nstdout: {}\nstderr: {}",
-        code, stdout, stderr
+        code,
+        stdout,
+        stderr
     );
     stdout
 }
@@ -61,11 +63,7 @@ fn rust_simple_reverse_deps() {
 
 #[test]
 fn rust_cycle_detected() {
-    let (code, stdout, _stderr) = run(&[
-        "cycles",
-        "tests/fixtures/deps/rust_cycle",
-        "--rebuild",
-    ]);
+    let (code, stdout, _stderr) = run(&["cycles", "tests/fixtures/deps/rust_cycle", "--rebuild"]);
     assert_eq!(code, 3, "cycles command should exit 3 when cycle present");
     assert!(stdout.contains("cycle"), "missing cycle word: {stdout}");
     assert!(stdout.contains("a.rs"), "missing a.rs: {stdout}");
@@ -74,13 +72,12 @@ fn rust_cycle_detected() {
 
 #[test]
 fn rust_simple_no_cycle() {
-    let (code, stdout, _) = run(&[
-        "cycles",
-        "tests/fixtures/deps/rust_simple",
-        "--rebuild",
-    ]);
+    let (code, stdout, _) = run(&["cycles", "tests/fixtures/deps/rust_simple", "--rebuild"]);
     assert_eq!(code, 0, "expected exit 0 (no cycles): {stdout}");
-    assert!(stdout.contains("no cycles"), "expected no cycles message: {stdout}");
+    assert!(
+        stdout.contains("no cycles"),
+        "expected no cycles message: {stdout}"
+    );
 }
 
 // ---- Python ----
@@ -94,7 +91,10 @@ fn python_relative_from_import() {
         "1",
         "--rebuild",
     ]);
-    assert!(s.contains("helpers.py"), "expected helpers.py in deps:\n{s}");
+    assert!(
+        s.contains("helpers.py"),
+        "expected helpers.py in deps:\n{s}"
+    );
 }
 
 #[test]
@@ -200,15 +200,15 @@ fn cache_round_trip_returns_same_graph() {
         "--json",
         "--rebuild",
     ]);
-    let s2 = run_ok(&[
-        "graph",
-        "tests/fixtures/deps/rust_simple",
-        "--json",
-    ]);
+    let s2 = run_ok(&["graph", "tests/fixtures/deps/rust_simple", "--json"]);
     // Strip `built_at` since it differs run-to-run.
     let extract = |s: &str| {
         let v: serde_json::Value = serde_json::from_str(s).unwrap();
-        (v["file_count"].clone(), v["edge_count"].clone(), v["edges"].clone())
+        (
+            v["file_count"].clone(),
+            v["edge_count"].clone(),
+            v["edges"].clone(),
+        )
     };
     let (f1, e1, edges1) = extract(&s1);
     let (f2, e2, edges2) = extract(&s2);
@@ -357,7 +357,10 @@ fn cpp_reverse_deps() {
     ]);
     // util.h is included by lib.h and util.cpp; lib.h is included by main.cpp.
     assert!(s.contains("lib.h"), "expected lib.h as importer:\n{s}");
-    assert!(s.contains("util.cpp"), "expected util.cpp as importer:\n{s}");
+    assert!(
+        s.contains("util.cpp"),
+        "expected util.cpp as importer:\n{s}"
+    );
 }
 
 // ---- Ruby ----

--- a/tests/digest_format.rs
+++ b/tests/digest_format.rs
@@ -73,10 +73,7 @@ fn digest_legend_includes_overloads_when_overload_collapse_fires() {
 
 #[test]
 fn digest_legend_includes_deprecated_only_when_present() {
-    let dir = std::env::temp_dir().join(format!(
-        "ast-bro-legend-test-{}",
-        std::process::id()
-    ));
+    let dir = std::env::temp_dir().join(format!("ast-bro-legend-test-{}", std::process::id()));
     let _ = std::fs::create_dir_all(&dir);
     let f = dir.join("dep.rs");
     std::fs::write(&f, "#[deprecated]\npub fn old() {}\n").expect("write");
@@ -100,10 +97,7 @@ fn file_header_shows_size_label_and_char_count() {
         header.contains("[tiny]") || header.contains("[small]"),
         "missing size label:\n{header}"
     );
-    assert!(
-        header.contains("chars"),
-        "missing char count:\n{header}"
-    );
+    assert!(header.contains("chars"), "missing char count:\n{header}");
     // Token estimate was deliberately skipped — different tokenizers
     // produce different counts, char count is the honest metric.
     assert!(
@@ -143,10 +137,7 @@ fn rust_trait_renders_as_trait_not_interface() {
 #[test]
 fn deprecated_and_modifier_markers() {
     // Build a quick fixture inline.
-    let dir = std::env::temp_dir().join(format!(
-        "ast-bro-digest-test-{}",
-        std::process::id()
-    ));
+    let dir = std::env::temp_dir().join(format!("ast-bro-digest-test-{}", std::process::id()));
     let _ = std::fs::create_dir_all(&dir);
     let f = dir.join("dep.rs");
     std::fs::write(
@@ -178,10 +169,7 @@ fn deprecated_and_modifier_markers() {
 
 #[test]
 fn python_decorator_modifiers_and_deprecation() {
-    let dir = std::env::temp_dir().join(format!(
-        "ast-bro-py-test-{}",
-        std::process::id()
-    ));
+    let dir = std::env::temp_dir().join(format!("ast-bro-py-test-{}", std::process::id()));
     let _ = std::fs::create_dir_all(&dir);
     let f = dir.join("p.py");
     std::fs::write(
@@ -190,7 +178,10 @@ fn python_decorator_modifiers_and_deprecation() {
     )
     .expect("write");
     let s = run(&["digest", f.to_str().unwrap()]);
-    assert!(s.contains("[async]") && s.contains("[deprecated]"), "py async/deprecated:\n{s}");
+    assert!(
+        s.contains("[async]") && s.contains("[deprecated]"),
+        "py async/deprecated:\n{s}"
+    );
     assert!(s.contains("[classmethod]"), "py classmethod:\n{s}");
     assert!(s.contains("[static]"), "py staticmethod:\n{s}");
     assert!(s.contains("[property]"), "py property:\n{s}");
@@ -199,10 +190,7 @@ fn python_decorator_modifiers_and_deprecation() {
 
 #[test]
 fn typescript_modifiers_and_deprecation() {
-    let dir = std::env::temp_dir().join(format!(
-        "ast-bro-ts-test-{}",
-        std::process::id()
-    ));
+    let dir = std::env::temp_dir().join(format!("ast-bro-ts-test-{}", std::process::id()));
     let _ = std::fs::create_dir_all(&dir);
     let f = dir.join("s.ts");
     std::fs::write(
@@ -220,10 +208,7 @@ fn typescript_modifiers_and_deprecation() {
 
 #[test]
 fn kotlin_native_kind_data_and_sealed() {
-    let dir = std::env::temp_dir().join(format!(
-        "ast-bro-kt-test-{}",
-        std::process::id()
-    ));
+    let dir = std::env::temp_dir().join(format!("ast-bro-kt-test-{}", std::process::id()));
     let _ = std::fs::create_dir_all(&dir);
     let f = dir.join("k.kt");
     std::fs::write(
@@ -233,7 +218,10 @@ fn kotlin_native_kind_data_and_sealed() {
     .expect("write");
     let s = run(&["digest", f.to_str().unwrap()]);
     assert!(s.contains("data class"), "kotlin native data class:\n{s}");
-    assert!(s.contains("sealed class"), "kotlin native sealed class:\n{s}");
+    assert!(
+        s.contains("sealed class"),
+        "kotlin native sealed class:\n{s}"
+    );
     assert!(
         !s.contains("sealed sealed"),
         "modifier should not be re-emitted when already in native_kind:\n{s}"
@@ -244,10 +232,7 @@ fn kotlin_native_kind_data_and_sealed() {
 
 #[test]
 fn java_deprecation_annotation() {
-    let dir = std::env::temp_dir().join(format!(
-        "ast-bro-java-test-{}",
-        std::process::id()
-    ));
+    let dir = std::env::temp_dir().join(format!("ast-bro-java-test-{}", std::process::id()));
     let _ = std::fs::create_dir_all(&dir);
     let f = dir.join("J.java");
     std::fs::write(
@@ -256,7 +241,10 @@ fn java_deprecation_annotation() {
     )
     .expect("write");
     let s = run(&["digest", f.to_str().unwrap()]);
-    assert!(s.contains("[deprecated]"), "@Deprecated → [deprecated]:\n{s}");
+    assert!(
+        s.contains("[deprecated]"),
+        "@Deprecated → [deprecated]:\n{s}"
+    );
     assert!(s.contains("[static]"), "java static:\n{s}");
     assert!(s.contains("[abstract]"), "java abstract:\n{s}");
     let _ = std::fs::remove_dir_all(&dir);
@@ -264,10 +252,7 @@ fn java_deprecation_annotation() {
 
 #[test]
 fn go_deprecation_doc_convention() {
-    let dir = std::env::temp_dir().join(format!(
-        "ast-bro-go-test-{}",
-        std::process::id()
-    ));
+    let dir = std::env::temp_dir().join(format!("ast-bro-go-test-{}", std::process::id()));
     let _ = std::fs::create_dir_all(&dir);
     let f = dir.join("g.go");
     std::fs::write(
@@ -285,10 +270,7 @@ fn go_deprecation_doc_convention() {
 
 #[test]
 fn overload_collapse() {
-    let dir = std::env::temp_dir().join(format!(
-        "ast-bro-overload-test-{}",
-        std::process::id()
-    ));
+    let dir = std::env::temp_dir().join(format!("ast-bro-overload-test-{}", std::process::id()));
     let _ = std::fs::create_dir_all(&dir);
     let f = dir.join("ovl.rs");
     // Three free fns with the same name — different module-level overloads

--- a/tests/impact_e2e.rs
+++ b/tests/impact_e2e.rs
@@ -33,7 +33,10 @@ fn impact_on_type_finds_implementors() {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();
 
-    write(&root.join("Cargo.toml"), "[package]\nname=\"smoke\"\nversion=\"0.0.0\"\nedition=\"2021\"\n");
+    write(
+        &root.join("Cargo.toml"),
+        "[package]\nname=\"smoke\"\nversion=\"0.0.0\"\nedition=\"2021\"\n",
+    );
     write(
         &root.join("src/lib.rs"),
         r#"
@@ -51,8 +54,16 @@ pub fn create_animal() -> Box<dyn Animal> {
     let (out, code) = run_in(root, &["impact", "Animal", "--rebuild"]);
     assert_eq!(code, 0, "impact exited non-zero: {}", out);
 
-    assert!(out.contains("Dog"), "expected Dog (implementor of Animal), got:\n{}", out);
-    assert!(out.contains("struct"), "expected Dog to be labeled as struct, got:\n{}", out);
+    assert!(
+        out.contains("Dog"),
+        "expected Dog (implementor of Animal), got:\n{}",
+        out
+    );
+    assert!(
+        out.contains("struct"),
+        "expected Dog to be labeled as struct, got:\n{}",
+        out
+    );
 }
 
 #[test]
@@ -60,7 +71,10 @@ fn impact_on_struct_finds_construction_sites() {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();
 
-    write(&root.join("Cargo.toml"), "[package]\nname=\"smoke\"\nversion=\"0.0.0\"\nedition=\"2021\"\n");
+    write(
+        &root.join("Cargo.toml"),
+        "[package]\nname=\"smoke\"\nversion=\"0.0.0\"\nedition=\"2021\"\n",
+    );
     write(
         &root.join("src/lib.rs"),
         r#"
@@ -86,7 +100,10 @@ fn impact_on_type_dependents_mode_not_empty() {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();
 
-    write(&root.join("Cargo.toml"), "[package]\nname=\"smoke\"\nversion=\"0.0.0\"\nedition=\"2021\"\n");
+    write(
+        &root.join("Cargo.toml"),
+        "[package]\nname=\"smoke\"\nversion=\"0.0.0\"\nedition=\"2021\"\n",
+    );
     write(
         &root.join("src/lib.rs"),
         r#"
@@ -96,9 +113,15 @@ impl MyTrait for MyImpl {}
 "#,
     );
 
-    let (out, code) = run_in(root, &["impact", "MyTrait", "--mode", "dependents", "--rebuild"]);
+    let (out, code) = run_in(
+        root,
+        &["impact", "MyTrait", "--mode", "dependents", "--rebuild"],
+    );
     assert_eq!(code, 0);
-    assert!(out.contains("MyImpl"), "dependents mode should show MyImpl for MyTrait");
+    assert!(
+        out.contains("MyImpl"),
+        "dependents mode should show MyImpl for MyTrait"
+    );
 }
 
 #[test]
@@ -106,7 +129,10 @@ fn impact_transitive_for_type() {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();
 
-    write(&root.join("Cargo.toml"), "[package]\nname=\"smoke\"\nversion=\"0.0.0\"\nedition=\"2021\"\n");
+    write(
+        &root.join("Cargo.toml"),
+        "[package]\nname=\"smoke\"\nversion=\"0.0.0\"\nedition=\"2021\"\n",
+    );
     write(
         &root.join("src/lib.rs"),
         r#"
@@ -132,7 +158,11 @@ pub fn factory() {
     assert_eq!(code, 0);
 
     // Depth 1: MyService is an implementor of Service.
-    assert!(out.contains("MyService"), "expected MyService (implementor), got:\n{}", out);
+    assert!(
+        out.contains("MyService"),
+        "expected MyService (implementor), got:\n{}",
+        out
+    );
 
     // Depth 2: make_service constructs the implementor (`MyService {}`),
     // so it depends on the base type transitively.
@@ -153,7 +183,10 @@ fn impact_transitive_for_callable() {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();
 
-    write(&root.join("Cargo.toml"), "[package]\nname=\"smoke\"\nversion=\"0.0.0\"\nedition=\"2021\"\n");
+    write(
+        &root.join("Cargo.toml"),
+        "[package]\nname=\"smoke\"\nversion=\"0.0.0\"\nedition=\"2021\"\n",
+    );
     write(
         &root.join("src/lib.rs"),
         r#"
@@ -165,7 +198,19 @@ pub fn caller2() { caller1(); }
 
     let (out, code) = run_in(root, &["impact", "target", "--depth", "2", "--rebuild"]);
     assert_eq!(code, 0);
-    assert!(out.contains("caller1"), "expected caller1 (depth 1), got:\n{}", out);
-    assert!(out.contains("caller2"), "expected caller2 (depth 2), got:\n{}", out);
-    assert!(out.contains("1 symbols transitively affected"), "expected 1 transitive symbol (caller2), got:\n{}", out);
+    assert!(
+        out.contains("caller1"),
+        "expected caller1 (depth 1), got:\n{}",
+        out
+    );
+    assert!(
+        out.contains("caller2"),
+        "expected caller2 (depth 2), got:\n{}",
+        out
+    );
+    assert!(
+        out.contains("1 symbols transitively affected"),
+        "expected 1 transitive symbol (caller2), got:\n{}",
+        out
+    );
 }

--- a/tests/php_adapter.rs
+++ b/tests/php_adapter.rs
@@ -30,7 +30,10 @@ fn run(args: &[&str]) -> String {
 #[test]
 fn namespace_interface_class_render() {
     let s = run(&["map", FIXTURE]);
-    assert!(s.contains("namespace App\\Billing"), "namespace missing:\n{s}");
+    assert!(
+        s.contains("namespace App\\Billing"),
+        "namespace missing:\n{s}"
+    );
     assert!(s.contains("interface Payable"), "interface missing:\n{s}");
     assert!(s.contains("class Account"), "class missing:\n{s}");
 }

--- a/tests/ruby_adapter.rs
+++ b/tests/ruby_adapter.rs
@@ -32,7 +32,10 @@ fn run(args: &[&str]) -> String {
 #[test]
 fn module_renders_as_namespace() {
     let s = run(&["map", FIXTURE]);
-    assert!(s.contains("namespace Billing"), "module → namespace missing:\n{s}");
+    assert!(
+        s.contains("namespace Billing"),
+        "module → namespace missing:\n{s}"
+    );
     assert!(s.contains("class Account"), "nested class missing:\n{s}");
 }
 
@@ -42,7 +45,10 @@ fn private_and_protected_visibility_tracked() {
     // not fields on the AST — the adapter tracks them as state in the
     // class-body walk and applies them to every following method.
     let s = run(&["map", FIXTURE]);
-    assert!(s.contains("private def secret"), "private method missing:\n{s}");
+    assert!(
+        s.contains("private def secret"),
+        "private method missing:\n{s}"
+    );
     assert!(
         s.contains("protected def helper"),
         "protected method missing:\n{s}"
@@ -66,7 +72,10 @@ fn attr_macros_and_rails_associations_surface() {
 fn constants_and_singleton_methods_render() {
     let s = run(&["map", FIXTURE]);
     assert!(s.contains("VERSION"), "constant missing:\n{s}");
-    assert!(s.contains("def self.find"), "singleton method missing:\n{s}");
+    assert!(
+        s.contains("def self.find"),
+        "singleton method missing:\n{s}"
+    );
 }
 
 #[test]

--- a/tests/rust_adapter.rs
+++ b/tests/rust_adapter.rs
@@ -70,10 +70,7 @@ fn extern_block_surfaced_as_namespace() {
         s.contains("namespace extern \"C\""),
         "extern block not surfaced as namespace:\n{s}"
     );
-    assert!(
-        s.contains("pub fn libc_strlen"),
-        "foreign fn missing:\n{s}"
-    );
+    assert!(s.contains("pub fn libc_strlen"), "foreign fn missing:\n{s}");
     assert!(
         s.contains("pub static LIBC_ERRNO"),
         "foreign static missing:\n{s}"

--- a/tests/squeeze_e2e.rs
+++ b/tests/squeeze_e2e.rs
@@ -141,13 +141,16 @@ fn json_output_matches_squeeze_schema() {
         out.contains("ast-bro.squeeze.v1"),
         "missing JSON schema id:\n{out}"
     );
-    assert!(out.contains("\"emitted\""), "missing 'emitted' field:\n{out}");
+    assert!(
+        out.contains("\"emitted\""),
+        "missing 'emitted' field:\n{out}"
+    );
 
     // It must be valid JSON. We avoid a hard dep on a JSON crate's typed model
     // and instead do a lenient structural parse with serde_json::Value, which
     // is already a transitive dependency of the project.
-    let v: serde_json::Value =
-        serde_json::from_str(&out).unwrap_or_else(|e| panic!("stdout is not valid JSON: {e}\n{out}"));
+    let v: serde_json::Value = serde_json::from_str(&out)
+        .unwrap_or_else(|e| panic!("stdout is not valid JSON: {e}\n{out}"));
     assert_eq!(
         v.get("schema").and_then(|s| s.as_str()),
         Some("ast-bro.squeeze.v1"),
@@ -178,11 +181,14 @@ fn json_compact_is_single_line() {
         "compact JSON missing schema id:\n{out}"
     );
     // Compact JSON should still parse.
-    let _v: serde_json::Value =
-        serde_json::from_str(out.trim()).unwrap_or_else(|e| panic!("compact stdout not valid JSON: {e}\n{out}"));
+    let _v: serde_json::Value = serde_json::from_str(out.trim())
+        .unwrap_or_else(|e| panic!("compact stdout not valid JSON: {e}\n{out}"));
     // pretty = !compact, so compact output is a single line (sans trailing newline).
     let line_count = out.trim_end_matches('\n').lines().count();
-    assert_eq!(line_count, 1, "compact JSON should be one line, got {line_count}:\n{out}");
+    assert_eq!(
+        line_count, 1,
+        "compact JSON should be one line, got {line_count}:\n{out}"
+    );
 }
 
 #[test]
@@ -196,7 +202,11 @@ fn raw_flag_emits_original_without_legend() {
     let out = run_ok(&["squeeze", path_str, "--raw"]);
 
     // --raw prints a `[raw ...]` header and NO legend / no squeeze claim.
-    assert!(out.contains("[raw"), "expected '[raw ...]' header:\n{}", &out[..out.len().min(200)]);
+    assert!(
+        out.contains("[raw"),
+        "expected '[raw ...]' header:\n{}",
+        &out[..out.len().min(200)]
+    );
     assert!(
         !out.contains("# legend:"),
         "--raw must not print a legend:\n{}",
@@ -230,12 +240,27 @@ fn line_range_limits_considered_lines() {
     let out = run_ok(&["squeeze", path_str, "2:4", "--raw"]);
 
     // Only lines 2..=4 should be considered.
-    assert!(out.contains("LINE_BRAVO"), "range should include line 2:\n{out}");
-    assert!(out.contains("LINE_CHARLIE"), "range should include line 3:\n{out}");
-    assert!(out.contains("LINE_DELTA"), "range should include line 4:\n{out}");
+    assert!(
+        out.contains("LINE_BRAVO"),
+        "range should include line 2:\n{out}"
+    );
+    assert!(
+        out.contains("LINE_CHARLIE"),
+        "range should include line 3:\n{out}"
+    );
+    assert!(
+        out.contains("LINE_DELTA"),
+        "range should include line 4:\n{out}"
+    );
     // Lines 1 and 5 are outside the range and must be excluded from the body.
-    assert!(!out.contains("LINE_ALPHA"), "line 1 should be excluded by range 2:4:\n{out}");
-    assert!(!out.contains("LINE_ECHO"), "line 5 should be excluded by range 2:4:\n{out}");
+    assert!(
+        !out.contains("LINE_ALPHA"),
+        "line 1 should be excluded by range 2:4:\n{out}"
+    );
+    assert!(
+        !out.contains("LINE_ECHO"),
+        "line 5 should be excluded by range 2:4:\n{out}"
+    );
 }
 
 #[test]
@@ -246,8 +271,8 @@ fn open_ended_json_range_clamps_end_to_eof() {
     let path_str = path.to_str().unwrap();
 
     let out = run_ok(&["squeeze", path_str, "2:", "--json"]);
-    let v: serde_json::Value =
-        serde_json::from_str(&out).unwrap_or_else(|e| panic!("stdout is not valid JSON: {e}\n{out}"));
+    let v: serde_json::Value = serde_json::from_str(&out)
+        .unwrap_or_else(|e| panic!("stdout is not valid JSON: {e}\n{out}"));
     let range = v
         .get("range")
         .and_then(|r| r.as_object())

--- a/tests/surface_e2e.rs
+++ b/tests/surface_e2e.rs
@@ -133,24 +133,24 @@ fn ts_barrel_resolves_named_glob_and_rename() {
         "Direct.greet missing:\n{s}"
     );
     // `export { Client } from './client'` — barrel resolution.
-    assert!(s.contains("ts_barrel.Client"), "Client barrel missing:\n{s}");
+    assert!(
+        s.contains("ts_barrel.Client"),
+        "Client barrel missing:\n{s}"
+    );
     assert!(
         s.contains("ts_barrel.Client.connect"),
         "Client.connect missing:\n{s}"
     );
     // Rename via `export { Util as Helper }`.
-    assert!(s.contains("ts_barrel.Helper"), "Helper rename missing:\n{s}");
     assert!(
-        !s.contains("ts_barrel.Util"),
-        "unrenamed Util leaked:\n{s}"
+        s.contains("ts_barrel.Helper"),
+        "Helper rename missing:\n{s}"
     );
+    assert!(!s.contains("ts_barrel.Util"), "unrenamed Util leaked:\n{s}");
     // `export *` glob — type and interface.
     assert!(s.contains("ts_barrel.Id"), "Id glob missing:\n{s}");
     assert!(s.contains("ts_barrel.Spec"), "Spec glob missing:\n{s}");
-    assert!(
-        s.contains("[via *]"),
-        "glob marker missing:\n{s}"
-    );
+    assert!(s.contains("[via *]"), "glob marker missing:\n{s}");
 }
 
 #[test]


### PR DESCRIPTION
- fix(clippy): use sort_by_key instead of sort_by in deps/manifest.rs
- fix(clippy): use sort_by_key instead of sort_by in deps/scc.rs
- fix(clippy): remove unnecessary .into_iter() in search/index.rs
- style: cargo fmt across all source files

Baseline:
  cargo check: 0 errors
  cargo clippy -D warnings: 3->0
  cargo fmt --check: 86 files diff->clean
  cargo test: 306 passed, 7 ignored, 1 pre-existing failure