### PR TITLE
fix(chunker): add TOML/PS1 file recognition for search indexing

### DIFF
--- a/src/search/chunker.rs
+++ b/src/search/chunker.rs
@@ -43,6 +43,7 @@ pub struct Chunk {
 pub enum ChunkerKind {
     AstGrep(SupportLang),
     Markdown,
+    Plain(&'static str),
 }
 
 impl ChunkerKind {
@@ -53,6 +54,7 @@ impl ChunkerKind {
         match self {
             ChunkerKind::AstGrep(lang) => format!("{lang:?}").to_ascii_lowercase(),
             ChunkerKind::Markdown => "markdown".to_string(),
+            ChunkerKind::Plain(name) => name.to_string(),
         }
     }
 }
@@ -69,6 +71,12 @@ pub fn is_indexable(path: &Path) -> Option<ChunkerKind> {
         .map(str::to_ascii_lowercase);
     if matches!(ext.as_deref(), Some("md" | "markdown" | "mdx" | "mdown")) {
         return Some(ChunkerKind::Markdown);
+    }
+    if ext.as_deref() == Some("toml") {
+        return Some(ChunkerKind::Plain("toml"));
+    }
+    if matches!(ext.as_deref(), Some("ps1" | "psm1" | "psd1")) {
+        return Some(ChunkerKind::Plain("powershell"));
     }
     SupportLang::from_path(path).map(ChunkerKind::AstGrep)
 }
@@ -94,6 +102,7 @@ pub fn chunk_source(source: &str, file_path: &str, kind: ChunkerKind) -> Vec<Chu
     let split_points = match kind {
         ChunkerKind::AstGrep(lang) => ast_grep_split_points(source, lang),
         ChunkerKind::Markdown => markdown_split_points(source),
+        ChunkerKind::Plain(_) => paragraph_split_points(source),
     };
     let lang_name = kind.language_name();
     pack(source, file_path, &lang_name, &split_points)
@@ -145,6 +154,32 @@ fn markdown_split_points(source: &str) -> Vec<usize> {
             if end > *points.last().unwrap() && end <= source.len() {
                 points.push(end);
             }
+        }
+    }
+    if *points.last().unwrap() < source.len() {
+        points.push(source.len());
+    }
+    points
+}
+
+/// Split at blank-line boundaries (consecutive newlines).
+/// Used for plain-text formats (TOML, PowerShell) that lack tree-sitter grammars.
+fn paragraph_split_points(source: &str) -> Vec<usize> {
+    let mut points = vec![0usize];
+    let bytes = source.as_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+    while i < len {
+        if bytes[i] == b'\n' {
+            let start = i;
+            while i < len && bytes[i] == b'\n' {
+                i += 1;
+            }
+            if i - start >= 2 && i < len {
+                points.push(i);
+            }
+        } else {
+            i += 1;
         }
     }
     if *points.last().unwrap() < source.len() {
@@ -385,5 +420,25 @@ content c
         let chunks = md(src);
         let joined: String = chunks.iter().map(|c| c.content.as_str()).collect();
         assert_eq!(joined, src);
+    }
+
+    #[test]
+    fn is_indexable_accepts_toml() {
+        assert!(
+            is_indexable(&PathBuf::from("Cargo.toml")).is_some(),
+            "expected .toml to be indexable"
+        );
+    }
+
+    #[test]
+    fn is_indexable_accepts_powershell() {
+        for ext in ["ps1", "psm1", "psd1"] {
+            let p = PathBuf::from(format!("script.{}", ext));
+            assert!(
+                is_indexable(&p).is_some(),
+                "expected .{} to be indexable",
+                ext
+            );
+        }
     }
 }


### PR DESCRIPTION
## 本 PR 做了什么
修复 ast-bro 搜索索引器（chunker）对 TOML 和 PowerShell 文件的识别缺陷。
`chunker::is_indexable()` 此前仅依赖 `SupportLang::from_path()` 检测文件类型，
而 `ast_grep_language` 枚举中不包含 TOML/PowerShell variant，
导致 `.toml` / `.ps1` / `.psm1` / `.psd1` 文件被搜索索引器跳过。

新增 `ChunkerKind::Plain` 变体，通过空行分段策略支持这些纯文本格式。

## 为什么需要
`map` / `digest` 命令可以通过 `can_parse_for_hook()` 中的硬编码扩展名列表正确
解析 TOML/PS1 文件，但 `index` / `search` 命令走独立的 `is_indexable()` 路径，
两条路径不一致导致：
- `ast-bro map Cargo.toml` ✅ 可解析
- `ast-bro search "serde"` ❌ 不返回 Cargo.toml 结果
- `ast-bro map monitor.ps1` ✅ 可解析
- `ast-bro search "Get-ProcessInfo"` ❌ 不返回 monitor.ps1 结果

## 审查者验证方式
### 如何验证
```bash
# 运行 chunker 测试套件
cargo test -p ast-bro --lib search::chunker::tests
# 验证新测试通过
cargo test is_indexable_accepts_toml
cargo test is_indexable_accepts_powershell
```

## 效果对比
**改前:** `is_indexable("Cargo.toml")` → `None`，文件不进入索引
**改后:** `is_indexable("Cargo.toml")` → `Some(ChunkerKind::Plain("toml"))`，文件被空行分段索引

## 已测试平台
| 系统 | 状态 |
|------|:----:|
| 🍏 macOS | ⚠️ 未测试 |
| 🪟 Windows | ✅ 已测试 (x86_64-pc-windows-msvc) |
| 🐧 Linux | ✅ 已测试 (x86_64-unknown-linux-gnu) |

## 验证命令
```bash
cd ast-bro
cargo check              # ✅
cargo clippy -- -D warnings  # ✅ 0 warnings
cargo fmt --check        # ✅
cargo test --lib         # ✅ 308 passed, 0 failed
```

## 风险与范围
- **主要风险:** 低——仅影响搜索索引器的文件类型检测逻辑，不改变已有格式的索引行为
- **未验证范围:** TOML/PS1 文件的实际搜索质量（索引→嵌入→搜索完整链路）、大文件的分段表现
- **破坏性变更:** 无

## 关联 Issue
无

<details>
<summary>English Translation</summary>

## What this PR does
Fixes the search indexer (chunker) to recognize TOML and PowerShell files.
Previously `chunker::is_indexable()` relied solely on `SupportLang::from_path()`,
which lacks TOML/PowerShell variants in `ast_grep_language`, causing
`.toml` / `.ps1` files to be silently skipped by the indexer.

Adds a `ChunkerKind::Plain` variant with paragraph-boundary splitting.

## Why it's needed
`map`/`digest` parse TOML/PS1 correctly via hardcoded extension checks in
`can_parse_for_hook()`, but `index`/`search` use a separate `is_indexable()`
path — creating an inconsistency where map works but search doesn't.

## Reviewer Test Plan
```bash
cargo test -p ast-bro --lib search::chunker::tests  # 16 passed
```

## Evidence (Before & After)
**Before:** `is_indexable("Cargo.toml")` → `None`
**After:** `is_indexable("Cargo.toml")` → `Some(ChunkerKind::Plain("toml"))`

## Risk & Scope
- **Main risk:** Low — only affects chunker file detection logic
- **Breaking changes:** None

</details>

## AI Assistance Disclosure
本 PR 使用 aspnmy-Qwen-Auto-Cli 辅助实现和审查。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Search and indexing capabilities have been extended to support TOML configuration files, including Cargo.toml and other `.toml` files
* Added support for indexing and searching PowerShell script files (`.ps1`, `.psm1`, `.psd1`)
* Enhanced content parsing for plain text formats with intelligent splitting at paragraph boundaries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->