### PR TITLE
Rework search chunking, add two-phase retrieval, and make results reproducible

### DIFF
--- a/src/file_filter.rs
+++ b/src/file_filter.rs
@@ -136,6 +136,53 @@ const TEST_FILE_SUFFIXES: &[&str] = &[
     "_tests", ".tests", "_specs", ".specs",
 ];
 
+/// Suffixes that end a compound test-directory name, lowercased.
+///
+/// Held apart from [`TEST_DIR_TOKENS`], which matches a whole component:
+/// a suffix counts only where [`names_a_test_dir`] finds a separator or a
+/// case boundary in front of it.
+const TEST_DIR_SUFFIXES: &[&str] = &["tests", "test", "specs", "spec"];
+
+/// Reports whether `component` names a test directory.
+///
+/// A component qualifies two ways: it equals a token in [`TEST_DIR_TOKENS`],
+/// or it ends with one of [`TEST_DIR_SUFFIXES`] introduced by `.`, `-`, `_`,
+/// or a lowercase-to-uppercase boundary. Matching is ASCII case-insensitive.
+///
+/// That introduction rule is doing real work in both directions. Without it
+/// `latest`, `contest` and `protests` become test directories; without the
+/// suffixes, `ICSharpCode.Decompiler.Tests/` and every other suffixed
+/// convention read as production code — on ILSpy, whole-component matching
+/// classified 0 of 1768 files as tests.
+fn names_a_test_dir(component: &str) -> bool {
+    let lower = component.to_ascii_lowercase();
+    if TEST_DIR_TOKENS.contains(&lower.as_str()) {
+        return true;
+    }
+    for suffix in TEST_DIR_SUFFIXES {
+        let Some(head) = lower.strip_suffix(suffix) else {
+            continue;
+        };
+        if head.is_empty() {
+            continue;
+        }
+        if head.ends_with(['.', '-', '_']) {
+            return true;
+        }
+        // `to_ascii_lowercase` preserves length, so `head.len()` indexes the
+        // same byte in the original spelling.
+        let starts_upper = component.as_bytes()[head.len()].is_ascii_uppercase();
+        let ends_lower = head
+            .bytes()
+            .next_back()
+            .is_some_and(|b| b.is_ascii_lowercase() || b.is_ascii_digit());
+        if starts_upper && ends_lower {
+            return true;
+        }
+    }
+    false
+}
+
 /// Return `true` when `path` (relative to `repo_root`) looks like a test
 /// file by path heuristics — covers `tests/`, `__tests__`,
 /// `*.test.ts`, `*_test.go`, `*.spec.js`, `e2e/`, `cypress/`, etc.
@@ -146,8 +193,7 @@ pub fn is_test_file(path: &Path, repo_root: &Path) -> bool {
     let rel = path.strip_prefix(repo_root).unwrap_or(path);
     for component in rel.components() {
         let s = component.as_os_str().to_string_lossy();
-        let lower = s.to_lowercase();
-        if TEST_DIR_TOKENS.iter().any(|t| *t == lower) {
+        if names_a_test_dir(&s) {
             return true;
         }
     }
@@ -253,6 +299,43 @@ pub fn detect_language(path: &Path) -> Option<ast_grep_language::SupportLang> {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+
+    /// A directory whose name ends in a test suffix after a separator or a
+    /// case boundary is a test path, not only one named exactly `test`.
+    #[test]
+    fn suffixed_test_directories_are_test_paths() {
+        let root = PathBuf::from("/repo");
+        for dir in [
+            "ICSharpCode.Decompiler.Tests",
+            "ILSpy.Tests",
+            "Foo.Test",
+            "FooTests",
+            "FooSpec",
+            "foo_test",
+            "foo-tests",
+            "api_specs",
+        ] {
+            assert!(
+                is_test_file(&root.join(dir).join("a.cs"), &root),
+                "{dir} should read as a test directory"
+            );
+        }
+    }
+
+    /// An ordinary word ending in the same letters stays a production path.
+    ///
+    /// Red here means the separator-or-case-boundary requirement was relaxed,
+    /// which demotes a whole directory tree out of every result list.
+    #[test]
+    fn words_that_merely_end_in_test_are_not_test_paths() {
+        let root = PathBuf::from("/repo");
+        for dir in ["latest", "contest", "protests", "greatest", "manifests", "attest"] {
+            assert!(
+                !is_test_file(&root.join(dir).join("a.rs"), &root),
+                "{dir} is not a test directory"
+            );
+        }
+    }
 
     #[test]
     fn skip_node_modules_anywhere() {

--- a/src/search/chunker.rs
+++ b/src/search/chunker.rs
@@ -1216,6 +1216,9 @@ fn build_outline_chunks(
 }
 
 #[cfg(test)]
+mod langs;
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use std::path::PathBuf;

--- a/src/search/chunker.rs
+++ b/src/search/chunker.rs
@@ -4,9 +4,10 @@
 //!
 //! - **Anything ast-grep can parse** (bash, cpp, css, c#, dart, elixir, go,
 //!   haskell, hcl, html, java, json, kotlin, lua, nix, php, python, ruby, rust,
-//!   scala, solidity, swift, ts/tsx/js, yaml) — split at top-level declaration
-//!   boundaries via ast-grep. The chunker doesn't need a per-language outline
-//!   adapter; it only needs the AST root + iteration of named children.
+//!   scala, solidity, swift, ts/tsx/js, yaml) — split at member boundaries via
+//!   ast-grep, descending through type containers to reach them. The chunker
+//!   doesn't need a per-language outline adapter; it only needs the AST root +
+//!   iteration of named children.
 //! - **Markdown** (`.md`/`.markdown`/`.mdx`/`.mdown`) — split at `section`
 //!   boundaries via raw `tree_sitter_md`.
 //! - **Plain text** (`.toml`, PowerShell `.ps1`/`.psm1`/`.psd1`) — formats
@@ -16,18 +17,43 @@
 //!   UTF-16-encoded `.ps1` files fail `read_to_string` and are skipped, like
 //!   everywhere else in the codebase.
 //!
-//! All paths feed the same greedy packer that targets `MAX_CHARS = 1500` and
-//! never splits mid-declaration. Files outside these sets are not chunked —
-//! `is_indexable` is the single source of truth for what gets indexed.
+//! Both paths feed the same greedy packer, which targets `MAX_CHARS = 1500`.
+//! Files outside both sets are not chunked — `is_indexable` is the single
+//! source of truth for what gets indexed.
+//!
+//! Output is a hierarchy rather than a partition, described by [`ChunkKind`]:
+//! `Source` and `Enclosing` tile the file once, `Part` re-covers the inside of
+//! a member too large to stand alone, and `Outline` synthesizes a signature
+//! list per file. Only the packer's own regions are size-bounded — a member is
+//! never split down the middle to hit the target.
 
 use ast_grep_core::{AstGrep, Language};
 use ast_grep_language::{LanguageExt, SupportLang};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
-/// Target chunk size in characters. Chunks may exceed this when a single
-/// top-level declaration is larger; they are not split mid-declaration.
+/// Target chunk size in characters. Chunks may exceed this when a declaration
+/// is larger even at `MAX_SPLIT_DEPTH`; they are not split mid-declaration.
 pub const MAX_CHARS: usize = 1500;
+
+/// What a chunk holds, which decides how retrieval should treat it.
+///
+/// `Source` and `Enclosing` together tile the file exactly once. `Part` chunks
+/// sit *inside* an `Enclosing` one, so the two levels overlap on purpose — a
+/// query can match the specific statement or the method that contains it.
+/// `Outline` is synthesized and covers no source bytes of its own.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum ChunkKind {
+    /// A contiguous slice of the file, packed at member boundaries.
+    #[default]
+    Source,
+    /// A member too large for one chunk, kept whole beside its parts.
+    Enclosing,
+    /// A body-level slice of an `Enclosing` member.
+    Part,
+    /// Signatures only, synthesized for the whole file — no body text.
+    Outline,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Chunk {
@@ -42,6 +68,12 @@ pub struct Chunk {
     pub end_byte: u32,
     /// Always set — language is known per `is_indexable`.
     pub language: String,
+    /// Enclosing declaration names, outermost first (`Outer > handle`). Empty
+    /// when nothing encloses the chunk, or for languages with no `name` field.
+    #[serde(default)]
+    pub breadcrumb: String,
+    #[serde(default)]
+    pub kind: ChunkKind,
 }
 
 /// Strategy used to chunk a given file.
@@ -105,71 +137,730 @@ pub fn chunk_file(path: &Path, file_path: &str) -> Vec<Chunk> {
 }
 
 /// Chunk pre-read source text using the given `kind`.
+///
+/// The result is a hierarchy, not a partition. A member too large to be one
+/// chunk is emitted whole *and* split into body-level parts, so a query can
+/// match either the specific statement or the method that contains it. Every
+/// source byte is still covered at least once.
 pub fn chunk_source(source: &str, file_path: &str, kind: ChunkerKind) -> Vec<Chunk> {
     if source.trim().is_empty() {
         return Vec::new();
     }
-    let split_points = match kind {
-        ChunkerKind::AstGrep(lang) => ast_grep_split_points(source, lang),
-        ChunkerKind::Markdown => markdown_split_points(source),
-        ChunkerKind::Plain(_) => paragraph_split_points(source),
-    };
     let lang_name = kind.language_name();
-    pack(source, file_path, &lang_name, &split_points)
+    let lines = LineIndex::new(source);
+    let lang = match kind {
+        ChunkerKind::AstGrep(lang) => lang,
+        ChunkerKind::Plain(_) => {
+            // Blank-line paragraphs, and nothing to synthesize an outline
+            // from: a TOML or PowerShell file declares no members.
+            let points = paragraph_split_points(source);
+            return pack(source, file_path, &lang_name, &lines, &points, ChunkKind::Source, "");
+        }
+        ChunkerKind::Markdown => {
+            let points = markdown_split_points(source);
+            let mut chunks =
+                pack(source, file_path, &lang_name, &lines, &points, ChunkKind::Source, "");
+            // Markdown needs outlines as much as code does, and for a sharper
+            // reason: two-phase retrieval can only ever *raise* a file's score,
+            // so a file with no outline cannot compete with one that has them.
+            // Without this a document loses to code on queries the document
+            // answers — the file type decided the ranking, not the relevance.
+            let plan = markdown_heading_plan(source);
+            chunks.extend(build_outline_chunks(file_path, &lang_name, &lines, &plan));
+            return chunks;
+        }
+    };
+
+    let plan = build_split_plan(source, lang);
+    let mut chunks = pack(
+        source,
+        file_path,
+        &lang_name,
+        &lines,
+        &plan.member_points,
+        ChunkKind::Source,
+        "",
+    );
+
+    // Level 2: the inside of each member that was too big to stand alone. The
+    // member itself stays in `chunks` above, retagged as Enclosing so ranking
+    // can prefer the finer-grained parts.
+    for deep in &plan.deep {
+        for c in chunks.iter_mut() {
+            if c.start_byte as usize <= deep.start && c.end_byte as usize >= deep.end {
+                c.kind = ChunkKind::Enclosing;
+                c.breadcrumb = deep.breadcrumb.clone();
+            }
+        }
+        chunks.extend(pack(
+            source,
+            file_path,
+            &lang_name,
+            &lines,
+            &deep.points,
+            ChunkKind::Part,
+            &deep.breadcrumb,
+        ));
+    }
+
+    assign_breadcrumbs(&plan, &mut chunks);
+
+    chunks.extend(build_outline_chunks(file_path, &lang_name, &lines, &plan));
+    chunks
 }
 
-/// Top-level named-child end-bytes for an ast-grep parse.
-fn ast_grep_split_points(source: &str, lang: SupportLang) -> Vec<usize> {
+/// Byte offsets of every newline in one source file, built once so a line
+/// number is a binary search instead of a scan.
+///
+/// Counting newlines from the start of the file per chunk is O(file) per call,
+/// and both the packer and the outline builder call it twice per chunk. On a
+/// 1.3 MB file producing 1289 chunks that came to 0.4 s of chunking, nearly
+/// all of it rescanning the same prefix.
+struct LineIndex {
+    newlines: Vec<usize>,
+}
+
+impl LineIndex {
+    fn new(source: &str) -> Self {
+        Self {
+            newlines: source
+                .as_bytes()
+                .iter()
+                .enumerate()
+                .filter(|(_, b)| **b == b'\n')
+                .map(|(i, _)| i)
+                .collect(),
+        }
+    }
+
+    /// 1-indexed line containing `byte`.
+    fn line_of(&self, byte: usize) -> u32 {
+        self.newlines.partition_point(|&pos| pos < byte) as u32 + 1
+    }
+}
+
+/// A member too large for one chunk: where it is, what encloses it, and the
+/// body-level boundaries its parts are packed from.
+struct DeepRegion {
+    start: usize,
+    end: usize,
+    breadcrumb: String,
+    points: Vec<usize>,
+}
+
+/// One member declaration seen during the walk, used for breadcrumbs and for
+/// the synthesized outline document.
+struct MemberSpan {
+    start: usize,
+    end: usize,
+    breadcrumb: String,
+    signature: String,
+}
+
+#[derive(Default)]
+struct SplitPlan {
+    member_points: Vec<usize>,
+    deep: Vec<DeepRegion>,
+    members: Vec<MemberSpan>,
+}
+
+/// Walk the parse once and collect everything the chunker needs: member
+/// boundaries, oversized members worth splitting further, and the member list
+/// the outline document is built from.
+fn build_split_plan(source: &str, lang: SupportLang) -> SplitPlan {
     let ast: AstGrep<_> = lang.ast_grep(source);
     let root = ast.root();
 
-    let mut points: Vec<usize> = vec![0];
-    for child in root.children() {
+    let mut plan = SplitPlan {
+        member_points: vec![0],
+        ..SplitPlan::default()
+    };
+    let mut trail: Vec<String> = Vec::new();
+    collect_split_points(&root, source, &mut plan, &mut trail, Descent::root(source.len()));
+    if *plan.member_points.last().unwrap() < source.len() {
+        plan.member_points.push(source.len());
+    }
+    plan
+}
+
+/// Maximum *narrowing* levels the member walk descends.
+///
+/// Counted in levels that actually shrink the region, not in AST nodes. A
+/// language that spends nodes on structure rather than on scope would
+/// otherwise exhaust the budget before reaching any member: Ruby costs two
+/// nodes per scope (the `class` and its `body_statement`), so
+/// `module/module/class/class` sat eight nodes deep and its methods were never
+/// opened.
+const MAX_SPLIT_DEPTH: u32 = 6;
+
+/// Backstop against pathological nesting, counted in AST nodes.
+///
+/// A chain of pass-through wrappers costs no levels, so [`MAX_SPLIT_DEPTH`]
+/// does not bound the walk on its own. Minified sources and deeply nested data
+/// nest far past anything a member walk needs.
+const MAX_AST_DESCENT: u32 = 64;
+
+/// A container this close in size to the one holding it is a pass-through
+/// wrapper, and costs no level.
+///
+/// `module Outer` wrapping `module Inner` wrapping a class tells the reader
+/// nothing new about size: each holds essentially the same bytes. Only a
+/// container that meaningfully narrows the region is a level, which makes the
+/// budget count real structure instead of grammar bookkeeping.
+const WRAPPER_KEEP_RATIO: (usize, usize) = (9, 10);
+
+/// How far the member walk has descended, and how much it has narrowed.
+#[derive(Clone, Copy)]
+struct Descent {
+    /// Levels that narrowed the region. Bounded by `MAX_SPLIT_DEPTH`.
+    levels: u32,
+    /// Raw AST nodes descended. Bounded by `MAX_AST_DESCENT`.
+    ast: u32,
+    /// Byte length of the last container that counted as a level.
+    kept_len: usize,
+}
+
+impl Descent {
+    fn root(source_len: usize) -> Self {
+        Descent {
+            levels: 0,
+            ast: 0,
+            kept_len: source_len,
+        }
+    }
+
+    /// Descend into a container of `child_len` bytes.
+    fn into_child(self, child_len: usize) -> Self {
+        let (num, den) = WRAPPER_KEEP_RATIO;
+        let narrows = child_len * den < self.kept_len * num;
+        Descent {
+            levels: self.levels + u32::from(narrows),
+            ast: self.ast + 1,
+            kept_len: if narrows { child_len } else { self.kept_len },
+        }
+    }
+
+    fn exhausted(self) -> bool {
+        self.levels >= MAX_SPLIT_DEPTH || self.ast >= MAX_AST_DESCENT
+    }
+}
+
+/// Reports whether `kind` names a member declaration, where a chunk may start.
+///
+/// Tree-sitter grammars name these consistently enough across languages that
+/// suffix matching beats a per-language table: Java and Go use `*_declaration`,
+/// Python `*_definition`, Rust `*_item`. Ruby names a method just `method`.
+///
+/// Matching on suffixes rather than substrings is what keeps `method_invocation`
+/// out — a substring test for `method` accepts every call site, and a split
+/// would then land in the middle of an expression.
+///
+/// Two grammars opt out of the convention and need naming, or their types are
+/// neither members nor containers and descent never opens them: Ruby calls a
+/// class `class` and a module `module`, and C/C++ call a type body a
+/// `*_specifier`. Both collapsed a whole file into one chunk.
+fn is_member_kind(kind: &str) -> bool {
+    const SUFFIXES: [&str; 3] = ["_declaration", "_definition", "_item"];
+    const EXACT: [&str; 11] = [
+        "method",
+        "function",
+        // Ruby. `def self.x` parses as `singleton_method` and `class << self`
+        // as `singleton_class`; neither carries a suffix any rule matches, so a
+        // class written in either style offered no split point at all.
+        "class",
+        "module",
+        "singleton_method",
+        "singleton_class",
+        // TypeScript: `namespace X { … }`.
+        "internal_module",
+        // C/C++
+        "class_specifier",
+        "struct_specifier",
+        "union_specifier",
+        "enum_specifier",
+    ];
+    if kind.starts_with("local_") {
+        // `local_variable_declaration` and friends carry the `_declaration`
+        // suffix but are statements, not members: accepting them puts a chunk
+        // boundary between two lines of a constructor body.
+        return false;
+    }
+    SUFFIXES.iter().any(|s| kind.ends_with(s)) || EXACT.contains(&kind)
+}
+
+/// Reports whether `kind` names a callable, whose body holds statements.
+///
+/// Constructors and destructors count. They are named `*_declaration` rather
+/// than anything containing `method`, so a name-based rule alone files them as
+/// containers: descent then enters the body and splits it at statement
+/// boundaries, and an oversized constructor yields no `Part` chunks.
+/// C# names three more callables without any of those words. An
+/// `operator_declaration` holds statements, and so does each
+/// `accessor_declaration` inside a property, an indexer, or an event. Omitting
+/// them files all three as containers, whose bodies split at statement level
+/// with no `Part` chunks to show for it. The full kind name is matched rather
+/// than a bare `operator`, which would also accept `assignment_operator` and
+/// friends inside an expression.
+fn is_callable_kind(kind: &str) -> bool {
+    const MARKERS: [&str; 8] = [
+        "function",
+        "method",
+        "lambda",
+        "closure",
+        "constructor",
+        "destructor",
+        "operator_declaration",
+        "accessor_declaration",
+    ];
+    MARKERS.iter().any(|m| kind.contains(m))
+}
+
+/// Reports whether `node` binds a callable to a name instead of declaring one.
+///
+/// `export const handler = () => {…}` is the dominant style in TypeScript and
+/// JavaScript. The member is a `lexical_declaration`, which no kind test calls
+/// callable, and the body belongs to an `arrow_function` two levels down.
+/// Treated as a container it yielded no `Part` chunks at all, so an oversized
+/// handler stayed one chunk past `MAX_EMBED_CHARS` and dropped out of dense
+/// retrieval entirely.
+///
+/// The kind list is what keeps this off types. A `class_declaration` also has a
+/// callable grandchild — every method it holds — and calling it callable would
+/// split a class at statement level instead of into its members.
+fn binds_a_callable<D: ast_grep_core::Doc>(node: &ast_grep_core::Node<'_, D>) -> bool {
+    const BINDING_KINDS: [&str; 5] = [
+        "lexical_declaration",
+        "variable_declaration",
+        "variable_declarator",
+        "field_declaration",
+        "public_field_definition",
+    ];
+    let kind = node.kind();
+    if !BINDING_KINDS.iter().any(|k| *k == &*kind) {
+        return false;
+    }
+    node.children().any(|c| {
+        c.is_named()
+            && (is_callable_kind(&c.kind())
+                || c.children().any(|g| g.is_named() && is_callable_kind(&g.kind())))
+    })
+}
+
+/// Reports whether `node` wraps a container that ends where `node` does.
+///
+/// Ruby writes `S = Struct.new(:x) do … end` as `assignment > call > do_block`
+/// and `describe … do` as `call > do_block`. No kind in either chain is a
+/// member or a container, so every member inside was unreachable and the file
+/// stayed one chunk. Matched by shape, like `wraps_member`: the child has to
+/// end where its parent ends, which is what makes it a wrapper rather than one
+/// element among several.
+///
+/// Callers must exclude callables first. A method also ends with its body, and
+/// descending into one would split it at expression level.
+fn wraps_container<D: ast_grep_core::Doc>(node: &ast_grep_core::Node<'_, D>) -> bool {
+    let end = node.range().end;
+    node.children().any(|c| {
+        c.is_named()
+            && c.range().end == end
+            && (is_member_container_kind(&c.kind())
+                || c.children().any(|g| {
+                    g.is_named() && g.range().end == end && is_member_container_kind(&g.kind())
+                }))
+    })
+}
+
+/// Reports whether `kind` holds member declarations, so descent should open it.
+///
+/// Two ways to qualify: a body that groups members (`class_body`,
+/// `declaration_list`, Python's `block`), or a member declaration that is not
+/// itself callable (a class, an `impl`, an inline module).
+///
+/// Descent never enters a callable, so a bare `block` reached below the top
+/// level is always a type body, never a method body.
+///
+/// `body_statement` is named exactly rather than by suffix. It is Ruby's body
+/// for a class and for a method alike, and a `_statement` suffix rule would
+/// also admit `if_statement` and `expression_statement` in every other
+/// language, putting split points inside control flow.
+fn is_member_container_kind(kind: &str) -> bool {
+    const BODY_SUFFIXES: [&str; 3] = ["_body", "_list", "_block"];
+    const EXACT: [&str; 3] = [
+        "block",
+        // Ruby: the body of a class, a module, and a method alike.
+        "body_statement",
+        // C/C++: `extern "C" { … }`. Opaque, it makes RocksDB's `db/c.cc` a
+        // single 463 KB chunk, far past `MAX_EMBED_CHARS`.
+        "linkage_specification",
+    ];
+    if BODY_SUFFIXES.iter().any(|s| kind.ends_with(s)) || EXACT.contains(&kind) {
+        return true;
+    }
+    is_member_kind(kind) && !is_callable_kind(kind)
+}
+
+/// Push end-bytes of `node`'s named children, descending into any child that is
+/// itself larger than `MAX_CHARS`.
+///
+/// Splitting only at *top-level* children collapses whole files into one chunk
+/// in class-per-file languages (Java, Kotlin, C#, Scala), where the single
+/// top-level declaration is the entire class. Descending recovers per-member
+/// granularity.
+///
+/// Depth 0 keeps every named child as a split point, which is what non-code
+/// files (JSON, YAML, HTML) rely on to chunk at all. Below that only member
+/// declarations qualify, so a chunk always begins at a member boundary.
+///
+/// An oversized callable is recorded as a `DeepRegion` rather than descended
+/// into here — its parts are packed separately so both levels survive.
+fn collect_split_points<D: ast_grep_core::Doc>(
+    node: &ast_grep_core::Node<'_, D>,
+    source: &str,
+    plan: &mut SplitPlan,
+    trail: &mut Vec<String>,
+    d: Descent,
+) {
+    let source_len = source.len();
+    for child in node.children() {
         if !child.is_named() {
             continue;
         }
-        let end = child.range().end;
-        if end > *points.last().unwrap() && end <= source.len() {
-            points.push(end);
-        }
-    }
-    if *points.last().unwrap() < source.len() {
-        points.push(source.len());
-    }
-    points
-}
+        let range = child.range();
+        let kind = child.kind();
+        let too_big = range.end.saturating_sub(range.start) > MAX_CHARS;
+        let member = is_member_kind(&kind);
 
-/// Top-level `section` and `fenced_code_block` end-bytes for a markdown parse.
-fn markdown_split_points(source: &str) -> Vec<usize> {
-    let mut parser = tree_sitter::Parser::new();
-    if parser
-        .set_language(&tree_sitter_md::LANGUAGE.into())
-        .is_err()
-    {
-        // tree-sitter-md is bundled and version-pinned, so this shouldn't
-        // happen — but if it does, emit one chunk covering the whole file
-        // rather than dropping it.
-        return vec![0, source.len()];
-    }
-    let Some(tree) = parser.parse(source, None) else {
-        return vec![0, source.len()];
-    };
-    let root = tree.root_node();
+        // A node that only wraps a member — `export_statement` in TS/JS,
+        // `decorated_definition` in Python — is transparent. Detected by shape
+        // rather than by kind name: it holds a member that ends where it ends.
+        // Opaque, it hides `export function f()` from the member walk, and a
+        // TypeScript outline then lists exactly the declarations that are
+        // *not* exported.
+        let wraps_member = child
+            .children()
+            .any(|c| c.is_named() && is_member_kind(&c.kind()) && c.range().end == range.end);
 
-    let mut points: Vec<usize> = vec![0];
-    let mut cursor = root.walk();
-    for child in root.named_children(&mut cursor) {
-        if matches!(child.kind(), "section" | "fenced_code_block") {
-            let end = child.end_byte();
-            if end > *points.last().unwrap() && end <= source.len() {
-                points.push(end);
+        if member && !wraps_member {
+            let name = node_name(&child, source);
+            let breadcrumb = join_trail(trail, name.as_deref());
+            plan.members.push(MemberSpan {
+                start: range.start,
+                end: range.end,
+                breadcrumb: breadcrumb.clone(),
+                signature: signature_of(&child, source),
+            });
+            if too_big && (is_callable_kind(&kind) || binds_a_callable(&child)) {
+                let mut points = vec![range.start];
+                collect_body_points(&child, source_len, &mut points);
+                if points.last() != Some(&range.end) && range.end <= source_len {
+                    points.push(range.end);
+                }
+                if points.len() > 2 {
+                    plan.deep.push(DeepRegion {
+                        start: range.start,
+                        end: range.end,
+                        breadcrumb,
+                        points,
+                    });
+                }
             }
         }
+
+        // Descend into every container, not just oversized ones: the member
+        // list feeds breadcrumbs and the outline, which a small file needs just
+        // as much. Emitting more split points costs nothing — `pack` merges
+        // members back together whenever they fit in one chunk.
+        let transparent =
+            wraps_member || (!is_callable_kind(&kind) && wraps_container(&child));
+        if !d.exhausted() && (is_member_container_kind(&kind) || transparent) {
+            let name = node_name(&child, source);
+            // A wrapper contributes no name of its own — `export` is not a
+            // level in the breadcrumb.
+            // Only a member-wrapper is nameless. A container that happens to end
+            // with its own body — every class — still contributes its name.
+            let pushed = name.is_some() && !is_body_kind(&kind) && !wraps_member;
+            if pushed {
+                trail.push(name.unwrap());
+            }
+            let next = d.into_child(range.end.saturating_sub(range.start));
+            collect_split_points(&child, source, plan, trail, next);
+            if pushed {
+                trail.pop();
+            }
+        }
+
+        // Top level is an AST fact, not a narrowing one: at the file root every
+        // named child is a split point, which is what non-code files rely on.
+        if d.ast > 0 && !member {
+            continue;
+        }
+        if range.end > *plan.member_points.last().unwrap() && range.end <= source_len {
+            plan.member_points.push(range.end);
+        }
     }
-    if *points.last().unwrap() < source.len() {
-        points.push(source.len());
+}
+
+/// Statement-level end-bytes inside a callable body.
+///
+/// Unlike the member walk this does enter blocks — that is the point, since
+/// the parts of an oversized method are its statements. It stays out of
+/// expressions, so a boundary never lands inside a call or an argument list;
+/// a lambda body qualifies because it is a block in its own right.
+fn collect_body_points<D: ast_grep_core::Doc>(
+    node: &ast_grep_core::Node<'_, D>,
+    source_len: usize,
+    points: &mut Vec<usize>,
+) {
+    for child in node.children() {
+        if !child.is_named() {
+            continue;
+        }
+        let range = child.range();
+        let kind = child.kind();
+        // `binds_a_callable` carries the walk through the declarator that sits
+        // between `const f =` and the arrow function's own body.
+        if is_body_kind(&kind) || is_callable_kind(&kind) || binds_a_callable(&child) {
+            collect_body_points(&child, source_len, points);
+            continue;
+        }
+        // Only statements directly inside a body become boundaries. Reaching
+        // here from anything else means we are inside an expression.
+        if is_body_kind(&node.kind()) && range.end > *points.last().unwrap() && range.end <= source_len {
+            points.push(range.end);
+        }
     }
-    points
+}
+
+/// Reports whether `kind` groups statements or members rather than being one.
+///
+/// Two are named exactly: Ruby's `body_statement`, and the `compound_statement`
+/// that C, C++, and PHP use for a function body. Without them an oversized
+/// method in those languages has no body to walk and never produces `Part`
+/// chunks. A `_statement` suffix rule would instead admit `if_statement` and
+/// every other control-flow node in every language.
+fn is_body_kind(kind: &str) -> bool {
+    const SUFFIXES: [&str; 3] = ["_body", "_list", "_block"];
+    const EXACT: [&str; 3] = ["block", "body_statement", "compound_statement"];
+    SUFFIXES.iter().any(|s| kind.ends_with(s)) || EXACT.contains(&kind)
+}
+
+/// The declaration's own name, via the `name` field every tree-sitter grammar
+/// uses for it. `None` for anonymous declarations and grammars without it.
+fn node_name<D: ast_grep_core::Doc>(node: &ast_grep_core::Node<'_, D>, source: &str) -> Option<String> {
+    let field = node.field("name")?;
+    let r = field.range();
+    let name = source.get(r.start..r.end)?.trim();
+    if name.is_empty() {
+        None
+    } else {
+        Some(name.to_string())
+    }
+}
+
+fn join_trail(trail: &[String], name: Option<&str>) -> String {
+    let mut parts: Vec<&str> = trail.iter().map(String::as_str).collect();
+    if let Some(n) = name {
+        parts.push(n);
+    }
+    parts.join(" > ")
+}
+
+/// Longest signature kept in an outline. Past this the header is a wall of
+/// generic parameters, and the outline is a list to scan, not a reference.
+const MAX_SIGNATURE_CHARS: usize = 200;
+
+/// The declaration's header: everything before its body, as one line.
+///
+/// The cut comes from the AST — the start of the first body-like child — not
+/// from scanning for `{`. Scanning got two things wrong. A brace can appear
+/// *inside* a parameter list, so `fn unpack(Config { host, port }: Config)`
+/// came out as `fn unpack(Config`, and the same for every destructured
+/// TypeScript prop. And stopping at the first newline dropped the parameters
+/// of any signature wrapped across lines, which is most non-trivial ones.
+///
+/// Only when there is no body child — an interface method, an abstract
+/// declaration, a field — does it fall back to the text, and then the newline
+/// is the right cut because there is no body to find.
+fn signature_of<D: ast_grep_core::Doc>(
+    node: &ast_grep_core::Node<'_, D>,
+    source: &str,
+) -> String {
+    let range = node.range();
+    // Prefer the `body` field the grammar labels itself. Kind matching alone
+    // cuts Go and C# at the opening paren, because both name the parameter node
+    // `parameter_list` as a *direct* child of the declaration, and that ends
+    // with `_list` like every class body does. Go methods came out worse than
+    // Go functions: the receiver is the first `parameter_list`, so the cut
+    // landed before the method name and the outline entry read `func`, naming
+    // nothing at all. C and C++ escaped only because their parameter list is
+    // wrapped in a `function_declarator`.
+    //
+    // The kind scan stays as the fallback, for the grammars that label no
+    // `body` field — narrowing it to statement bodies instead would break the
+    // type signatures that rely on `declaration_list` and
+    // `field_declaration_list`, and C++ callables on `compound_statement`.
+    let body_start = node.field("body").map(|c| c.range().start).or_else(|| {
+        node.children()
+            .filter(|c| c.is_named() && is_body_kind(&c.kind()))
+            .map(|c| c.range().start)
+            .min()
+    });
+    // With no body child the declaration *is* the signature — an interface
+    // method, an abstract declaration, a field. Take all of it: cutting at the
+    // first newline instead lost the parameters of any such declaration written
+    // across lines, which is exactly where the long ones are.
+    let end = match body_start {
+        Some(b) if b > range.start => b,
+        _ => range.end,
+    };
+    let slice = source.get(range.start..end).unwrap_or("");
+    // Collapse the wrapping: a signature spread over five lines is still one
+    // signature, and the outline is line-per-member.
+    let mut flat = String::with_capacity(slice.len());
+    for word in slice.split_whitespace() {
+        if !flat.is_empty() {
+            flat.push(' ');
+        }
+        flat.push_str(word);
+    }
+    let flat = flat.trim_end_matches(&['(', ',', '='][..]).trim().to_string();
+    if flat.len() <= MAX_SIGNATURE_CHARS {
+        return flat;
+    }
+    let mut cut = MAX_SIGNATURE_CHARS;
+    while !flat.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    format!("{}…", &flat[..cut])
+}
+
+/// A document's headings, shaped like a `SplitPlan` so the same outline builder
+/// serves both markdown and code.
+///
+/// A heading is to a document what a signature is to a class: the line that
+/// says what the section is for. Nesting is carried in the breadcrumb, so
+/// `## Pipeline` under `# Semantic search` reads as `Semantic search`.
+fn markdown_heading_plan(source: &str) -> SplitPlan {
+    let mut plan = SplitPlan::default();
+    let mut trail: Vec<(usize, String)> = Vec::new();
+    let mut offset = 0usize;
+
+    let mut fence: Option<&str> = None;
+    // One line of lookback, so a `===` underline can promote what came before.
+    let mut previous: Option<String> = None;
+    let mut previous_start = 0usize;
+    // YAML front matter opens and closes with `---`, and that closing line
+    // looks exactly like a setext underline — it promoted the last metadata
+    // line into a heading.
+    let mut in_front_matter = source.starts_with("---\n") || source.starts_with("---\r\n");
+    let mut first_line = true;
+    for line in source.split_inclusive('\n') {
+        if in_front_matter {
+            if !first_line && line.trim_end() == "---" {
+                in_front_matter = false;
+            }
+            first_line = false;
+            offset += line.len();
+            continue;
+        }
+        first_line = false;
+        let trimmed = line.trim_start();
+
+        // A `#` inside a fenced block is a shell comment, a preprocessor
+        // directive, a Python comment — not a heading. Left unhandled it not
+        // only invented sections, it poisoned the breadcrumb of every real
+        // heading that followed.
+        if let Some(marker) = fence {
+            if trimmed.starts_with(marker) {
+                fence = None;
+            }
+            offset += line.len();
+            continue;
+        }
+        for marker in ["```", "~~~"] {
+            if trimmed.starts_with(marker) {
+                fence = Some(marker);
+            }
+        }
+        if fence.is_some() {
+            offset += line.len();
+            continue;
+        }
+
+        // CommonMark allows at most three spaces before a heading marker;
+        // four makes it an indented code block. Using that rule directly is
+        // both correct and cheaper than modelling code blocks separately.
+        let indent = line.len() - line.trim_start_matches(' ').len();
+        let hashes = trimmed.bytes().take_while(|b| *b == b'#').count();
+        let atx = indent <= 3
+            && (1..=6).contains(&hashes)
+            && trimmed[hashes..].starts_with(|c: char| c.is_whitespace());
+
+        // Setext: a run of `=` or `-` underlining the previous paragraph line.
+        let body = trimmed.trim_end();
+        let setext_level = if indent <= 3 && !body.is_empty() {
+            if body.bytes().all(|b| b == b'=') {
+                Some(1)
+            } else if body.bytes().all(|b| b == b'-') {
+                Some(2)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        let setext = setext_level
+            .zip(previous.clone())
+            .filter(|(_, prev)| !prev.is_empty());
+
+        if let Some((level, title)) = setext {
+            trail.retain(|(l, _)| *l < level);
+            let breadcrumb = trail
+                .iter()
+                .map(|(_, t)| t.as_str())
+                .collect::<Vec<_>>()
+                .join(" > ");
+            plan.members.push(MemberSpan {
+                start: previous_start,
+                end: offset + line.trim_end().len(),
+                breadcrumb,
+                signature: title.clone(),
+            });
+            trail.push((level, title));
+            previous = None;
+            offset += line.len();
+            continue;
+        }
+
+        previous_start = offset;
+        let is_rule = !body.is_empty()
+            && (body.bytes().all(|b| b == b'-') || body.bytes().all(|b| b == b'='));
+        previous = if atx || body.is_empty() || is_rule {
+            None
+        } else {
+            Some(body.to_string())
+        };
+
+        if atx {
+            let title = trimmed[hashes..].trim().to_string();
+            if !title.is_empty() {
+                trail.retain(|(level, _)| *level < hashes);
+                let breadcrumb = trail
+                    .iter()
+                    .map(|(_, t)| t.as_str())
+                    .collect::<Vec<_>>()
+                    .join(" > ");
+                plan.members.push(MemberSpan {
+                    start: offset,
+                    end: offset + line.trim_end().len(),
+                    breadcrumb,
+                    signature: title.clone(),
+                });
+                trail.push((hashes, title));
+            }
+        }
+        offset += line.len();
+    }
+    plan
 }
 
 /// Blank-line end-bytes for plain-text formats (TOML, PowerShell) that have
@@ -229,12 +920,54 @@ fn paragraph_split_points(source: &str) -> Vec<usize> {
     points
 }
 
+/// Top-level `section` and `fenced_code_block` end-bytes for a markdown parse.
+fn markdown_split_points(source: &str) -> Vec<usize> {
+    let mut parser = tree_sitter::Parser::new();
+    if parser
+        .set_language(&tree_sitter_md::LANGUAGE.into())
+        .is_err()
+    {
+        // tree-sitter-md is bundled and version-pinned, so this shouldn't
+        // happen — but if it does, emit one chunk covering the whole file
+        // rather than dropping it.
+        return vec![0, source.len()];
+    }
+    let Some(tree) = parser.parse(source, None) else {
+        return vec![0, source.len()];
+    };
+    let root = tree.root_node();
+
+    let mut points: Vec<usize> = vec![0];
+    let mut cursor = root.walk();
+    for child in root.named_children(&mut cursor) {
+        if matches!(child.kind(), "section" | "fenced_code_block") {
+            let end = child.end_byte();
+            if end > *points.last().unwrap() && end <= source.len() {
+                points.push(end);
+            }
+        }
+    }
+    if *points.last().unwrap() < source.len() {
+        points.push(source.len());
+    }
+    points
+}
+
 /// Greedy-pack regions defined by `split_points` into chunks ≤ `MAX_CHARS`.
 ///
-/// All source bytes are covered exactly once: gaps between split points attach
-/// to the *following* chunk so nothing is lost from the index. Single regions
-/// bigger than the target are emitted on their own (no mid-decl splits).
-fn pack(source: &str, file_path: &str, lang_name: &str, split_points: &[usize]) -> Vec<Chunk> {
+/// Within one call every byte between the first and last split point is covered
+/// exactly once: gaps between split points attach to the *following* chunk so
+/// nothing is lost. Single regions bigger than the target are emitted on their
+/// own (no mid-decl splits).
+fn pack(
+    source: &str,
+    file_path: &str,
+    lang_name: &str,
+    lines: &LineIndex,
+    split_points: &[usize],
+    kind: ChunkKind,
+    breadcrumb: &str,
+) -> Vec<Chunk> {
     if split_points.len() < 2 {
         return Vec::new();
     }
@@ -242,6 +975,10 @@ fn pack(source: &str, file_path: &str, lang_name: &str, split_points: &[usize]) 
     let mut chunks = Vec::new();
     let mut cur_start = split_points[0];
     let mut cur_end = cur_start;
+
+    let flush = |start: usize, end: usize, out: &mut Vec<Chunk>| {
+        push_chunk(source, file_path, lang_name, lines, start, end, kind, breadcrumb, out);
+    };
 
     for w in split_points.windows(2) {
         let region_size = w[1] - w[0];
@@ -252,38 +989,37 @@ fn pack(source: &str, file_path: &str, lang_name: &str, split_points: &[usize]) 
         } else if cur_size + region_size <= MAX_CHARS {
             cur_end = w[1];
         } else {
-            push_chunk(source, file_path, lang_name, cur_start, cur_end, &mut chunks);
+            flush(cur_start, cur_end, &mut chunks);
             cur_start = w[0];
             cur_end = w[1];
         }
     }
     if cur_end > cur_start {
-        push_chunk(source, file_path, lang_name, cur_start, cur_end, &mut chunks);
+        flush(cur_start, cur_end, &mut chunks);
     }
 
     chunks
 }
 
+#[allow(clippy::too_many_arguments)]
 fn push_chunk(
     source: &str,
     file_path: &str,
     lang_name: &str,
+    lines: &LineIndex,
     start: usize,
     end: usize,
+    kind: ChunkKind,
+    breadcrumb: &str,
     out: &mut Vec<Chunk>,
 ) {
     let content = &source[start..end];
     if content.trim().is_empty() {
         return;
     }
-    // Count newlines in the byte-range directly — slicing `&str[..n]` would
-    // panic when `n` falls inside a multi-byte UTF-8 char. Counting on the
-    // raw byte slice is safe and equivalent (`b'\n'` is never part of any
-    // multi-byte sequence in valid UTF-8).
-    let bytes = source.as_bytes();
-    let start_line = bytes[..start].iter().filter(|&&b| b == b'\n').count() as u32 + 1;
+    let start_line = lines.line_of(start);
     let last_byte = end.saturating_sub(1).max(start);
-    let end_line = bytes[..last_byte].iter().filter(|&&b| b == b'\n').count() as u32 + 1;
+    let end_line = lines.line_of(last_byte);
 
     out.push(Chunk {
         content: content.to_string(),
@@ -293,7 +1029,190 @@ fn push_chunk(
         start_byte: start as u32,
         end_byte: end as u32,
         language: lang_name.to_string(),
+        breadcrumb: breadcrumb.to_string(),
+        kind,
     });
+}
+
+/// Fill in the breadcrumb of every chunk that does not already carry one.
+///
+/// A chunk holding exactly one member is named after it. A chunk that groups
+/// several members — the packer merges small ones — is named after the
+/// container instead, since naming just one of them would misdescribe the rest.
+fn assign_breadcrumbs(plan: &SplitPlan, chunks: &mut [Chunk]) {
+    for c in chunks.iter_mut() {
+        if !c.breadcrumb.is_empty() {
+            continue;
+        }
+        let (start, end) = (c.start_byte as usize, c.end_byte as usize);
+        if let Some(m) = plan
+            .members
+            .iter()
+            .filter(|m| m.start <= start && m.end >= end)
+            .min_by_key(|m| m.end - m.start)
+        {
+            c.breadcrumb = m.breadcrumb.clone();
+            continue;
+        }
+        // Chunk boundaries do not line up with member boundaries — the packer
+        // starts at the previous member's end and stops when full. Name the
+        // member the chunk covers the largest *fraction* of: an enclosing type
+        // always overlaps more bytes, but the member the chunk is really about
+        // is the one it nearly exhausts.
+        //
+        // Ties break toward the *earliest* member in the chunk, so the label
+        // names what a reader sees at the top of it. Breaking toward the
+        // smallest instead named a chunk after whichever short member happened
+        // to sit inside: one opening on `render_index_stats_json` came back
+        // labelled `hit_to_json`, forty lines below, and an agent jumping to
+        // the reported line landed on the wrong function.
+        let best = plan
+            .members
+            .iter()
+            .filter_map(|m| {
+                let overlap = m.end.min(end).saturating_sub(m.start.max(start));
+                let size = m.end.saturating_sub(m.start);
+                if overlap == 0 || size == 0 {
+                    return None;
+                }
+                // Integer permille — f32 has no total order to sort on.
+                Some((overlap * 1000 / size, std::cmp::Reverse(m.start), m))
+            })
+            .max_by(|a, b| (a.0, a.1).cmp(&(b.0, b.1)));
+        if let Some((_, _, m)) = best {
+            c.breadcrumb = m.breadcrumb.clone();
+        }
+    }
+}
+
+/// How large one outline document may get before it is split in two.
+///
+/// Well under the embedder's own size cap, because an outline that exceeds that
+/// cap is dropped from the dense index entirely — and the files with the
+/// longest outlines are the large, central ones a query is most likely to want.
+/// Leaving them unembedded made file-level retrieval miss exactly
+/// `QueryExecutorImpl`, `PgConnection`, `PgResultSet` and their kind.
+const OUTLINE_MAX_CHARS: usize = 3000;
+
+/// Synthesized signature-list chunks for a file, one per `OUTLINE_MAX_CHARS`.
+///
+/// They carry no body text, so they answer "which file exposes this API" for
+/// queries that name a type or method — the case where body-level chunks are
+/// scattered and each one matches only weakly. They sit in the index beside the
+/// source chunks rather than replacing them; ranking decides which is better.
+///
+/// A split piece spans the lines of the members it lists rather than the whole
+/// file, so a hit points at a region instead of at everything. The pieces do
+/// not overlap: carrying signatures across the boundary measured worse (MRR@10
+/// 0.332 with no overlap, 0.316 at three signatures, and recall@5 dropped at
+/// twenty). A piece is a list of independent signatures, not prose, so there is
+/// no evidence straddling the cut for an overlap to rescue — it only duplicates
+/// terms and makes near-identical pieces compete.
+fn build_outline_chunks(
+    file_path: &str,
+    lang_name: &str,
+    lines: &LineIndex,
+    plan: &SplitPlan,
+) -> Vec<Chunk> {
+    let listed: Vec<(&MemberSpan, String)> = plan
+        .members
+        .iter()
+        .filter(|m| !m.signature.is_empty())
+        .map(|m| {
+            let line = if m.breadcrumb.is_empty() {
+                m.signature.clone()
+            } else {
+                format!("{} :: {}", m.breadcrumb, m.signature)
+            };
+            (m, line)
+        })
+        .collect();
+    if listed.is_empty() {
+        return Vec::new();
+    }
+
+    // A path long enough to eat the whole budget would underflow every size
+    // calculation below. Nothing forbids one — the walk follows whatever
+    // directory tree it is pointed at — so the prefix is dropped rather than
+    // charged when it does not fit. `Chunk.file_path` still carries it.
+    let prefix = if file_path.len() + 1 < OUTLINE_MAX_CHARS {
+        file_path
+    } else {
+        ""
+    };
+    let base_len = prefix.len() + 1;
+    let line_budget = OUTLINE_MAX_CHARS - base_len;
+
+    let mut out = Vec::new();
+    let mut batch: Vec<&str> = Vec::new();
+    let mut batch_len = base_len;
+    let mut first: Option<&MemberSpan> = None;
+    let mut last: Option<&MemberSpan> = None;
+
+    let flush = |batch: &mut Vec<&str>,
+                     first: &mut Option<&MemberSpan>,
+                     last: &mut Option<&MemberSpan>,
+                     out: &mut Vec<Chunk>| {
+        let (Some(f), Some(l)) = (*first, *last) else {
+            return;
+        };
+        let mut content = String::with_capacity(base_len);
+        content.push_str(prefix);
+        for line in batch.iter() {
+            content.push('\n');
+            content.push_str(line);
+        }
+        out.push(Chunk {
+            content,
+            file_path: file_path.to_string(),
+            start_line: lines.line_of(f.start),
+            end_line: lines.line_of(l.end.saturating_sub(1)),
+            start_byte: f.start as u32,
+            end_byte: l.end as u32,
+            language: lang_name.to_string(),
+            breadcrumb: String::new(),
+            kind: ChunkKind::Outline,
+        });
+        batch.clear();
+        *first = None;
+        *last = None;
+    };
+
+    // A single signature can exceed the budget on its own — a one-line
+    // declaration with a long parameter list, or generated code. Truncating it
+    // keeps every piece embeddable, which is the whole point of splitting: an
+    // outline over the embedder's cap loses its dense vector and drops out of
+    // phase-one file retrieval.
+    let truncated: Vec<String> = listed
+        .iter()
+        .map(|(_, line)| {
+            if line.len() <= line_budget {
+                line.clone()
+            } else {
+                const ELLIPSIS: &str = "…";
+                let mut cut = line_budget.saturating_sub(ELLIPSIS.len());
+                while cut > 0 && !line.is_char_boundary(cut) {
+                    cut -= 1;
+                }
+                format!("{}{ELLIPSIS}", &line[..cut])
+            }
+        })
+        .collect();
+
+    for ((m, _), line) in listed.iter().zip(truncated.iter()) {
+        if batch_len + line.len() > OUTLINE_MAX_CHARS && !batch.is_empty() {
+            flush(&mut batch, &mut first, &mut last, &mut out);
+            batch_len = base_len;
+        }
+        if first.is_none() {
+            first = Some(m);
+        }
+        last = Some(m);
+        batch_len += line.len() + 1;
+        batch.push(line);
+    }
+    flush(&mut batch, &mut first, &mut last, &mut out);
+    out
 }
 
 #[cfg(test)]
@@ -303,6 +1222,19 @@ mod tests {
 
     fn rust(src: &str) -> Vec<Chunk> {
         chunk_source(src, "f.rs", ChunkerKind::AstGrep(SupportLang::Rust))
+    }
+
+    /// The chunks that tile the file exactly once — everything except the
+    /// overlapping `Part` level and the synthesized outline.
+    fn tiling(src: &str) -> Vec<Chunk> {
+        rust(src)
+            .into_iter()
+            .filter(|c| matches!(c.kind, ChunkKind::Source | ChunkKind::Enclosing))
+            .collect()
+    }
+
+    fn of_kind(chunks: &[Chunk], kind: ChunkKind) -> Vec<&Chunk> {
+        chunks.iter().filter(|c| c.kind == kind).collect()
     }
 
     #[test]
@@ -358,7 +1290,7 @@ mod tests {
 
     #[test]
     fn rust_one_function_one_chunk() {
-        let chunks = rust("fn hello() {\n    println!(\"hi\");\n}\n");
+        let chunks = tiling("fn hello() {\n    println!(\"hi\");\n}\n");
         assert_eq!(chunks.len(), 1);
         assert_eq!(chunks[0].start_line, 1);
         assert_eq!(chunks[0].language, "rust");
@@ -367,7 +1299,7 @@ mod tests {
 
     #[test]
     fn rust_groups_small_decls_under_max_chars() {
-        let chunks = rust("fn a() { 1 }\nfn b() { 2 }\nfn c() { 3 }\n");
+        let chunks = tiling("fn a() { 1 }\nfn b() { 2 }\nfn c() { 3 }\n");
         assert_eq!(chunks.len(), 1);
         assert!(chunks[0].content.contains("fn a"));
         assert!(chunks[0].content.contains("fn c"));
@@ -389,7 +1321,7 @@ mod tests {
     #[test]
     fn ast_chunks_are_contiguous_and_cover_source() {
         let src = "// header comment\nfn a() {}\n\nfn b() {}\n// trailer\n";
-        let chunks = rust(src);
+        let chunks = tiling(src);
         let joined: String = chunks.iter().map(|c| c.content.as_str()).collect();
         assert_eq!(joined, src);
     }
@@ -407,13 +1339,21 @@ mod tests {
     #[test]
     fn line_numbers_are_one_indexed_and_correct() {
         let src = "fn a() {}\nfn b() {}\nfn c() {}\n";
-        let chunks = rust(src);
+        let chunks = tiling(src);
         assert_eq!(chunks.len(), 1);
         assert_eq!(chunks[0].start_line, 1);
         assert_eq!(chunks[0].end_line, 3);
     }
 
     // ── Markdown ──────────────────────────────────────────────────────────
+
+    /// Markdown chunks that tile the source, i.e. everything but the outline.
+    fn md_tiling(src: &str) -> Vec<Chunk> {
+        md(src)
+            .into_iter()
+            .filter(|c| c.kind != ChunkKind::Outline)
+            .collect()
+    }
 
     fn md(src: &str) -> Vec<Chunk> {
         chunk_source(src, "README.md", ChunkerKind::Markdown)
@@ -422,7 +1362,7 @@ mod tests {
     #[test]
     fn markdown_single_section_one_chunk() {
         let src = "# Title\n\nSome paragraph.\n";
-        let chunks = md(src);
+        let chunks = md_tiling(src);
         assert_eq!(chunks.len(), 1);
         assert_eq!(chunks[0].language, "markdown");
         assert!(chunks[0].content.contains("# Title"));
@@ -440,7 +1380,7 @@ content b
 # Section C
 content c
 ";
-        let chunks = md(src);
+        let chunks = md_tiling(src);
         // All three small sections should pack into one chunk.
         assert_eq!(chunks.len(), 1);
         assert!(chunks[0].content.contains("Section A"));
@@ -458,12 +1398,429 @@ content c
     #[test]
     fn markdown_chunks_cover_source() {
         let src = "# Hello\n\nworld\n\n# Goodbye\n\ncruel world\n";
-        let chunks = md(src);
+        let chunks = md_tiling(src);
         let joined: String = chunks.iter().map(|c| c.content.as_str()).collect();
         assert_eq!(joined, src);
     }
 
-    // ── Plain text (TOML / PowerShell) ────────────────────────────────────
+    // ── hierarchy, breadcrumbs, outline ────────────────────────────────────
+
+    fn java(src: &str) -> Vec<Chunk> {
+        chunk_source(src, "Outer.java", ChunkerKind::AstGrep(SupportLang::Java))
+    }
+
+    /// `n` lines of filler, enough to push a body past `MAX_CHARS`.
+    fn filler(n: usize, tag: &str) -> String {
+        (0..n)
+            .map(|i| format!("    // {tag} line {i:03} aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"))
+            .collect()
+    }
+
+    #[test]
+    fn java_class_splits_into_members() {
+        let src = format!(
+            "package p;\npublic class Outer {{\n  void a() {{\n{}  }}\n  void b() {{\n{}  }}\n}}\n",
+            filler(20, "a"),
+            filler(20, "b")
+        );
+        let tiles: Vec<Chunk> = java(&src)
+            .into_iter()
+            .filter(|c| matches!(c.kind, ChunkKind::Source | ChunkKind::Enclosing))
+            .collect();
+        assert!(
+            tiles.len() >= 2,
+            "expected the class to split per member, got {}",
+            tiles.len()
+        );
+        // The whole-class chunk of the old top-level-only walk is gone.
+        assert!(tiles.iter().all(|c| c.content.len() <= MAX_CHARS * 2));
+    }
+
+    #[test]
+    fn oversized_method_is_kept_whole_beside_its_parts() {
+        let src = format!(
+            "public class Outer {{\n  void big() {{\n{}    list.forEach(item -> {{\n{}    }});\n  }}\n}}\n",
+            filler(25, "pre"),
+            filler(25, "lambda")
+        );
+        let chunks = java(&src);
+        let enclosing = of_kind(&chunks, ChunkKind::Enclosing);
+        let parts = of_kind(&chunks, ChunkKind::Part);
+        assert_eq!(enclosing.len(), 1, "the big method should survive whole");
+        assert!(parts.len() >= 2, "and also be split, got {}", parts.len());
+        // Every part lies inside the member it came from.
+        let whole = enclosing[0];
+        for p in &parts {
+            assert!(p.start_byte >= whole.start_byte && p.end_byte <= whole.end_byte);
+        }
+    }
+
+    /// A chunk boundary never lands inside an expression.
+    #[test]
+    fn splits_never_land_inside_an_expression() {
+        // A substring test for "method" accepts `method_invocation`, which puts
+        // `list.forEach` and `(item -> {` in different chunks.
+        let src = format!(
+            "public class Outer {{\n  void big() {{\n{}    list.forEach(item -> {{\n{}    }});\n  }}\n}}\n",
+            filler(25, "pre"),
+            filler(25, "lambda")
+        );
+        for c in java(&src) {
+            let head = c.content.trim_start();
+            assert!(
+                !head.starts_with('(') && !head.starts_with(';') && !head.starts_with("->"),
+                "chunk starts mid-expression: {:?}",
+                &head[..head.len().min(40)]
+            );
+        }
+    }
+
+    #[test]
+    fn nested_class_members_get_breadcrumbs() {
+        let src = format!(
+            "public class Outer {{\n  public static class Nested {{\n    void deep() {{\n{}    }}\n    void tiny() {{}}\n  }}\n}}\n",
+            filler(25, "d")
+        );
+        let chunks = java(&src);
+        assert!(
+            chunks
+                .iter()
+                .any(|c| c.breadcrumb.contains("Outer") && c.breadcrumb.contains("Nested")),
+            "expected a breadcrumb naming the nested class, got {:?}",
+            chunks.iter().map(|c| &c.breadcrumb).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn outline_chunk_lists_signatures_without_bodies() {
+        let src = "public class Outer {\n  void alpha() { int x = 1; }\n  void beta() { int y = 2; }\n}\n";
+        let chunks = java(src);
+        let outlines = of_kind(&chunks, ChunkKind::Outline);
+        assert_eq!(outlines.len(), 1);
+        let text = &outlines[0].content;
+        assert!(text.contains("alpha"), "outline missing alpha: {text}");
+        assert!(text.contains("beta"), "outline missing beta: {text}");
+        assert!(!text.contains("int x = 1"), "outline leaked a body: {text}");
+    }
+
+    /// Every outline piece stays inside the size the embedder accepts.
+    #[test]
+    fn long_outline_splits_so_every_piece_stays_embeddable() {
+        // Enough members that one outline document would exceed the size the
+        // embedder accepts, which drops the biggest files out of the dense
+        // index entirely unless the outline is split.
+        let members: String = (0..400)
+            .map(|i| format!("  public void someDescriptiveMethodName{i:03}(String argument) {{}}\n"))
+            .collect();
+        let src = format!("public class Big {{\n{members}}}\n");
+        let outlines: Vec<Chunk> = java(&src)
+            .into_iter()
+            .filter(|c| c.kind == ChunkKind::Outline)
+            .collect();
+        assert!(outlines.len() > 1, "expected a split, got {}", outlines.len());
+        for o in &outlines {
+            assert!(
+                o.content.len() <= OUTLINE_MAX_CHARS * 2,
+                "outline piece too large: {}",
+                o.content.len()
+            );
+            assert!(o.start_line >= 1 && o.end_line >= o.start_line);
+        }
+        // Every member is still listed somewhere.
+        let all: String = outlines.iter().map(|o| o.content.as_str()).collect();
+        assert!(all.contains("someDescriptiveMethodName000"));
+        assert!(all.contains("someDescriptiveMethodName399"));
+    }
+
+    #[test]
+    fn outline_pieces_point_at_the_members_they_list() {
+        let members: String = (0..400)
+            .map(|i| format!("  public void someDescriptiveMethodName{i:03}(String argument) {{}}\n"))
+            .collect();
+        let src = format!("public class Big {{\n{members}}}\n");
+        let outlines: Vec<Chunk> = java(&src)
+            .into_iter()
+            .filter(|c| c.kind == ChunkKind::Outline)
+            .collect();
+        // Pieces after the first must not all claim to start at line 1 — that
+        // was the whole-file range the unsplit outline used.
+        assert!(
+            outlines.iter().skip(1).any(|o| o.start_line > 1),
+            "split pieces still span the whole file"
+        );
+    }
+
+    #[test]
+    fn rust_impl_block_splits_per_method() {
+        let body = filler(20, "x").replace("//", "//");
+        let src = format!(
+            "pub struct S;\nimpl S {{\n  pub fn one(&self) {{\n{body}  }}\n  pub fn two(&self) {{\n{body}  }}\n}}\n"
+        );
+        let tiles: Vec<Chunk> = rust(&src)
+            .into_iter()
+            .filter(|c| matches!(c.kind, ChunkKind::Source | ChunkKind::Enclosing))
+            .collect();
+        assert!(
+            tiles.len() >= 2,
+            "expected the impl block to split per method, got {}",
+            tiles.len()
+        );
+        assert!(rust(&src).iter().any(|c| c.breadcrumb.contains("S")));
+    }
+
+    #[test]
+    fn oversized_constructor_splits_like_a_method() {
+        // A constructor is named `*_declaration`, not `*method*`, so before it
+        // counted as a callable it was treated as a container: descent entered
+        // the body and `local_variable_declaration` — which also ends in
+        // `_declaration` — became a split point in the middle of it.
+        let body: String = (0..60)
+            .map(|i| format!("    int v{i:03} = compute({i});\n"))
+            .collect();
+        let src = format!("public class Ctor {{\n  public Ctor(String arg) {{\n{body}  }}\n  void tiny() {{}}\n}}\n");
+        let chunks = java(&src);
+        for c in &chunks {
+            if matches!(c.kind, ChunkKind::Part) {
+                continue; // a Part starts inside the body — that is its job
+            }
+            let head = c.content.trim_start();
+            assert!(
+                !head.starts_with("int v"),
+                "the tiling splits mid-constructor: {:?}",
+                &head[..head.len().min(40)]
+            );
+        }
+        // Whole beside its parts, exactly as an oversized method behaves.
+        assert_eq!(of_kind(&chunks, ChunkKind::Enclosing).len(), 1);
+        assert!(!of_kind(&chunks, ChunkKind::Part).is_empty());
+        assert!(chunks.iter().any(|c| c.breadcrumb == "Ctor > Ctor"));
+    }
+
+    #[test]
+    fn a_single_huge_signature_cannot_blow_the_outline_budget() {
+        // One declaration whose header alone exceeds the outline budget: the
+        // batching check is guarded by "batch is non-empty", so without
+        // truncation this landed in an empty batch and came out oversized.
+        let params: String = (0..400)
+            .map(|i| format!("String parameterNumber{i:03}, "))
+            .collect();
+        let src = format!("public class Wide {{\n  void wide({params}int last) {{}}\n}}\n");
+        for outline in of_kind(&java(&src), ChunkKind::Outline) {
+            assert!(
+                outline.content.len() <= OUTLINE_MAX_CHARS,
+                "outline piece is {} chars, over the {OUTLINE_MAX_CHARS} budget",
+                outline.content.len()
+            );
+        }
+    }
+
+    #[test]
+    fn outline_pieces_budget_for_the_path_prefix() {
+        let members: String = (0..400)
+            .map(|i| format!("  public void someDescriptiveMethodName{i:03}(String argument) {{}}\n"))
+            .collect();
+        let src = format!("public class Big {{\n{members}}}\n");
+        // The rendered chunk opens with the file path, so the budget has to
+        // cover the prefix or every piece comes out that much over.
+        for outline in of_kind(&java(&src), ChunkKind::Outline) {
+            assert!(outline.content.len() <= OUTLINE_MAX_CHARS);
+        }
+    }
+
+    #[test]
+    fn markdown_gets_an_outline_from_its_headings() {
+        // Without one, two-phase retrieval — which can only raise a score —
+        // leaves documents unable to compete with code on any query.
+        let src = "# Semantic search\n\nintro\n\n## Pipeline\n\nbody\n\n### RRF\n\nmore\n";
+        let chunks = chunk_source(src, "wiki/search.md", ChunkerKind::Markdown);
+        let outlines = of_kind(&chunks, ChunkKind::Outline);
+        assert_eq!(outlines.len(), 1, "expected one outline, got {}", outlines.len());
+        let text = &outlines[0].content;
+        for heading in ["Semantic search", "Pipeline", "RRF"] {
+            assert!(text.contains(heading), "outline missing {heading}: {text}");
+        }
+        assert!(!text.contains("intro"), "outline leaked body text: {text}");
+    }
+
+    #[test]
+    fn markdown_outline_nests_headings_in_the_breadcrumb() {
+        let src = "# Top\n\n## Middle\n\n### Leaf\n\ntext\n";
+        let chunks = chunk_source(src, "d.md", ChunkerKind::Markdown);
+        let text = &of_kind(&chunks, ChunkKind::Outline)[0].content;
+        assert!(text.contains("Top > Middle :: Leaf"), "breadcrumb not nested: {text}");
+    }
+
+    #[test]
+    fn a_hash_that_is_not_a_heading_is_ignored() {
+        let src = "# Real\n\n#nospace is not a heading\n\n####### seven hashes either\n";
+        let chunks = chunk_source(src, "d.md", ChunkerKind::Markdown);
+        let text = &of_kind(&chunks, ChunkKind::Outline)[0].content;
+        assert!(text.contains("Real"));
+        assert!(!text.contains("nospace"), "picked up a non-heading: {text}");
+        assert!(!text.contains("seven hashes"), "picked up seven hashes: {text}");
+    }
+
+    #[test]
+    fn breadcrumb_names_the_earliest_member_in_the_chunk() {
+        // A chunk holding several whole members used to be named after the
+        // smallest of them, so the label could point dozens of lines past the
+        // line the result reports.
+        let src = "fn alpha() { let a = 1; let b = 2; }\nfn b() {}\n";
+        for c in rust(src) {
+            if c.kind == ChunkKind::Outline || c.breadcrumb.is_empty() {
+                continue;
+            }
+            assert_eq!(c.breadcrumb, "alpha", "chunk labelled {:?}", c.breadcrumb);
+        }
+    }
+
+    fn outline_of(src: &str, path: &str, kind: ChunkerKind) -> String {
+        chunk_source(src, path, kind)
+            .into_iter()
+            .filter(|c| c.kind == ChunkKind::Outline)
+            .map(|c| c.content)
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn signature_keeps_a_brace_that_belongs_to_the_parameters() {
+        // Cutting at the first `{` truncated every destructured parameter:
+        // `fn unpack(Config { host, port }: Config)` came out as `fn unpack(Config`.
+        let src = "pub fn unpack(Config { host, port }: Config) -> String { String::new() }\n";
+        let text = outline_of(src, "b.rs", ChunkerKind::AstGrep(SupportLang::Rust));
+        assert!(text.contains("host, port"), "parameters truncated: {text}");
+        assert!(text.contains("-> String"), "return type truncated: {text}");
+        assert!(!text.contains("String::new"), "body leaked: {text}");
+    }
+
+    #[test]
+    fn signature_survives_being_wrapped_across_lines() {
+        // Cutting at the first newline dropped the parameters of any signature
+        // long enough to need wrapping, which is most non-trivial ones.
+        let src = "pub fn configure(\n    name: &str,\n    retries: usize,\n) -> Result<C, E> {\n    todo!()\n}\n";
+        let text = outline_of(src, "b.rs", ChunkerKind::AstGrep(SupportLang::Rust));
+        assert!(text.contains("name: &str"), "parameters lost: {text}");
+        assert!(text.contains("retries: usize"), "parameters lost: {text}");
+        assert!(text.contains("-> Result<C, E>"), "return type lost: {text}");
+        assert!(!text.contains("todo!"), "body leaked: {text}");
+        assert_eq!(text.lines().count(), 2, "signature not flattened: {text}");
+    }
+
+    #[test]
+    fn exported_declarations_reach_the_outline() {
+        // `export_statement` is neither a member nor a container, so an opaque
+        // wrapper hid exactly the declarations that form the public API: a
+        // TypeScript outline listed only what was *not* exported.
+        let src = "export function exported() {}\nfunction plain() {}\nexport class Widget { render() {} }\n";
+        let text = outline_of(src, "e.ts", ChunkerKind::AstGrep(SupportLang::TypeScript));
+        for name in ["exported", "plain", "Widget", "render"] {
+            assert!(text.contains(name), "outline missing {name}: {text}");
+        }
+        assert!(!text.contains("export ::"), "wrapper became its own entry: {text}");
+    }
+
+    #[test]
+    fn a_wrapper_adds_no_level_to_the_breadcrumb() {
+        let src = "export class Widget { render() {} }\n";
+        let text = outline_of(src, "e.ts", ChunkerKind::AstGrep(SupportLang::TypeScript));
+        assert!(text.contains("Widget > render"), "breadcrumb wrong: {text}");
+    }
+
+    #[test]
+    fn a_decorator_is_not_a_member_of_its_own() {
+        let src = "@decorator\ndef decorated(a, b):\n    return a\n";
+        let text = outline_of(src, "f.py", ChunkerKind::AstGrep(SupportLang::Python));
+        assert!(text.contains("decorated"), "declaration missing: {text}");
+        assert!(
+            !text.lines().any(|l| l.trim() == "@decorator"),
+            "decorator listed as its own member: {text}"
+        );
+    }
+
+    #[test]
+    fn headings_inside_a_fenced_block_are_not_headings() {
+        // A `#` in a shell snippet is a comment. Treating it as a heading also
+        // poisoned the breadcrumb of every real heading after it.
+        let src = "# Real\n\n```bash\n# not a heading\necho hi\n```\n\n## Second\n";
+        let text = outline_of(src, "d.md", ChunkerKind::Markdown);
+        assert!(!text.contains("not a heading"), "fenced comment became a heading: {text}");
+        assert!(text.contains("Real :: Second"), "breadcrumb poisoned: {text}");
+    }
+
+    #[test]
+    fn a_tilde_fence_also_hides_headings() {
+        let src = "# Real\n\n~~~\n# not a heading\n~~~\n\n## Second\n";
+        let text = outline_of(src, "d.md", ChunkerKind::Markdown);
+        assert!(!text.contains("not a heading"), "tilde fence ignored: {text}");
+    }
+
+    #[test]
+    fn a_very_long_signature_is_truncated() {
+        let params: String = (0..200).map(|i| format!("arg{i:03}: usize, ")).collect();
+        let src = format!("pub fn wide({params}last: usize) {{}}\n");
+        let text = outline_of(&src, "b.rs", ChunkerKind::AstGrep(SupportLang::Rust));
+        for line in text.lines().skip(1) {
+            assert!(line.len() <= MAX_SIGNATURE_CHARS + 32, "signature not capped: {}", line.len());
+        }
+    }
+
+    #[test]
+    fn setext_headings_are_headings_too() {
+        let src = "Top level\n=========\n\ntext\n\nSecond\n------\n\n### Deep\n";
+        let text = outline_of(src, "g.md", ChunkerKind::Markdown);
+        assert!(text.contains("Top level"), "setext h1 missed: {text}");
+        assert!(text.contains("Second"), "setext h2 missed: {text}");
+        assert!(text.contains("Top level > Second :: Deep"), "nesting wrong: {text}");
+    }
+
+    #[test]
+    fn front_matter_dashes_do_not_promote_nothing() {
+        // A `---` with no paragraph line above it is a thematic break or front
+        // matter, not an underline.
+        let src = "---\ntitle: x\n---\n\n# Real\n";
+        let text = outline_of(src, "g.md", ChunkerKind::Markdown);
+        assert!(text.contains("Real"));
+        assert!(!text.contains("title: x"), "front matter became a heading: {text}");
+    }
+
+    #[test]
+    fn a_hash_indented_four_spaces_is_code_not_a_heading() {
+        // CommonMark allows at most three spaces before the marker; four makes
+        // it an indented code block.
+        let src = "# Real\n\n    # indented, so code\n    echo hi\n\n## Second\n";
+        let text = outline_of(src, "g.md", ChunkerKind::Markdown);
+        assert!(!text.contains("indented"), "indented code became a heading: {text}");
+        assert!(text.contains("Real :: Second"), "breadcrumb poisoned: {text}");
+    }
+
+    #[test]
+    fn a_declaration_without_a_body_keeps_its_whole_signature() {
+        // Interface methods have no body child, so the fallback decides. Cutting
+        // at the first newline lost the parameters of any wrapped one.
+        let src = "public interface Repo {\n  List<Row> find(\n      String name,\n      Status status) throws SQLException;\n}\n";
+        let text = outline_of(src, "h.java", ChunkerKind::AstGrep(SupportLang::Java));
+        assert!(text.contains("String name"), "parameters lost: {text}");
+        assert!(text.contains("throws SQLException"), "tail lost: {text}");
+    }
+
+    #[test]
+    fn an_absurdly_long_path_does_not_underflow_the_budget() {
+        // Nothing forbids a repo-relative path longer than the outline budget,
+        // and `OUTLINE_MAX_CHARS - path.len()` panics in debug when it happens.
+        let path = format!("{}/x.rs", "nested".repeat(700));
+        assert!(path.len() > OUTLINE_MAX_CHARS);
+        let src = "fn alpha() {}\nfn beta() {}\n";
+        let chunks = chunk_source(src, &path, ChunkerKind::AstGrep(SupportLang::Rust));
+        let outlines = of_kind(&chunks, ChunkKind::Outline);
+        assert!(!outlines.is_empty(), "outline dropped entirely");
+        for o in &outlines {
+            assert!(o.content.len() <= OUTLINE_MAX_CHARS, "over budget: {}", o.content.len());
+            assert_eq!(o.file_path, path, "the chunk still carries the full path");
+        }
+        let text = outlines[0].content.clone();
+        assert!(text.contains("alpha") && text.contains("beta"), "members lost: {text}");
+    }
 
     #[test]
     fn is_indexable_accepts_plain_text_formats() {
@@ -550,5 +1907,20 @@ content c
         assert_eq!(chunks.len(), 1);
         assert_eq!(chunks[0].start_line, 1);
         assert_eq!(chunks[0].end_line, 3);
+    }
+
+    #[test]
+    fn tiling_still_covers_every_byte_exactly_once() {
+        let src = format!(
+            "public class Outer {{\n  void big() {{\n{}  }}\n  void small() {{}}\n}}\n",
+            filler(30, "f")
+        );
+        let mut tiles: Vec<Chunk> = java(&src)
+            .into_iter()
+            .filter(|c| matches!(c.kind, ChunkKind::Source | ChunkKind::Enclosing))
+            .collect();
+        tiles.sort_by_key(|c| c.start_byte);
+        let joined: String = tiles.iter().map(|c| c.content.as_str()).collect();
+        assert_eq!(joined, src);
     }
 }

--- a/src/search/chunker/langs.rs
+++ b/src/search/chunker/langs.rs
@@ -1,0 +1,605 @@
+//! Per-language chunker coverage.
+//!
+//! The kind predicates in the parent module match tree-sitter node names by
+//! suffix or substring across every grammar `ast-grep` parses, so a language
+//! that spells a container differently loses member granularity with nothing
+//! to catch it. These fixtures are what catches it.
+//!
+//! Two tables feed the assertions. [`FIXTURES`] holds one file per
+//! `SupportLang`, built from six members each comfortably under [`MAX_CHARS`]
+//! and adding up to well over it; the table is checked against
+//! `SupportLang::all_langs()`, so a language added to `ast-grep` without a
+//! fixture here fails the build rather than shipping unmeasured. [`VARIANTS`]
+//! holds a second spelling for languages that have one, because a single
+//! fixture measures the style that fixture happens to use — Ruby passed on
+//! `class` plus `def` while `def self.x`, `class << self`, a `do` block holding
+//! members, and four levels of nesting all still collapsed.
+//!
+//! [`KNOWN_GAPS`] names the languages that still collapse, with the cause.
+//! An entry there is not a waiver: `known_gaps_still_fail` asserts each one
+//! still reproduces, so repairing a language turns that test red and forces
+//! its entry out alongside the fix.
+//!
+//! Data formats have no members to find and assert chunk size only.
+use super::*;
+
+/// What a fixture is expected to yield beyond small chunks.
+enum Expect {
+    /// The member walk must find at least this many declarations.
+    Members(usize),
+    /// A data format: split points come from top-level children, not members.
+    SplitsOnly,
+}
+
+struct Fixture {
+    lang: SupportLang,
+    /// Whole file. `{body}` is replaced by the concatenated members.
+    file: &'static str,
+    /// One member. `{i}` is the index, `{pad}` the generated padding.
+    member: &'static str,
+    /// One padding line inside a member body. `{j}` is the line index.
+    pad_line: &'static str,
+    expect: Expect,
+}
+
+const MEMBERS: usize = 6;
+const PAD_LINES: usize = 12;
+
+fn render(f: &Fixture) -> String {
+    let body: String = (0..MEMBERS)
+        .map(|i| {
+            let pad: String = (0..PAD_LINES)
+                .map(|j| f.pad_line.replace("{j}", &j.to_string()))
+                .collect();
+            f.member
+                .replace("{pad}", &pad)
+                .replace("{i}", &i.to_string())
+        })
+        .collect();
+    f.file.replace("{body}", &body)
+}
+
+#[rustfmt::skip]
+const FIXTURES: &[Fixture] = &[
+    Fixture { lang: SupportLang::Bash, file: "{body}",
+        member: "m{i}() {\n{pad}  echo {i}\n}\n\n",
+        pad_line: "  # padding line {j} that exists only to grow this body\n",
+        expect: Expect::Members(MEMBERS) },
+    Fixture { lang: SupportLang::C, file: "{body}",
+        member: "void m{i}(void) {\n{pad}}\n\n",
+        pad_line: "    // padding line {j} that exists only to grow this body\n",
+        expect: Expect::Members(MEMBERS) },
+    Fixture { lang: SupportLang::Cpp, file: "class A {\npublic:\n{body}};\n",
+        member: "    void m{i}() {\n{pad}    }\n",
+        pad_line: "        // padding line {j} that exists only to grow this body\n",
+        expect: Expect::Members(MEMBERS) },
+    Fixture { lang: SupportLang::CSharp, file: "namespace N;\npublic class A {\n{body}}\n",
+        member: "    void M{i}() {\n{pad}    }\n",
+        pad_line: "        // padding line {j} that exists only to grow this body\n",
+        expect: Expect::Members(MEMBERS) },
+    Fixture { lang: SupportLang::Css, file: "{body}",
+        member: ".c{i} {\n{pad}  color: red;\n}\n\n",
+        pad_line: "  /* padding line {j} that exists only to grow this rule */\n",
+        expect: Expect::SplitsOnly },
+    Fixture { lang: SupportLang::Dart, file: "class A {\n{body}}\n",
+        member: "  void m{i}() {\n{pad}  }\n",
+        pad_line: "    // padding line {j} that exists only to grow this body\n",
+        expect: Expect::Members(MEMBERS) },
+    Fixture { lang: SupportLang::Elixir, file: "defmodule A do\n{body}end\n",
+        member: "  def m{i}(x) do\n{pad}    x\n  end\n",
+        pad_line: "    # padding line {j} that exists only to grow this body\n",
+        expect: Expect::Members(MEMBERS) },
+    Fixture { lang: SupportLang::Go, file: "package a\n\n{body}",
+        member: "func M{i}() {\n{pad}}\n\n",
+        pad_line: "    // padding line {j} that exists only to grow this body\n",
+        expect: Expect::Members(MEMBERS) },
+    Fixture { lang: SupportLang::Haskell, file: "module A where\n\n{body}",
+        member: "m{i} :: Int -> Int\nm{i} x =\n{pad}    x\n\n",
+        pad_line: "    -- padding line {j} that exists only to grow this body\n",
+        expect: Expect::Members(MEMBERS) },
+    Fixture { lang: SupportLang::Hcl, file: "{body}",
+        member: "resource \"null_resource\" \"m{i}\" {\n{pad}  count = 1\n}\n\n",
+        pad_line: "  # padding line {j} that exists only to grow this block\n",
+        expect: Expect::SplitsOnly },
+    Fixture { lang: SupportLang::Html, file: "<html><body>\n{body}</body></html>\n",
+        member: "<div id=\"m{i}\">\n{pad}</div>\n",
+        pad_line: "  <!-- padding line {j} that exists only to grow this node -->\n",
+        expect: Expect::SplitsOnly },
+    Fixture { lang: SupportLang::Java, file: "public class A {\n{body}}\n",
+        member: "    void m{i}() {\n{pad}    }\n",
+        pad_line: "        // padding line {j} that exists only to grow this body\n",
+        expect: Expect::Members(MEMBERS) },
+    Fixture { lang: SupportLang::JavaScript, file: "class A {\n{body}}\n",
+        member: "  m{i}() {\n{pad}  }\n",
+        pad_line: "    // padding line {j} that exists only to grow this body\n",
+        expect: Expect::Members(MEMBERS) },
+    Fixture { lang: SupportLang::Json, file: "{\n{body}  \"tail\": 1\n}\n",
+        member: "  \"m{i}\": {\n{pad}    \"v\": 1\n  },\n",
+        pad_line: "    \"p{j}\": \"padding value that exists only to grow this object\",\n",
+        expect: Expect::SplitsOnly },
+    Fixture { lang: SupportLang::Kotlin, file: "class A {\n{body}}\n",
+        member: "    fun m{i}() {\n{pad}    }\n",
+        pad_line: "        // padding line {j} that exists only to grow this body\n",
+        expect: Expect::Members(MEMBERS) },
+    Fixture { lang: SupportLang::Lua, file: "{body}",
+        member: "function m{i}(x)\n{pad}  return x\nend\n\n",
+        pad_line: "  -- padding line {j} that exists only to grow this body\n",
+        expect: Expect::Members(MEMBERS) },
+    Fixture { lang: SupportLang::Nix, file: "{\n{body}}\n",
+        member: "  m{i} = {\n{pad}    v = 1;\n  };\n",
+        pad_line: "    # padding line {j} that exists only to grow this set\n",
+        expect: Expect::SplitsOnly },
+    Fixture { lang: SupportLang::Php, file: "<?php\nclass A {\n{body}}\n",
+        member: "    function m{i}() {\n{pad}    }\n",
+        pad_line: "        // padding line {j} that exists only to grow this body\n",
+        expect: Expect::Members(MEMBERS) },
+    Fixture { lang: SupportLang::Python, file: "class A:\n{body}",
+        member: "    def m{i}(self):\n{pad}        pass\n",
+        pad_line: "        # padding line {j} that exists only to grow this body\n",
+        expect: Expect::Members(MEMBERS) },
+    Fixture { lang: SupportLang::Ruby, file: "class A\n{body}end\n",
+        member: "  def m{i}\n{pad}  end\n",
+        pad_line: "    # padding line {j} that exists only to grow this body\n",
+        expect: Expect::Members(MEMBERS) },
+    Fixture { lang: SupportLang::Rust, file: "pub struct A;\n\nimpl A {\n{body}}\n",
+        member: "    pub fn m{i}(&self) {\n{pad}    }\n",
+        pad_line: "        // padding line {j} that exists only to grow this body\n",
+        expect: Expect::Members(MEMBERS) },
+    Fixture { lang: SupportLang::Scala, file: "class A {\n{body}}\n",
+        member: "  def m{i}(): Unit = {\n{pad}  }\n",
+        pad_line: "    // padding line {j} that exists only to grow this body\n",
+        expect: Expect::Members(MEMBERS) },
+    Fixture { lang: SupportLang::Solidity, file: "contract A {\n{body}}\n",
+        member: "    function m{i}() public {\n{pad}    }\n",
+        pad_line: "        // padding line {j} that exists only to grow this body\n",
+        expect: Expect::Members(MEMBERS) },
+    Fixture { lang: SupportLang::Swift, file: "class A {\n{body}}\n",
+        member: "    func m{i}() {\n{pad}    }\n",
+        pad_line: "        // padding line {j} that exists only to grow this body\n",
+        expect: Expect::Members(MEMBERS) },
+    Fixture { lang: SupportLang::Tsx, file: "{body}",
+        member: "export function M{i}() {\n{pad}  return <div />;\n}\n\n",
+        pad_line: "  // padding line {j} that exists only to grow this body\n",
+        expect: Expect::Members(MEMBERS) },
+    Fixture { lang: SupportLang::TypeScript, file: "export class A {\n{body}}\n",
+        member: "  m{i}(): void {\n{pad}  }\n",
+        pad_line: "    // padding line {j} that exists only to grow this body\n",
+        expect: Expect::Members(MEMBERS) },
+    Fixture { lang: SupportLang::Yaml, file: "{body}",
+        member: "m{i}:\n{pad}  v: 1\n",
+        pad_line: "  p{j}: padding value that exists only to grow this entry\n",
+        expect: Expect::SplitsOnly },
+];
+
+/// Adding a language to `ast-grep` without a fixture here is a build failure,
+/// not a silently unmeasured language.
+#[test]
+fn every_supported_language_has_a_fixture() {
+    let missing: Vec<String> = SupportLang::all_langs()
+        .iter()
+        .filter(|l| !FIXTURES.iter().any(|f| f.lang == **l))
+        .map(|l| format!("{l:?}"))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "no chunker fixture for {missing:?} — add one to FIXTURES"
+    );
+}
+
+/// Languages the chunker does not handle yet, and what stops it.
+///
+/// None of these has a `map` adapter: `ast-grep` parses them, but they are not
+/// first-class anywhere else in the tool, so the collapse costs less than the
+/// per-grammar special-casing a fix would take.
+///
+/// An entry is not a waiver. `known_gaps_still_fail` asserts every one of them
+/// still fails, so fixing a language turns that test red and the entry has to
+/// be deleted along with the fix.
+const KNOWN_GAPS: &[(SupportLang, &str)] = &[
+    (
+        SupportLang::Dart,
+        "a method is a `class_member` wrapping sibling `method_signature` and \
+         `function_body` nodes, so no single node spans the member",
+    ),
+    (
+        SupportLang::Elixir,
+        "every form is a `call` carrying a `do_block`; `def` is indistinguishable \
+         from any other macro call by node kind alone",
+    ),
+    (
+        SupportLang::Haskell,
+        "top-level `declarations` is not a container, and a definition is split \
+         into sibling `signature` and `function` nodes",
+    ),
+    (
+        SupportLang::Hcl,
+        "the parse root holds one `body` node, so blocks sit at depth 1 where \
+         only member kinds qualify",
+    ),
+    (
+        SupportLang::Html,
+        "the parse root holds one `element`, so nested elements sit at depth 1 \
+         where only member kinds qualify",
+    ),
+    (
+        SupportLang::Json,
+        "the parse root holds one `object`, so pairs sit at depth 1 where only \
+         member kinds qualify",
+    ),
+    (
+        SupportLang::Nix,
+        "the parse root holds one `attrset_expression`, so bindings sit at depth \
+         1 where only member kinds qualify",
+    ),
+    (
+        SupportLang::Yaml,
+        "the parse root holds one `document`, so mapping entries sit at depth 1 \
+         where only member kinds qualify",
+    ),
+];
+
+fn is_known_gap(lang: SupportLang) -> bool {
+    KNOWN_GAPS.iter().any(|(l, _)| *l == lang)
+}
+
+/// Property 1: the member walk sees every declaration the fixture declares.
+fn member_failure(f: &Fixture) -> Option<String> {
+    let Expect::Members(want) = f.expect else {
+        return None;
+    };
+    let found = build_split_plan(&render(f), f.lang).members.len();
+    (found < want).then(|| format!("{:?}: found {found} members, want >= {want}", f.lang))
+}
+
+/// Property 2: no `Source` chunk swallows the whole file.
+fn split_failure(f: &Fixture) -> Option<String> {
+    let src = render(f);
+    let limit = MAX_CHARS + src.len() / MEMBERS;
+    let chunks = chunk_source(&src, "fixture", ChunkerKind::AstGrep(f.lang));
+    let worst = chunks
+        .iter()
+        .filter(|c| c.kind == ChunkKind::Source)
+        .map(|c| c.content.len())
+        .max()
+        .unwrap_or(0);
+    (worst > limit).then(|| {
+        format!(
+            "{:?}: largest Source chunk is {worst} chars of a {} char file (limit {limit}, {} chunks)",
+            f.lang,
+            src.len(),
+            chunks.len()
+        )
+    })
+}
+
+/// The member walk must see every declaration the fixture declares.
+///
+/// Zero members means the grammar's node kinds fall outside `is_member_kind`
+/// and `is_member_container_kind`. The file then has no outline, no
+/// breadcrumbs, and no member-level split points.
+#[test]
+fn every_language_finds_its_members() {
+    let failures: Vec<String> = FIXTURES
+        .iter()
+        .filter(|f| !is_known_gap(f.lang))
+        .filter_map(member_failure)
+        .collect();
+    assert!(failures.is_empty(), "member walk incomplete:\n  {}", failures.join("\n  "));
+}
+
+/// No `Source` chunk may swallow the whole file.
+///
+/// Each fixture member is well under `MAX_CHARS`, so a correct split never
+/// exceeds the target by more than the member that crossed it. A language
+/// whose container the walk cannot open produces one chunk holding everything,
+/// which is what this catches.
+#[test]
+fn every_language_splits_a_large_file() {
+    let failures: Vec<String> = FIXTURES
+        .iter()
+        .filter(|f| !is_known_gap(f.lang))
+        .filter_map(split_failure)
+        .collect();
+    assert!(failures.is_empty(), "chunks not split:\n  {}", failures.join("\n  "));
+}
+
+/// Every `KNOWN_GAPS` entry still reproduces. Fixing one fails here on purpose.
+#[test]
+fn known_gaps_still_fail() {
+    let fixed: Vec<&str> = KNOWN_GAPS
+        .iter()
+        .filter(|(lang, _)| {
+            let f = FIXTURES.iter().find(|f| f.lang == *lang).expect("gap without a fixture");
+            member_failure(f).is_none() && split_failure(f).is_none()
+        })
+        .map(|(_, reason)| *reason)
+        .collect();
+    assert!(
+        fixed.is_empty(),
+        "these languages now chunk correctly — delete their KNOWN_GAPS entries:\n  {}",
+        fixed.join("\n  ")
+    );
+}
+
+
+/// One oversized callable, in a shape a real codebase uses.
+///
+/// `{pad}` is replaced by statement-sized filler that puts the body past
+/// `MAX_CHARS`. Only languages with a `map` adapter appear here: these are the
+/// shapes users actually search for.
+struct Shape {
+    label: &'static str,
+    lang: SupportLang,
+    src: &'static str,
+}
+
+/// Enough lines that even the tersest statement style clears `MAX_CHARS`.
+const SHAPE_PAD_LINES: usize = 70;
+
+fn render_shape(s: &Shape, pad_line: &str) -> String {
+    let pad: String = (0..SHAPE_PAD_LINES)
+        .map(|j| pad_line.replace("{j}", &j.to_string()))
+        .collect();
+    s.src.replace("{pad}", &pad)
+}
+
+/// Padding must be real statements, not comments. Several grammars attach a
+/// leading comment to the *declaration* rather than to its body, so a body of
+/// comments has nothing for the statement walk to split on — an artifact of the
+/// fixture, not of the chunker.
+const CISH: &str = "        int pad{j} = {j}; // grows the body\n";
+const TSISH: &str = "        let pad{j} = {j}; // grows the body\n";
+const GOISH: &str = "        pad{j} := {j}; _ = pad{j}\n";
+const RSISH: &str = "        let pad{j} = {j}; // grows the body\n";
+const PYISH: &str = "        pad{j} = {j}  # grows the body\n";
+const RBISH: &str = "        pad{j} = {j} # grows the body\n";
+const PHPISH: &str = "        $pad{j} = {j}; // grows the body\n";
+const KTISH: &str = "        val pad{j} = {j} // grows the body\n";
+
+#[rustfmt::skip]
+fn shapes() -> Vec<(Shape, &'static str)> {
+    vec![
+        (Shape { label: "C# method", lang: SupportLang::CSharp,
+            src: "namespace N;\nclass A {\n  public void M() {\n{pad}  }\n}\n" }, CISH),
+        (Shape { label: "C# constructor", lang: SupportLang::CSharp,
+            src: "namespace N;\nclass A {\n  public A() {\n{pad}  }\n}\n" }, CISH),
+        (Shape { label: "C# operator", lang: SupportLang::CSharp,
+            src: "namespace N;\nclass A {\n  public static A operator +(A a, A b) {\n{pad}    return a;\n  }\n}\n" }, CISH),
+        (Shape { label: "C# indexer", lang: SupportLang::CSharp,
+            src: "namespace N;\nclass A {\n  public int this[int i] {\n    get {\n{pad}      return i;\n    }\n  }\n}\n" }, CISH),
+        (Shape { label: "C# property accessor", lang: SupportLang::CSharp,
+            src: "namespace N;\nclass A {\n  public int P {\n    get {\n{pad}      return 1;\n    }\n  }\n}\n" }, CISH),
+        (Shape { label: "Java method", lang: SupportLang::Java,
+            src: "public class A {\n  void m() {\n{pad}  }\n}\n" }, CISH),
+        (Shape { label: "Java constructor", lang: SupportLang::Java,
+            src: "public class A {\n  public A() {\n{pad}  }\n}\n" }, CISH),
+        (Shape { label: "TS method", lang: SupportLang::TypeScript,
+            src: "export class A {\n  m(): void {\n{pad}  }\n}\n" }, TSISH),
+        (Shape { label: "TS exported function", lang: SupportLang::TypeScript,
+            src: "export function f(): void {\n{pad}}\n" }, TSISH),
+        (Shape { label: "TS arrow const", lang: SupportLang::TypeScript,
+            src: "export const f = (): void => {\n{pad}};\n" }, TSISH),
+        (Shape { label: "Go function", lang: SupportLang::Go,
+            src: "package a\n\nfunc F() {\n{pad}}\n" }, GOISH),
+        (Shape { label: "Go method", lang: SupportLang::Go,
+            src: "package a\n\ntype A struct{}\n\nfunc (a *A) M() {\n{pad}}\n" }, GOISH),
+        (Shape { label: "Rust method", lang: SupportLang::Rust,
+            src: "pub struct A;\n\nimpl A {\n  pub fn m(&self) {\n{pad}  }\n}\n" }, RSISH),
+        (Shape { label: "Python method", lang: SupportLang::Python,
+            src: "class A:\n    def m(self):\n{pad}        pass\n" }, PYISH),
+        (Shape { label: "Ruby method", lang: SupportLang::Ruby,
+            src: "class A\n  def m\n{pad}  end\nend\n" }, RBISH),
+        (Shape { label: "Kotlin method", lang: SupportLang::Kotlin,
+            src: "class A {\n  fun m() {\n{pad}  }\n}\n" }, KTISH),
+        (Shape { label: "Scala method", lang: SupportLang::Scala,
+            src: "class A {\n  def m(): Unit = {\n{pad}  }\n}\n" }, KTISH),
+        (Shape { label: "PHP method", lang: SupportLang::Php,
+            src: "<?php\nclass A {\n  function m() {\n{pad}  }\n}\n" }, PHPISH),
+        (Shape { label: "C++ method", lang: SupportLang::Cpp,
+            src: "class A {\npublic:\n  void m() {\n{pad}  }\n};\n" }, CISH),
+    ]
+}
+
+/// An oversized callable must be split into `Part` chunks beside the whole.
+///
+/// Without this the member is one chunk larger than `MAX_EMBED_CHARS`, whose
+/// vector is dropped from dense retrieval, so only BM25 can reach it.
+#[test]
+fn an_oversized_callable_is_split_into_parts() {
+    let mut failures = Vec::new();
+    for (s, pad_line) in shapes() {
+        let src = render_shape(&s, pad_line);
+        // Guard the fixture, not the chunker: a shape whose member stopped
+        // clearing MAX_CHARS would pass the real assertion for the wrong reason.
+        let biggest = build_split_plan(&src, s.lang)
+            .members
+            .iter()
+            .map(|m| m.end - m.start)
+            .max()
+            .unwrap_or(0);
+        assert!(
+            biggest > MAX_CHARS,
+            "{}: largest member is {biggest} chars, under MAX_CHARS — grow SHAPE_PAD_LINES",
+            s.label
+        );
+        let chunks = chunk_source(&src, "fixture", ChunkerKind::AstGrep(s.lang));
+        let parts = chunks.iter().filter(|c| c.kind == ChunkKind::Part).count();
+        if parts < 2 {
+            failures.push(format!(
+                "{}: {parts} Part chunk(s) for a {} char body ({} chunks total)",
+                s.label,
+                src.len(),
+                chunks.len()
+            ));
+        }
+    }
+    assert!(failures.is_empty(), "oversized callables not split:\n  {}", failures.join("\n  "));
+}
+
+
+/// A second way the same language spells a container or a member.
+///
+/// One fixture per language measures the style that fixture happens to use.
+/// Ruby shipped "fixed" on `class` + `def` while `def self.x`, `class << self`,
+/// a `do` block holding members, and four levels of nesting all still collapsed
+/// into one chunk — the table below is what would have caught that.
+struct Variant {
+    label: &'static str,
+    lang: SupportLang,
+    /// A whole file. `{pad}` is replaced per member; `{i}` is the index.
+    src: &'static str,
+}
+
+fn render_variant(v: &Variant, members: usize, pad_lines: usize, pad_line: &str) -> String {
+    let one: String = (0..members)
+        .map(|i| {
+            let pad: String = (0..pad_lines)
+                .map(|j| pad_line.replace("{j}", &j.to_string()))
+                .collect();
+            v.src
+                .split("{member}")
+                .nth(1)
+                .unwrap_or("")
+                .replace("{pad}", &pad)
+                .replace("{i}", &i.to_string())
+        })
+        .collect();
+    let (head, tail) = v.src.split_once("{member}").unwrap();
+    let tail = tail.split_once("{member}").map(|(_, t)| t).unwrap_or("");
+    format!("{head}{one}{tail}")
+}
+
+#[rustfmt::skip]
+fn variants() -> Vec<(Variant, &'static str)> {
+    vec![
+        (Variant { label: "Ruby def self.", lang: SupportLang::Ruby,
+            src: "class A\n{member}  def self.m{i}\n{pad}  end\n{member}end\n" }, RBISH),
+        (Variant { label: "Ruby class << self", lang: SupportLang::Ruby,
+            src: "class A\n  class << self\n{member}    def m{i}\n{pad}    end\n{member}  end\nend\n" }, RBISH),
+        (Variant { label: "Ruby nested 4 deep", lang: SupportLang::Ruby,
+            src: "module O\n  module I\n    class M\n      class D\n{member}        def m{i}\n{pad}        end\n{member}      end\n    end\n  end\nend\n" }, RBISH),
+        (Variant { label: "Ruby do-block members", lang: SupportLang::Ruby,
+            src: "S = Struct.new(:x) do\n{member}  def m{i}\n{pad}  end\n{member}end\n" }, RBISH),
+        (Variant { label: "C++ extern \"C\"", lang: SupportLang::Cpp,
+            src: "extern \"C\" {\n{member}void m{i}(void) {\n{pad}}\n{member}}\n" }, CISH),
+        (Variant { label: "C# nested namespace", lang: SupportLang::CSharp,
+            src: "namespace N {\n  namespace M {\n    class A {\n{member}      void M{i}() {\n{pad}      }\n{member}    }\n  }\n}\n" }, CISH),
+        (Variant { label: "Python nested class", lang: SupportLang::Python,
+            src: "class Outer:\n    class Inner:\n{member}        def m{i}(self):\n{pad}            pass\n{member}" }, PYISH),
+        (Variant { label: "TS namespace", lang: SupportLang::TypeScript,
+            src: "export namespace N {\n  export class A {\n{member}    m{i}(): void {\n{pad}    }\n{member}  }\n}\n" }, TSISH),
+    ]
+}
+
+/// Every spelling of a container must split, not just the one the main fixture
+/// happens to use.
+#[test]
+fn every_member_shape_splits() {
+    let mut failures = Vec::new();
+    for (v, pad_line) in variants() {
+        let src = render_variant(&v, MEMBERS, PAD_LINES, pad_line);
+        let limit = MAX_CHARS + src.len() / MEMBERS;
+        let chunks = chunk_source(&src, "fixture", ChunkerKind::AstGrep(v.lang));
+        let worst = chunks
+            .iter()
+            .filter(|c| c.kind == ChunkKind::Source)
+            .map(|c| c.content.len())
+            .max()
+            .unwrap_or(0);
+        if worst > limit {
+            failures.push(format!(
+                "{}: largest Source chunk is {worst} chars of a {} char file (limit {limit}, {} chunks)",
+                v.label,
+                src.len(),
+                chunks.len()
+            ));
+        }
+    }
+    assert!(failures.is_empty(), "member shapes not split:\n  {}", failures.join("\n  "));
+}
+
+
+/// One declaration per language, and the signature its outline entry carries.
+///
+/// The shape tables above assert member counts and `Part` splitting, never
+/// signature *text*, which is how Go and C# shipped with their parameters cut
+/// off: both name the parameter node `parameter_list` as a direct child of the
+/// declaration, so a body-start rule based on kind alone fired on it.
+struct SigCase {
+    label: &'static str,
+    lang: SupportLang,
+    src: &'static str,
+    /// The signature one member of `src` must carry, whitespace collapsed.
+    want: &'static str,
+}
+
+#[rustfmt::skip]
+fn sig_cases() -> Vec<SigCase> {
+    vec![
+        SigCase { label: "Java method", lang: SupportLang::Java,
+            src: "public class Db {\n  public Conn connect(String host, int port, int retries) {\n    return null;\n  }\n}\n",
+            want: "public Conn connect(String host, int port, int retries)" },
+        SigCase { label: "Rust struct", lang: SupportLang::Rust,
+            src: "pub struct Config {\n    pub host: String,\n    pub port: u16,\n}\n",
+            want: "pub struct Config" },
+        SigCase { label: "Rust method", lang: SupportLang::Rust,
+            src: "pub struct C;\nimpl C {\n    pub fn connect(&self, host: &str, port: u16) -> Result<S, String> {\n        Ok(())\n    }\n}\n",
+            want: "pub fn connect(&self, host: &str, port: u16) -> Result<S, String>" },
+        SigCase { label: "Python method", lang: SupportLang::Python,
+            src: "class S:\n    def connect(self, host: str, port: int) -> None:\n        pass\n",
+            want: "def connect(self, host: str, port: int) -> None:" },
+        SigCase { label: "TypeScript method", lang: SupportLang::TypeScript,
+            src: "export class S {\n  connect(host: string, port: number): Promise<void> {\n    return null;\n  }\n}\n",
+            want: "connect(host: string, port: number): Promise<void>" },
+        SigCase { label: "Ruby method", lang: SupportLang::Ruby,
+            src: "class S\n  def connect(host, port, retries)\n    nil\n  end\nend\n",
+            want: "def connect(host, port, retries)" },
+        SigCase { label: "Kotlin method", lang: SupportLang::Kotlin,
+            src: "class S {\n    fun connect(host: String, port: Int): String {\n        return \"\"\n    }\n}\n",
+            want: "fun connect(host: String, port: Int): String" },
+        SigCase { label: "Scala method", lang: SupportLang::Scala,
+            src: "class S {\n  def connect(host: String, port: Int): String = {\n    \"\"\n  }\n}\n",
+            want: "def connect(host: String, port: Int): String" },
+        SigCase { label: "PHP method", lang: SupportLang::Php,
+            src: "<?php\nclass S {\n  function connect($host, $port) {\n    return null;\n  }\n}\n",
+            want: "function connect($host, $port)" },
+        SigCase { label: "C++ method", lang: SupportLang::Cpp,
+            src: "namespace ns {\nclass Widget {\npublic:\n  int method0(int a, int b) {\n    return a + b;\n  }\n};\n}\n",
+            want: "int method0(int a, int b)" },
+        SigCase { label: "C# class", lang: SupportLang::CSharp,
+            src: "namespace N;\npublic class Db {\n  public Conn Connect(string host, int port) {\n    return null;\n  }\n}\n",
+            want: "public class Db" },
+        SigCase { label: "C# method", lang: SupportLang::CSharp,
+            src: "namespace N;\npublic class Db {\n  public Conn Connect(string host, int port) {\n    return null;\n  }\n}\n",
+            want: "public Conn Connect(string host, int port)" },
+        SigCase { label: "Go function", lang: SupportLang::Go,
+            src: "package a\n\ntype C struct{}\n\nfunc Connect(host string, port int) (*C, error) {\n\treturn nil, nil\n}\n",
+            want: "func Connect(host string, port int) (*C, error)" },
+        SigCase { label: "Go method", lang: SupportLang::Go,
+            src: "package a\n\ntype C struct{}\n\nfunc (c *C) Query(sql string) error {\n\treturn nil\n}\n",
+            want: "func (c *C) Query(sql string) error" },
+    ]
+}
+
+/// An outline entry must name the declaration and carry its parameters.
+///
+/// The shape tables assert member counts and `Part` splitting; neither notices
+/// a signature cut in half, which is how Go shipped an entry reading `func` and
+/// naming nothing. Outlines are the only input to phase-one file ranking, so a
+/// language whose entries are truncated cannot earn the prior its neighbour
+/// gets on the same query.
+#[test]
+fn every_language_keeps_its_parameters_in_the_signature() {
+    let mut failures = Vec::new();
+    for c in sig_cases() {
+        let got: Vec<String> = build_split_plan(c.src, c.lang)
+            .members
+            .into_iter()
+            .map(|m| m.signature)
+            .collect();
+        if !got.iter().any(|s| s == c.want) {
+            failures.push(format!("{}: want {:?}, got {:?}", c.label, c.want, got));
+        }
+    }
+    assert!(failures.is_empty(), "signatures truncated:\n  {}", failures.join("\n  "));
+}

--- a/src/search/embed.rs
+++ b/src/search/embed.rs
@@ -333,6 +333,8 @@ pub fn cosine_topk(
     top.into_iter()
         .filter_map(|i| {
             let s = scores[i as usize];
+            // A row past the size the model handles is stored non-finite on
+            // purpose, which keeps it reachable lexically and never densely.
             if s.is_finite() { Some((i, s)) } else { None }
         })
         .collect()
@@ -351,7 +353,17 @@ fn score_row(
         }
     }
     let row = &embeddings[i * DIM..(i + 1) * DIM];
-    dot_simd(q_lanes, row)
+    let score = dot_simd(q_lanes, row);
+    // NaN participates in no ordering: `partial_cmp` answers `None` against
+    // every value, and the caller reads that as a tie. A row left comparable
+    // to nothing can be partitioned into the top-k window and then dropped by
+    // the `is_finite` filter, returning a pool shorter than `k`. Demoting the
+    // sentinel here is what makes the comparison total.
+    if score.is_finite() {
+        score
+    } else {
+        f32::NEG_INFINITY
+    }
 }
 
 #[inline]
@@ -521,6 +533,51 @@ mod tests {
             }
         }
         v
+    }
+
+    /// An unembedded row is never a dense candidate, however the pool is sized.
+    #[test]
+    fn a_non_finite_row_never_enters_the_top_k() {
+        // A zero vector cannot serve as the sentinel: its dot product is a
+        // finite 0.0, which outranks every negative similarity and so enters
+        // the pool whenever the corpus is smaller than the pool — the normal
+        // case for a small repository.
+        let mut rows = vec![0.0f32; DIM * 3];
+        rows[..DIM].fill(1.0 / (DIM as f32).sqrt()); // row 0: matches
+        rows[DIM..DIM * 2].fill(-1.0 / (DIM as f32).sqrt()); // row 1: opposes
+        rows[DIM * 2..].fill(f32::NAN); // row 2: never embedded
+        let mut query = [0.0f32; DIM];
+        query.fill(1.0 / (DIM as f32).sqrt());
+
+        let top = cosine_topk(&query, &rows, None, 10);
+        let ids: Vec<u32> = top.iter().map(|(i, _)| *i).collect();
+        assert!(ids.contains(&0), "the matching row should rank");
+        assert!(ids.contains(&1), "even an opposing row is a candidate");
+        assert!(!ids.contains(&2), "the non-embedded row must not be a candidate");
+        assert_eq!(top.len(), 2, "asked for 10 of 3 rows, one is excluded");
+    }
+
+    /// The pool holds `k` embedded rows even when unembedded rows sort first.
+    ///
+    /// Red here means the sentinel stopped being comparable, so unembedded
+    /// rows occupy window slots and the `is_finite` filter returns a short pool.
+    #[test]
+    fn non_finite_rows_do_not_steal_the_top_k_window() {
+        // Unembedded rows come first so a partition that treats them as ties
+        // has every chance to keep them, which is the case that fails when the
+        // sentinel is left incomparable.
+        let unit = 1.0 / (DIM as f32).sqrt();
+        let mut rows = vec![f32::NAN; DIM * 6];
+        for (n, scale) in [(3usize, 1.0f32), (4, 0.9), (5, 0.8)] {
+            rows[n * DIM..(n + 1) * DIM].fill(unit * scale);
+        }
+        let mut query = [0.0f32; DIM];
+        query.fill(unit);
+
+        let top = cosine_topk(&query, &rows, None, 3);
+        let ids: Vec<u32> = top.iter().map(|(i, _)| *i).collect();
+        assert_eq!(ids, vec![3, 4, 5], "the three embedded rows, best first");
+        assert!(top.iter().all(|(_, s)| s.is_finite()), "every score finite");
     }
 
     #[test]

--- a/src/search/format.rs
+++ b/src/search/format.rs
@@ -5,6 +5,7 @@
 //! The CLI and MCP tool handlers both call into here so output is consistent
 //! between the two surfaces.
 
+use crate::search::chunker::ChunkKind;
 use crate::search::index::{Meta, SearchHit};
 use colored::Colorize;
 use serde_json::{json, Value};
@@ -61,14 +62,40 @@ pub fn render_related_text(file_path: &str, line: u32, hits: &[SearchHit]) -> St
     out
 }
 
-/// Shared header for one hit: `<cyan-bold path>:<lines>  [score X.XXX]` (score dimmed).
+/// Shared header for one hit: `<cyan-bold path>:<lines>  [score X.XXX]` (score
+/// dimmed), followed by the breadcrumb and chunk level when they add anything.
 fn render_hit_header(hit: &SearchHit) -> String {
     let location = format!(
         "{}:{}-{}",
         hit.chunk.file_path, hit.chunk.start_line, hit.chunk.end_line
     );
     let score = format!("[score {:.3}]", hit.score);
-    format!("{}  {}\n", location.cyan().bold(), score.dimmed())
+    let mut out = format!("{}  {}\n", location.cyan().bold(), score.dimmed());
+
+    let mut note = String::new();
+    if !hit.chunk.breadcrumb.is_empty() {
+        note.push_str(&hit.chunk.breadcrumb);
+    }
+    // `Source` is the ordinary case and says nothing worth a line; the other
+    // levels change how the result should be read.
+    let level = match hit.chunk.kind {
+        ChunkKind::Source => "",
+        ChunkKind::Enclosing => "whole member",
+        ChunkKind::Part => "part of member",
+        ChunkKind::Outline => "file outline",
+    };
+    if !level.is_empty() {
+        if !note.is_empty() {
+            note.push_str("  ");
+        }
+        note.push('(');
+        note.push_str(level);
+        note.push(')');
+    }
+    if !note.is_empty() {
+        out.push_str(&format!("  {}\n", note.dimmed()));
+    }
+    out
 }
 
 /// Shared body: chunk content indented by 4 spaces. No syntax colouring —
@@ -177,6 +204,13 @@ fn hit_to_json(hit: &SearchHit) -> Value {
         "end_line": hit.chunk.end_line,
         "language": hit.chunk.language,
         "score": hit.score,
+        "breadcrumb": hit.chunk.breadcrumb,
+        "kind": match hit.chunk.kind {
+            ChunkKind::Source => "source",
+            ChunkKind::Enclosing => "enclosing",
+            ChunkKind::Part => "part",
+            ChunkKind::Outline => "outline",
+        },
         "content": hit.chunk.content,
     })
 }
@@ -192,7 +226,7 @@ fn to_json(v: &Value, pretty: bool) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::search::chunker::Chunk;
+    use crate::search::chunker::{Chunk, ChunkKind};
     use crate::search::index::ModelMeta;
 
     fn hit(path: &str, score: f32, content: &str) -> SearchHit {
@@ -205,6 +239,8 @@ mod tests {
                 start_byte: 0,
                 end_byte: content.len() as u32,
                 language: "rust".to_string(),
+                breadcrumb: String::new(),
+                kind: ChunkKind::Source,
             },
             score,
         }

--- a/src/search/format.rs
+++ b/src/search/format.rs
@@ -202,6 +202,10 @@ fn hit_to_json(hit: &SearchHit) -> Value {
         "path": hit.chunk.file_path,
         "start_line": hit.chunk.start_line,
         "end_line": hit.chunk.end_line,
+        // Line numbers cannot place an answer that starts or ends mid-line,
+        // which the eval harness needs for a span written as `line:column`.
+        "start_byte": hit.chunk.start_byte,
+        "end_byte": hit.chunk.end_byte,
         "language": hit.chunk.language,
         "score": hit.score,
         "breadcrumb": hit.chunk.breadcrumb,

--- a/src/search/index.rs
+++ b/src/search/index.rs
@@ -31,7 +31,7 @@ use crate::file_filter::{add_filters, should_skip_path};
 use crate::project_root::{relative_posix, resolve_home, Marker};
 use crate::search::bm25::Bm25Index;
 use crate::search::cache::{compute_delta, hash_file, FileRecord, MAX_INDEX_FILE_BYTES};
-use crate::search::chunker::{chunk_file, is_indexable, Chunk};
+use crate::search::chunker::{chunk_file, is_indexable, Chunk, ChunkKind};
 use crate::search::download::{ensure_model, ModelInfo};
 use crate::search::embed::{cosine_topk, Embedder, DIM};
 use crate::search::fusion::{combine, resolve_alpha, rrf_scores};
@@ -42,11 +42,65 @@ use fs2::FileExt;
 use ignore::WalkBuilder;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 use std::time::SystemTime;
+
+/// How many files phase one of two-phase search considers.
+const PHASE1_FILES: usize = 40;
+
+/// Weight of the phase-one file prior.
+///
+/// A chunk in a file phase one liked is multiplied by `1 + FILE_PRIOR_WEIGHT ×
+/// prior`, so the prior only ever promotes — a file phase one missed keeps its
+/// unmodified score. That is deliberate: a hard filter on phase one would zero
+/// out recall for every query whose file the outlines fail to surface, and
+/// phase one finds the right file in only about half of them.
+///
+/// Measured on the pinned eval corpus at `--min-iou 0.3`: MRR@10 0.204 → 0.226
+/// at unchanged recall@5. Anything in 0.5..=2.0 performs about the same, so
+/// this sits on a plateau rather than a spike.
+const FILE_PRIOR_WEIGHT: f32 = 1.0;
+
+/// Promote chunks whose file scored well in phase one.
+fn apply_file_prior(
+    scored: &mut HashMap<u32, f32>,
+    chunks: &[Chunk],
+    prior: &HashMap<&str, f32>,
+    weight: f32,
+) {
+    if prior.is_empty() {
+        return;
+    }
+    for (id, score) in scored.iter_mut() {
+        let chunk = &chunks[*id as usize];
+        if let Some(p) = prior.get(chunk.file_path.as_str()) {
+            *score *= 1.0 + weight * p;
+        }
+    }
+}
+
+/// How many candidates each retriever contributes before fusion.
+///
+/// Fixed rather than derived from `top_k`, so that asking for more results
+/// changes how many come back and not which ones. Deriving the pool feeds the
+/// reranker a different candidate set per `k`, and a different set is a
+/// different answer: at a pool of `max(100, top_k * 5)`, eight of thirty eval
+/// queries had a `k`-dependent top-3 and three a `k`-dependent top-1. Fixed,
+/// it is zero of thirty.
+///
+/// `max(_, top_k)` at the call site keeps the pool at least as large as the
+/// answer, so `k` above 100 couples the two again — by then the pool is the
+/// honest answer to the question anyway.
+///
+/// The size costs one wider `select_nth_unstable_by` over scores both
+/// retrievers already compute for every chunk. It buys no recall@5 and no
+/// MRR@10; it buys the same query answering the same way whatever `-k` it was
+/// asked with.
+const MIN_CANDIDATES: usize = 100;
 
 /// Current schema version written by all new builds.
 // v2 adds `breadcrumb` and `kind` to `Chunk`, which changes the bincode layout
@@ -692,13 +746,59 @@ impl Index {
         !delta.requires_rebuild() && delta.mtime_only.is_empty()
     }
 
+    /// Phase one of two-phase search: rank *files* using only their outline
+    /// chunks, and return a per-file prior in `0..=1`.
+    ///
+    /// An outline chunk is the file's signature list, so it states what the
+    /// file is for in one place. A body chunk can only ever match a fragment of
+    /// that, which is why aggregating body scores per file is a weaker file
+    /// signal than asking the outlines directly.
+    fn file_prior(
+        &self,
+        q_embed: &[f32; DIM],
+        query_tokens: &[String],
+        mask: Option<&[bool]>,
+    ) -> HashMap<&str, f32> {
+        // Restrict both retrievers to outline chunks, intersected with the
+        // caller's mask so language/scope filters still apply.
+        let outline_mask: Vec<bool> = self
+            .chunks
+            .iter()
+            .enumerate()
+            .map(|(i, c)| {
+                c.kind == ChunkKind::Outline && mask.is_none_or(|m| m[i])
+            })
+            .collect();
+        if !outline_mask.iter().any(|b| *b) {
+            return HashMap::new();
+        }
+
+        let sem = cosine_topk(q_embed, &self.embeddings, Some(&outline_mask), PHASE1_FILES);
+        let lex = if query_tokens.is_empty() {
+            Vec::new()
+        } else {
+            let raw = self.bm25.get_scores(query_tokens, Some(&outline_mask));
+            top_k_indices(&raw, PHASE1_FILES)
+        };
+        let fused = combine(&rrf_scores(&sem), &rrf_scores(&lex), 0.5);
+
+        let best = fused.values().copied().fold(0.0f32, f32::max);
+        if best <= 0.0 {
+            return HashMap::new();
+        }
+        fused
+            .into_iter()
+            .map(|(id, s)| (self.chunks[id as usize].file_path.as_str(), s / best))
+            .collect()
+    }
+
     /// Hybrid BM25 + dense search with full ranking pipeline.
     pub fn search(&self, query: &str, opts: &SearchOptions) -> Vec<SearchHit> {
         if self.chunks.is_empty() || opts.top_k == 0 {
             return Vec::new();
         }
         let alpha = resolve_alpha(query, opts.alpha);
-        let candidate_count = opts.top_k * 5;
+        let candidate_count = MIN_CANDIDATES.max(opts.top_k);
 
         // Build combined mask: language ∧ query_scope ∧ live ∧ path: ∧ name:.
         // Any may be inactive.
@@ -753,6 +853,8 @@ impl Index {
         // File coherence + query-aware boosts.
         let mut scored = combined;
         boost_multi_chunk_files(&mut scored, &self.chunks);
+        let prior = self.file_prior(&q_embed, &query_tokens, mask.as_deref());
+        apply_file_prior(&mut scored, &self.chunks, &prior, FILE_PRIOR_WEIGHT);
         let scored = apply_query_boost(scored, query, &self.chunks);
 
         // Final top-k with path penalties + saturation decay.

--- a/src/search/index.rs
+++ b/src/search/index.rs
@@ -786,10 +786,20 @@ impl Index {
         if best <= 0.0 {
             return HashMap::new();
         }
-        fused
-            .into_iter()
-            .map(|(id, s)| (self.chunks[id as usize].file_path.as_str(), s / best))
-            .collect()
+        // A file has one outline document per `OUTLINE_MAX_CHARS`, so several
+        // pieces can score. Keep the best — collecting into a map would let
+        // whichever piece came last in the (randomized) iteration order decide
+        // the file's prior, and the ranking downstream would differ run to run.
+        let mut prior: HashMap<&str, f32> = HashMap::new();
+        for (id, s) in fused {
+            let path = self.chunks[id as usize].file_path.as_str();
+            let normalised = s / best;
+            prior
+                .entry(path)
+                .and_modify(|p| *p = p.max(normalised))
+                .or_insert(normalised);
+        }
+        prior
     }
 
     /// Hybrid BM25 + dense search with full ranking pipeline.
@@ -1092,10 +1102,13 @@ fn top_k_indices(scores: &[f32], k: usize) -> Vec<(u32, f32)> {
             .unwrap_or(std::cmp::Ordering::Equal)
     });
     let mut top: Vec<u32> = idx.into_iter().take(take).collect();
+    // Tie-break on id so the candidate list is a total order, not merely a
+    // deterministic one — see the note in `rerank_topk`.
     top.sort_by(|&a, &b| {
         scores[b as usize]
             .partial_cmp(&scores[a as usize])
             .unwrap_or(std::cmp::Ordering::Equal)
+            .then(a.cmp(&b))
     });
     // Drop zero-score entries — BM25 zeros mean "no query token matched".
     top.into_iter()

--- a/src/search/index.rs
+++ b/src/search/index.rs
@@ -49,11 +49,10 @@ use std::sync::{Arc, OnceLock};
 use std::time::SystemTime;
 
 /// Current schema version written by all new builds.
-const SCHEMA: &str = "ast-bro.search-index.v1";
-/// Legacy v1 schema from pre-rename installs — still readable.
-const SCHEMA_V1_LEGACY: &str = "ast-outline.search-index.v1";
-/// Legacy v2 schema from pre-rename installs — still readable.
-const SCHEMA_V2_LEGACY: &str = "ast-outline.search-index.v2";
+// v2 adds `breadcrumb` and `kind` to `Chunk`, which changes the bincode layout
+// of chunks.bin. A v1 index cannot be decoded, so the loader rejects it and the
+// caller rebuilds.
+const SCHEMA: &str = "ast-bro.search-index.v2";
 
 /// On-disk paths under a repo's `.ast-bro/index/` directory.
 #[derive(Debug, Clone)]
@@ -359,10 +358,7 @@ impl Index {
         let started_embed = std::time::Instant::now();
         let embeddings: Vec<f32> = chunks
             .par_iter()
-            .flat_map(|c| {
-                let v = embedder.encode_one(&c.content);
-                v.to_vec()
-            })
+            .flat_map(|c| embed_chunk(&embedder, c))
             .collect();
         eprintln!(
             "ast-bro: embedded in {:.1}s",
@@ -515,7 +511,7 @@ impl Index {
         for (path, file_chunks) in chunked {
             let chunk_start = self.chunks.len() as u32;
             for c in file_chunks {
-                let v = self.embedder.encode_one(&c.content);
+                let v = embed_chunk(&self.embedder, &c);
                 self.embeddings.extend_from_slice(&v);
                 self.chunks.push(c);
             }
@@ -595,11 +591,13 @@ impl Index {
     /// Load from disk without delta-checking. Used by `open` and tests.
     fn load_unlocked(paths: &IndexPaths) -> io::Result<Self> {
         let meta: Meta = read_meta(&paths.meta_json)?;
-        // Accept current schema and the older legacy schemas.
-        if meta.schema != SCHEMA && meta.schema != SCHEMA_V1_LEGACY && meta.schema != SCHEMA_V2_LEGACY {
+        // Only the current schema decodes. Earlier ones — including the
+        // pre-rename `ast-outline.*` names — predate the `Chunk` layout change
+        // in v2, so the caller has to rebuild rather than read them.
+        if meta.schema != SCHEMA {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("schema {} not in [{SCHEMA}, {SCHEMA_V1_LEGACY}, {SCHEMA_V2_LEGACY}]", meta.schema),
+                format!("schema {} is not {SCHEMA}; rebuild the index", meta.schema),
             ));
         }
         if meta.model.dim as usize != DIM {
@@ -1022,8 +1020,68 @@ fn resolve_chunk(chunks: &[Chunk], file_path: &str, line: u32) -> Option<u32> {
     fallback
 }
 
-/// Append file path components to chunk content to boost path-based queries.
+/// Above this, a chunk is indexed lexically but not embedded.
+///
+/// `potion-code-16M` encodes a chunk as the mean of its token vectors, so the
+/// result drifts toward the centroid of the language as the chunk grows — a
+/// 40 KB class embeds as "generic Java" and matches everything weakly. Past
+/// this size the vector carries less signal than the noise it adds, so the
+/// chunk gets a non-finite vector, which `cosine_topk` drops, so only BM25 can
+/// retrieve it. Its `Part` chunks stay embedded, so the content is still
+/// reachable densely.
+///
+/// A zero vector would not do: its dot product is a finite `0.0`, which ranks
+/// above every negative similarity and enters the pool whenever the corpus has
+/// fewer positively-scoring chunks than the pool holds — the normal case for a
+/// small repository.
+const MAX_EMBED_CHARS: usize = 6000;
+
+/// The text a chunk is embedded from: its breadcrumb, then its content.
+///
+/// Prefixing the breadcrumb is worth more than it looks. `potion-code-16M` is
+/// static — it averages token vectors and never saw `Type > method` headers in
+/// training — so the prefix arguably just shifts every vector alike. Measured
+/// on the pinned 30-query pgjdbc set at `--min-iou 0.3` it does not:
+///
+/// ```text
+/// breadcrumb in embed + BM25   recall@5 23%   MRR@10 0.226
+/// no breadcrumb                recall@5 17%   MRR@10 0.148
+/// ```
+///
+/// Averaging is likely why it works: a body-level chunk that never names its
+/// own method gets those tokens pulled into its mean, and queries name methods.
+/// BM25 keeps the breadcrumb too (see `enrich_for_bm25`), where it measured as
+/// no change on top of this but carries the effect on its own.
+fn embed_text(chunk: &Chunk) -> String {
+    if chunk.breadcrumb.is_empty() {
+        return chunk.content.clone();
+    }
+    format!("{}\n{}", chunk.breadcrumb, chunk.content)
+}
+
+/// Embeds one chunk, or returns a non-finite vector when it is too big to
+/// embed well — see [`MAX_EMBED_CHARS`] for what `cosine_topk` then does with it.
+///
+/// The cap applies to what the embedder actually sees, breadcrumb included —
+/// measuring `content` alone let a chunk just under the limit cross it once the
+/// prefix was added. The length is computed before building the string so the
+/// oversized case allocates nothing.
+fn embed_chunk(embedder: &Embedder, chunk: &Chunk) -> Vec<f32> {
+    let crumb_len = if chunk.breadcrumb.is_empty() {
+        0
+    } else {
+        chunk.breadcrumb.len() + 1
+    };
+    if chunk.content.len() + crumb_len > MAX_EMBED_CHARS {
+        return vec![f32::NAN; DIM];
+    }
+    embedder.encode_one(&embed_text(chunk)).to_vec()
+}
+
+/// Append file path components and the breadcrumb to chunk content, so
+/// path-shaped and symbol-shaped queries reach the lexical retriever.
 fn enrich_for_bm25(chunk: &Chunk) -> String {
+    let crumb = chunk.breadcrumb.as_str();
     let path = Path::new(&chunk.file_path);
     let stem = path
         .file_stem()
@@ -1048,7 +1106,7 @@ fn enrich_for_bm25(chunk: &Chunk) -> String {
         .rev()
         .collect::<Vec<_>>()
         .join(" ");
-    format!("{} {} {} {}", chunk.content, stem, stem, dir_text)
+    format!("{} {} {} {} {}", chunk.content, stem, stem, dir_text, crumb)
 }
 
 /// Walk `walk_root` and return absolute file paths + their chunks.
@@ -1210,6 +1268,7 @@ fn normalise_path(p: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::search::chunker::ChunkKind;
     use std::fs::File;
     use std::io::Write;
 
@@ -1245,6 +1304,8 @@ mod tests {
             start_byte: 0,
             end_byte: 9,
             language: "rust".to_string(),
+            breadcrumb: String::new(),
+            kind: ChunkKind::Source,
         };
         let enriched = enrich_for_bm25(&chunk);
         // Stem appears twice; "src" and "auth" appear once each in dir text.
@@ -1264,6 +1325,8 @@ mod tests {
             start_byte: 0,
             end_byte: 0,
             language: "rust".to_string(),
+            breadcrumb: String::new(),
+            kind: ChunkKind::Source,
         };
         let chunks = vec![mk(1, 10), mk(20, 30), mk(40, 50)];
         assert_eq!(resolve_chunk(&chunks, "f.rs", 5), Some(0));
@@ -1303,6 +1366,8 @@ mod tests {
             start_byte: 0,
             end_byte: 5,
             language: "rust".to_string(),
+            breadcrumb: String::new(),
+            kind: ChunkKind::Source,
         }];
         let files = vec![FileRecord {
             path: "a.rs".to_string(),
@@ -1451,6 +1516,8 @@ mod tests {
             start_byte: 0,
             end_byte: 0,
             language: "rust".to_string(),
+            breadcrumb: String::new(),
+            kind: ChunkKind::Source,
         };
         let chunks = vec![mk()];
         assert!(build_combined_mask(&chunks, None, None, None, &[], &[]).is_none());
@@ -1467,6 +1534,8 @@ mod tests {
             start_byte: 0,
             end_byte: 0,
             language: lang.to_string(),
+            breadcrumb: String::new(),
+            kind: ChunkKind::Source,
         };
         let chunks = vec![
             mk("rust", "src/a.rs"),
@@ -1509,6 +1578,8 @@ mod tests {
             start_byte: 0,
             end_byte: 0,
             language: "rust".to_string(),
+            breadcrumb: String::new(),
+            kind: ChunkKind::Source,
         };
         let chunks = vec![
             mk("src/auth/login.rs"),

--- a/src/search/ranking.rs
+++ b/src/search/ranking.rs
@@ -5,7 +5,7 @@
 //! the dict key (frozen dataclass identity), we use the integer id and pass
 //! the chunks slice to functions that need `file_path` or `content`.
 
-use crate::search::chunker::Chunk;
+use crate::search::chunker::{Chunk, ChunkKind};
 use crate::search::tokens::split_identifier;
 use regex::{Regex, RegexBuilder};
 use std::collections::{HashMap, HashSet};
@@ -512,6 +512,21 @@ fn file_path_penalty(file_path: &str) -> f32 {
     penalty
 }
 
+/// How much a chunk's level costs it against a plain source chunk.
+///
+/// Both coarse levels are useful but rarely the best answer. An `Enclosing`
+/// chunk names a method when a `Part` could have named the statement; an
+/// `Outline` names a file when a body chunk could have named the line. They win
+/// only when nothing finer matched, which is the case they exist for — a query
+/// naming a type or an API that no single body mentions.
+fn chunk_kind_penalty(kind: ChunkKind) -> f32 {
+    match kind {
+        ChunkKind::Source | ChunkKind::Part => 1.0,
+        ChunkKind::Enclosing => 0.7,
+        ChunkKind::Outline => 0.8,
+    }
+}
+
 /// Greedy top-k selection with file-path penalties and file-saturation decay.
 /// Returns `(chunk_id, final_score)` pairs sorted by score descending.
 pub fn rerank_topk(
@@ -524,11 +539,12 @@ pub fn rerank_topk(
         return Vec::new();
     }
 
-    // Apply path penalties (cached per file).
+    // Apply path penalties (cached per file) and the chunk-level penalty.
     let mut penalty_cache: HashMap<&str, f32> = HashMap::new();
     let mut penalised: Vec<(u32, f32)> = Vec::with_capacity(scores.len());
     for (&id, &score) in scores {
-        let path: &str = chunks[id as usize].file_path.as_str();
+        let chunk = &chunks[id as usize];
+        let path: &str = chunk.file_path.as_str();
         let pen = if penalise_paths {
             *penalty_cache
                 .entry(path)
@@ -536,7 +552,26 @@ pub fn rerank_topk(
         } else {
             1.0
         };
-        penalised.push((id, score * pen));
+        penalised.push((id, score * pen * chunk_kind_penalty(chunk.kind)));
+    }
+
+    // An Enclosing chunk covers the same bytes as its Parts, so a body match
+    // scores both. Keep the finer one: the Part points at the statement, the
+    // Enclosing only at the method it sits in.
+    let covered: Vec<(u32, u32, &str)> = penalised
+        .iter()
+        .map(|(id, _)| &chunks[*id as usize])
+        .filter(|c| c.kind == ChunkKind::Part)
+        .map(|c| (c.start_byte, c.end_byte, c.file_path.as_str()))
+        .collect();
+    if !covered.is_empty() {
+        penalised.retain(|(id, _)| {
+            let c = &chunks[*id as usize];
+            c.kind != ChunkKind::Enclosing
+                || !covered.iter().any(|(s, e, p)| {
+                    *p == c.file_path && *s >= c.start_byte && *e <= c.end_byte
+                })
+        });
     }
 
     // Sort by penalised score descending (stable on ties — preserves insertion
@@ -593,6 +628,8 @@ mod tests {
             start_byte: 0,
             end_byte: content.len() as u32,
             language: "rust".to_string(),
+            breadcrumb: String::new(),
+            kind: crate::search::chunker::ChunkKind::Source,
         }
     }
 

--- a/src/search/ranking.rs
+++ b/src/search/ranking.rs
@@ -246,17 +246,26 @@ pub fn boost_multi_chunk_files(scores: &mut HashMap<u32, f32>, chunks: &[Chunk])
         return;
     }
 
+    // Walk in id order, not `HashMap` order, so the same query over the same
+    // index answers the same way twice. Two results here read the traversal
+    // order: a per-file sum, because float addition is not associative, and
+    // `best_chunk`, because an exact score tie keeps whichever chunk came
+    // first.
+    let mut ids: Vec<u32> = scores.keys().copied().collect();
+    ids.sort_unstable();
+
     let mut file_sum: HashMap<&str, f32> = HashMap::new();
     let mut best_chunk: HashMap<&str, u32> = HashMap::new();
-    for (&id, &score) in scores.iter() {
-        let path: &str = chunks[id as usize].file_path.as_str();
+    for id in &ids {
+        let score = scores[id];
+        let path: &str = chunks[*id as usize].file_path.as_str();
         *file_sum.entry(path).or_insert(0.0) += score;
         match best_chunk.get(path) {
             Some(&prev) if score > scores[&prev] => {
-                best_chunk.insert(path, id);
+                best_chunk.insert(path, *id);
             }
             None => {
-                best_chunk.insert(path, id);
+                best_chunk.insert(path, *id);
             }
             _ => {}
         }
@@ -267,7 +276,9 @@ pub fn boost_multi_chunk_files(scores: &mut HashMap<u32, f32>, chunks: &[Chunk])
         return;
     }
     let boost_unit = max_score * FILE_COHERENCE_BOOST_FRAC;
-    for (path, &id) in best_chunk.iter() {
+    let mut boosted: Vec<(&str, u32)> = best_chunk.into_iter().collect();
+    boosted.sort_unstable_by_key(|(_, id)| *id);
+    for (path, id) in boosted {
         let extra = boost_unit * file_sum[path] / max_file_sum;
         if let Some(s) = scores.get_mut(&id) {
             *s += extra;
@@ -574,10 +585,17 @@ pub fn rerank_topk(
         });
     }
 
-    // Sort by penalised score descending (stable on ties — preserves insertion
-    // order, matching Python's stable `sorted`).
+    // Sort by penalised score descending, breaking ties on chunk id.
+    //
+    // The tiebreak is what makes the order total rather than merely stable:
+    // `scores` is a `HashMap` whose iteration order is randomized per process,
+    // so a stable sort alone would carry that randomness into the result. Ties
+    // are common, since RRF maps every score onto `1 / (k + rank)` — a small
+    // set of discrete values.
     penalised.sort_by(|a, b| {
-        b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal)
+        b.1.partial_cmp(&a.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(a.0.cmp(&b.0))
     });
 
     // Greedy selection with file-saturation decay. We only need to walk far
@@ -606,7 +624,9 @@ pub fn rerank_topk(
     }
 
     selected.sort_by(|a, b| {
-        b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal)
+        b.0.partial_cmp(&a.0)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(a.1.cmp(&b.1))
     });
     selected.into_iter().take(top_k).map(|(s, id)| (id, s)).collect()
 }
@@ -618,6 +638,38 @@ pub fn rerank_topk(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn file_coherence_boost_is_independent_of_map_order() {
+        // `scores` is a HashMap, whose iteration order is randomized per
+        // process. Summing per-file scores in that order gave a different
+        // result each run, because float addition is not associative — the
+        // same query over the same index returned different rankings.
+        let chunks: Vec<Chunk> = (0..12)
+            .map(|i| ck(i, if i % 2 == 0 { "a.rs" } else { "b.rs" }, "body"))
+            .collect();
+        let reference = {
+            let mut m: HashMap<u32, f32> = (0..12).map(|i| (i, 0.1 + i as f32 * 0.0037)).collect();
+            boost_multi_chunk_files(&mut m, &chunks);
+            m
+        };
+        // Rebuilding the map inserts in a different order every run; the
+        // outcome must not move.
+        for _ in 0..8 {
+            let mut m: HashMap<u32, f32> = HashMap::new();
+            for i in (0..12).rev() {
+                m.insert(i, 0.1 + i as f32 * 0.0037);
+            }
+            boost_multi_chunk_files(&mut m, &chunks);
+            for (id, score) in &reference {
+                assert_eq!(
+                    m[id].to_bits(),
+                    score.to_bits(),
+                    "chunk {id} scored differently depending on map order"
+                );
+            }
+        }
+    }
 
     fn ck(_id: u32, file_path: &str, content: &str) -> Chunk {
         Chunk {

--- a/src/search/ranking.rs
+++ b/src/search/ranking.rs
@@ -108,7 +108,25 @@ fn test_file_re() -> &'static Regex {
 
 fn test_dir_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| Regex::new(r"(?:^|/)(?:tests?|__tests__|spec|testing)(?:/|$)").unwrap())
+    // A suffix counts only after a separator or an uppercase letter following a
+    // lowercase one, which is why the case-boundary arm insists on `Test` and
+    // not `test`: a bare `ends_with` swallows `latest/` and `protests/`.
+    //
+    // Matching whole components only is the opposite failure. It leaves
+    // `ICSharpCode.Decompiler.Tests/` unpenalised along with every suffixed
+    // convention, and on ILSpy that hands a sixth of the top-10 slots to a tree
+    // of decompiler fixtures whose file names match the queries by
+    // construction.
+    RE.get_or_init(|| {
+        Regex::new(concat!(
+            r"(?:^|/)(?:",
+            r"__tests__|testing",
+            "|", r"(?:[^/]*[._-])?(?:[Tt]ests?|[Ss]pecs?)",
+            "|", r"[^/]*[a-z0-9](?:Tests?|Specs?)",
+            r")(?:/|$)",
+        ))
+        .unwrap()
+    })
 }
 
 fn compat_dir_re() -> &'static Regex {
@@ -637,6 +655,39 @@ pub fn rerank_topk(
 
 #[cfg(test)]
 mod tests {
+    /// A test project is recognised by its suffix, not only by an exact name.
+    #[test]
+    fn suffixed_test_directories_are_penalised() {
+        for path in [
+            "ICSharpCode.Decompiler.Tests/TestCases/Pretty/YieldReturn.cs",
+            "ILSpy.Tests/Foo.cs",
+            "src/FooTests/Bar.cs",
+            "src/foo_test/bar.go",
+            "src/api-specs/x.rb",
+            "tests/a.rs",
+            "spec/b.rb",
+        ] {
+            assert!(test_dir_re().is_match(path), "{path} sits under a test directory");
+        }
+    }
+
+    /// A directory whose name merely ends in the same letters keeps full weight.
+    ///
+    /// Red here means the separator-or-case-boundary requirement was relaxed,
+    /// which demotes a production tree out of every result list.
+    #[test]
+    fn directories_that_merely_end_in_test_are_not_penalised() {
+        for path in [
+            "src/latest/a.rs",
+            "src/contest/b.rs",
+            "src/protests/c.rs",
+            "src/greatest/d.rs",
+            "src/manifests/e.rs",
+        ] {
+            assert!(!test_dir_re().is_match(path), "{path} is production code");
+        }
+    }
+
     use super::*;
 
     #[test]

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -1,0 +1,194 @@
+# Retrieval eval
+
+Measures whether `ast-bro search` returns the code a query is about. It exists
+because search quality is not something you can eyeball: several changes that
+looked obviously right measured flat, one that looked wrong measured well, and
+a non-determinism bug lived in the ranking code until this harness surfaced it.
+
+## Running it
+
+```bash
+git clone https://github.com/pgjdbc/pgjdbc ~/src/pgjdbc
+git -C ~/src/pgjdbc checkout 29bbe0268c1e55cc2037fa171d61dcdafca39a7a
+cargo build --release
+tests/eval/run_eval.py \
+  --repo ~/src/pgjdbc \
+  --queries tests/eval/queries/pgjdbc.tsv \
+  --binary target/release/ast-bro
+```
+
+```text
+recall@5 = 7/30 = 23%   MRR@10 = 0.226   (min-iou 0.3)
+answered@8k = 14/30 = 47%   answered@32k = 17/30 = 57%   median cost = 2246 chars   (min-coverage 0.5)
+```
+
+The revision is pinned in the query set and checked before scoring, because two
+scores are comparable only when they come from the same corpus. Measuring a
+change on today's master against a baseline from last month compares the change
+and a month of upstream commits at once, and the summary line does not say so.
+`--any-revision` overrides the check and prints a warning.
+
+`--verbose` prints the rank of each query. That is the output to compare
+between two variants; see *Reading a result* below.
+
+`queries/self.tsv` runs against this repository, so it needs no external
+checkout:
+
+```bash
+tests/eval/run_eval.py --repo . --queries tests/eval/queries/self.tsv \
+  --binary target/release/ast-bro
+```
+
+It is a smoke test, not evidence. Twenty Rust queries over a small repository
+cannot separate two ranking variants, and its absolute score reads low for a
+reason unrelated to quality: a near-miss counts as a miss, and on a small
+codebase the top hit is often the chunk immediately before the answer. Judge a
+change on a pinned set.
+
+## Query sets
+
+One query per line, tab-separated. The answer is a **line span**:
+
+```text
+<natural-language query>	<file>	<span>	<label>	<digest>
+```
+
+`<span>` is `startLine-endLine`, or `startLine:startColumn-endLine:endColumn`
+when the answer is finer than whole lines. Columns are 1-indexed and inclusive.
+`<label>` names the answer for the per-query output and is not scored.
+
+Spans need no language adapter, which is the point: `ast-bro map` covers
+thirteen of the twenty-seven languages ast-grep parses, and misses symbols even
+within those — a declaration in a C++ header, a Ruby method inside
+`class << self`, a C# indexer, anything under `#if DEBUG`. A span can target
+all of them.
+
+`<digest>` is what keeps a span honest. It is the first eight hex characters of
+the SHA-256 of the text the span designates. Line numbers alone rot silently:
+bump the pinned revision and every span points at whatever now occupies those
+lines, while the summary still prints a plausible number. The digest turns that
+into a loud, excluded row, and it also catches a hand-edited line number, which
+the older symbol form never did. Write `-` to leave a span unverified; the
+harness lists every unverified row.
+
+Generate a set rather than counting lines by hand:
+
+```bash
+tests/eval/run_eval.py --repo ~/src/pgjdbc --queries old.tsv --resolve > new.tsv
+```
+
+`--resolve` reads the older symbol form, asks `ast-bro map` where each symbol
+lives, and prints spans with digests. So `map` stays useful for authoring
+without being a runtime dependency, and a target it cannot see is written by
+hand.
+
+The **symbol form is still accepted** and is the right choice for a set with no
+pinned revision, where a span would go stale on every edit — `self.tsv` runs
+against the working tree for exactly that reason and stays symbol-based:
+
+```text
+<natural-language query>	<file>	<symbol>	[line]
+```
+
+A name can be declared more than once in a file, and then the first declaration
+is not necessarily the one the query means: `rollback` in `PgConnection` is both
+`rollback()` and `rollback(Savepoint)`, and a query about savepoints scored
+against the first can never be a hit at any search quality. The optional fourth
+field pins the intended line, and the harness warns for every unpinned
+ambiguous symbol.
+
+Write queries the way someone describes behaviour they cannot yet locate
+("release a savepoint on the server"), not the way they would grep
+("sendReleaseSavepoint"). A query that repeats the symbol name measures the
+lexical half only, and the lexical half was never the weak one.
+
+## Two scorings, and why both
+
+**IoU** — a result counts when it comes from the right file and its line range
+resembles the answer's: intersection over union at or above `--min-iou`,
+default 0.3. Outline chunks are skipped, for the same reason an outline spans
+its whole region; `--count-outlines` measures file-level recall instead.
+
+The threshold is not cosmetic. Bare overlap (`--min-iou 0`) rewards coarse
+chunking, since a result spanning a whole class overlaps every symbol in it by
+construction. Scored against this repository's pre-hierarchy chunker:
+
+```text
+threshold        old chunker        current
+overlap > 0      57%  MRR 0.388     50%  MRR 0.375
+IoU >= 0.1       17%  MRR 0.124     43%  MRR 0.330
+IoU >= 0.3        3%  MRR 0.037     23%  MRR 0.226
+IoU >= 0.5        0%  MRR 0.004     17%  MRR 0.159
+```
+
+The old chunker leads on exactly one row, the one that scores "the answer is
+somewhere in this 4400-line file" as a hit. Quote the threshold with any number
+you report — this table is why.
+
+**Cost** — a result *answers* when it carries at least `--min-coverage` of the
+answer (default 0.5) or lies inside it, and the cost of that answer is the
+total characters of every result up to and including it. That is what the
+reader had to get through. `answered@8k` and `answered@32k` are the share of
+queries answered inside a budget; the budgets are `--budget`.
+
+Cost exists because IoU measures the wrong thing when methods are short. A
+six-line method packed beside its neighbours into one 34-line chunk scores IoU
+0.2 and counts as a miss, though the answer is on screen after 34 lines. On
+fluentd the median achievable IoU over a 30-method sample is 0.21, so most of
+its methods are unscorable at any ranking quality — the number describes Ruby
+method length more than it describes retrieval.
+
+The inside-the-answer half of the rule matters just as much. A 19-line `Part`
+chunk of a 165-line function covers 12% of it and is the precise pointer;
+charging it as a miss would punish exactly the precision the chunk hierarchy
+was built for. Requiring coverage alone scored prometheus 0 of 15 while IoU
+scored 2.
+
+Cost needs no threshold to reject the coarse chunker that `--min-iou 0` would
+reward: a chunk spanning a 4400-line file does contain the answer, and it is
+priced accordingly. The budget it is compared against is a context window,
+which is a real quantity rather than a tuned constant.
+
+The two disagree on purpose. Report both.
+
+## Reading a result
+
+Two numbers, and they behave differently.
+
+**recall@5** — did the answer land in the top five. Coarse but stable: it moves
+in whole queries, and on a 30-query set one query is 3 percentage points.
+
+**MRR@10** — mean reciprocal rank, sensitive to movement that recall cannot
+see. It also swings more between variants that differ only by noise.
+
+**answered@budget** — did the answer arrive inside a reading budget. Moves in
+whole queries like recall, but counts a hit IoU rejects for being the wrong
+zoom rather than the wrong place.
+
+**median cost** — how much had to be read for a typical answered query. The
+number to watch when a change makes chunks coarser: recall can hold steady
+while cost climbs, and that is a regression the other three numbers hide.
+
+On a 30-query set, treat a one-query difference as nothing. What carries weight
+is the shape of the per-query diff: four queries improving with none regressing
+is a real effect, while a net +1 with three up and two down is not. Two changes
+were rejected on exactly that basis after their summary numbers looked good.
+
+The set is small enough that a change can be tuned into it. Before adopting a
+default, check that the win survives on a plateau — if only one parameter value
+helps and its neighbours do not, the parameter is fitted to these thirty
+queries rather than to search.
+
+## Adding queries
+
+Pick a symbol, write the query someone would actually type, and check it
+resolves:
+
+```bash
+tests/eval/run_eval.py --repo ~/src/pgjdbc --queries tests/eval/queries/pgjdbc.tsv --verbose
+```
+
+An unresolved entry prints a `!!` line and is excluded from the denominator, so
+a typo in the file path shows up as a warning rather than as a lower score. So
+does a stale digest, which is what a span looks like once the corpus moves
+underneath it.

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -45,6 +45,32 @@ reason unrelated to quality: a near-miss counts as a miss, and on a small
 codebase the top hit is often the chunk immediately before the answer. Judge a
 change on a pinned set.
 
+Six pinned sets ship, thirty queries each, across five languages:
+
+| Set | Corpus | Language | Clone |
+| --- | --- | --- | --- |
+| `pgjdbc.tsv` | pgjdbc/pgjdbc | Java | `29bbe0268c1e55cc2037fa171d61dcdafca39a7a` |
+| `prometheus.tsv` | prometheus/prometheus | Go | `bf5a9810e60d5f4cdbb4035119fd61668790b1b7` |
+| `etcd.tsv` | etcd-io/etcd | Go | `1b5ba72405d62c16f3011a7bfb56a6a721ee51a3` |
+| `brew.tsv` | Homebrew/brew | Ruby | `2b7c46891f47e60413f6dcc0aa0a46b982f7c9b3` |
+| `ilspy.tsv` | icsharpcode/ILSpy | C# | `d29aeb3eaae54efc841cff307dca01c7218e477c` |
+| `self.tsv` | this repository | Rust | working tree, twenty queries |
+
+Each file's header carries the repository URL, the revision, and the rules its
+targets follow. Read it before quoting a number from that set.
+
+**Do not compare one corpus's summary line against another's.** The absolute
+score depends heavily on how the queries were written: a set whose phrasing
+reuses the domain words that appear in the answer hands the lexical retriever
+free hits, and that alone moves recall@5 by a factor of two or three. Within the
+shipped sets, halves written under different discipline differ by exactly that
+much, in both directions. A summary line is comparable only against itself,
+across two variants of the ranker, and the per-query diff is what carries the
+signal.
+
+Run more than one before adopting a change. Five languages disagree about which
+chunking decisions matter, which is the point of having five.
+
 ## Query sets
 
 One query per line, tab-separated. The answer is a **line span**:

--- a/tests/eval/queries/brew.tsv
+++ b/tests/eval/queries/brew.tsv
@@ -1,0 +1,50 @@
+# Retrieval eval set for brew. See tests/eval/README.md for the format.
+#
+# repository: https://github.com/Homebrew/brew
+# revision: 2b7c46891f47e60413f6dcc0aa0a46b982f7c9b3
+#
+# Targets are methods of 21-150 lines under Library/Homebrew/, never vendor/
+# (307 files of third-party gems), test/, or sorbet/ stubs. A span runs from the
+# `def` line to its matching `end`; a preceding Sorbet `sig` block is excluded.
+#
+# Six rows target methods declared inside `class << self`. The Ruby adapter has
+# no singleton_class branch, so all 687 such methods are invisible to
+# `ast-bro map` and could not be targets before ground truth moved to spans.
+# They are ordinary, heavily-used Homebrew methods; leave them in.
+#
+# Rows 1-15 and 16-30 were written separately and score differently (recall@5 20% and 40%).
+# The gap tracks how strictly each author avoided reusing the domain words that
+# appear in the answer, not retrieval quality: the half that leans on them hands
+# the lexical retriever free hits. Judge a ranking change by the per-query diff,
+# never by the summary line, and never by comparing this corpus's summary
+# against another one's.
+decide whether a prebuilt binary can be used instead of compiling from source	Library/Homebrew/formula_installer.rb	251-286	pour_bottle?	361aef00
+unpack a prebuilt binary archive into the versioned install directory	Library/Homebrew/formula_installer.rb	1582-1649	pour	70f023bd
+build and install one prerequisite package before the requested one	Library/Homebrew/formula_installer.rb	882-949	install_dependency	cf163584
+refuse to continue when the requested package clashes with something already present	Library/Homebrew/formula_installer.rb	394-506	check_install_sanity	05788629
+create the symlinks that make an installed version the active one	Library/Homebrew/keg.rb	491-579	link	9c75cead
+undo the symlinks that make an installed version active	Library/Homebrew/keg.rb	356-393	unlink	d8cdc769
+rewrite the compile-time path recorded inside an installed binary	Library/Homebrew/keg_relocate.rb	250-287	relocate_build_prefix	d087517a
+substitute placeholder strings inside installed files after they move	Library/Homebrew/keg_relocate.rb	218-247	replace_text_in_files	1bae59b8
+clone a third-party repository of package definitions	Library/Homebrew/tap.rb	639-793	install	ef22b904
+repair the git origin url of an already cloned repository	Library/Homebrew/tap.rb	812-846	fix_remote_configuration	d67a8335
+get rid of broken links and empty folders left behind under the install tree	Library/Homebrew/cleanup.rb	846-906	prune_prefix_symlinks_and_directories	9d760a41
+delete cached archives that no longer belong to anything known	Library/Homebrew/cleanup.rb	607-631	cleanup_unreferenced_downloads	45b32f76
+replace installed packages whose version is behind the latest	Library/Homebrew/cmd/upgrade.rb	616-715	upgrade_outdated_formulae!	fd1f9c6c
+turn a downloadable archive requirement into a build-time dependency	Library/Homebrew/dependency_collector.rb	226-254	resource_dep	de3db2cf
+move an application bundle and its extras into place from the staging directory	Library/Homebrew/cask/installer.rb	301-356	install_artifacts	5aeff5f3
+walk the whole tree of prerequisites for a package, letting the caller drop or keep each one as it goes	Library/Homebrew/dependency.rb	188-234	Dependency.expand	2505dd51
+search a tap's recent history to explain that a package was removed and point at the commit that removed it	Library/Homebrew/missing_formula.rb	155-217	MissingFormula.deleted_reason	f15ad5d2
+work out which installed packages were only ever pulled in for something else and nothing needs them now	Library/Homebrew/utils/autoremove.rb	56-88	Autoremove.bottled_formulae_with_no_formula_dependents	f7d6a5c9
+record that a package should no longer be used, with the date, the reason and a suggested replacement	Library/Homebrew/formula.rb	5032-5061	Formula.deprecate!	2f9ed14b
+translate an Apple silicon processor identifier into the chip generation it belongs to	Library/Homebrew/extend/os/mac/hardware/cpu/hardware.rb	60-97	Hardware::CPU.arm_family	545bddda
+collect the installed software that relies on what is about to be replaced and has itself fallen behind	Library/Homebrew/upgrade.rb	226-273	Upgrade.dependants	8bcf623e
+download a source archive over http, reusing the cached copy while it is still current and trying another host when it fails	Library/Homebrew/download_strategy/curl_download_strategy.rb	37-131	CurlDownloadStrategy#fetch	5e143f37
+decide from a url alone whether the source has to be checked out of version control or simply fetched as an archive	Library/Homebrew/download_strategy/download_strategy_detector.rb	24-61	DownloadStrategyDetector.detect_from_url	eda5581d
+rewrite a project's web page address into the repository address whose tags can be listed remotely	Library/Homebrew/livecheck/strategy/git.rb	66-111	Livecheck::Strategy::Git.preprocess_url	e37d7355
+execute a build command confined by the operating system's restriction profile, attached to a pseudo terminal	Library/Homebrew/sandbox.rb	485-579	Sandbox#run	e8096095
+go over every binary in an installed package and sort the shared libraries it loads into system, sibling package and broken	Library/Homebrew/linkage_checker.rb	147-242	LinkageChecker#check_dylibs	4f936b2b
+resolve a typed package name that may be an alias, an old name, or one that has moved to another third-party repository	Library/Homebrew/formulary.rb	1170-1224	Formulary.tap_formula_name_type	84acba88
+produce the launchd job description saying how a background program starts and when it should be restarted	Library/Homebrew/service.rb	514-574	Service#to_plist	03f623c0
+rebuild a cask definition out of the json the api serves instead of evaluating a ruby file	Library/Homebrew/cask/cask_loader.rb	506-578	Cask::CaskLoader::FromAPILoader#load_from_struct	0de1e984
+notice that installed developer sdk folders are named for a version their contents disagree with	Library/Homebrew/extend/os/mac/diagnostic.rb	551-586	Diagnostic::Checks#check_broken_sdks	3523a10c

--- a/tests/eval/queries/etcd.tsv
+++ b/tests/eval/queries/etcd.tsv
@@ -1,0 +1,49 @@
+# Retrieval eval set for etcd. See tests/eval/README.md for the format.
+#
+# repository: https://github.com/etcd-io/etcd
+# revision: 1b5ba72405d62c16f3011a7bfb56a6a721ee51a3
+#
+# Targets are callables of 21-150 lines, each name-unique within its file.
+# etcd puts an interface beside its implementation often enough that 12% of
+# callable names repeat, and a target with a same-named sibling nearby tends to
+# be unanswerable in practice.
+#
+# No target is generated protobuf, a _test.go file, or the framework code under
+# tests/, which carries the ranker's 0.3x test-path penalty.
+#
+# Rows 1-15 and 16-30 were written separately and score differently (recall@5 20% and 7%).
+# The gap tracks how strictly each author avoided reusing the domain words that
+# appear in the answer, not retrieval quality: the half that leans on them hands
+# the lexical retriever free hits. Judge a ranking change by the per-query diff,
+# never by the summary line, and never by comparing this corpus's summary
+# against another one's.
+delete every key a lease was holding once that lease is given up	server/lease/lessor.go	326-365	Revoke	88926029
+gather the leases whose deadline already passed so they can be dropped	server/lease/lessor.go	728-751	findExpiredLeases	e81025a1
+catch up streams that fell behind by replaying stored events out of the backend	server/storage/mvcc/watchable_store.go	347-416	syncWatchers	f731d38a
+tell a caught-up stream the current revision when nothing has changed for it	server/storage/mvcc/watchable_store.go	517-543	progressIfSync	c16bf798
+drop superseded versions of a key below a revision, a batch at a time	server/storage/mvcc/kvstore_compaction.go	28-100	scheduleCompaction	747fce50
+rewrite the database file into a compacted copy to give free pages back	server/storage/backend/backend.go	476-614	defrag	c806bda9
+check whether the permissions a user was granted cover the whole span being touched	server/auth/range_perm_cache.go	110-129	isRangeOpPermitted	b46c3216
+refuse a membership change that would leave the cluster without a quorum	server/etcdserver/api/membership/cluster.go	306-389	ValidateConfigurationChange	e0a5a0c2
+close the current log segment, preallocate the next file and start writing there	server/storage/wal/wal.go	785-867	cut	b1b72b7c
+ship a database snapshot over http to a follower that lagged past the log	server/etcdserver/api/rafthttp/snapshot_sender.go	67-143	send	76c033fa
+ask every peer for the hash of its key space and alarm when they disagree	server/etcdserver/corrupt.go	179-264	PeriodicCheck	561e9334
+wait for the leader to confirm the index before serving a strongly consistent read	server/etcdserver/read/read.go	96-146	LinearizableReadLoop	805ec72b
+take a place in line for leadership and block until every earlier contender is gone	client/v3/concurrency/election.go	69-107	Campaign	779bb4c1
+return every stored range that overlaps the one being asked about	pkg/adt/interval_tree.go	767-774	Stab	110890ad
+reopen the broken grpc stream and resume from the last revision seen	client/v3/watch.go	1042-1062	openWatchClient	5fb4e7d6
+back up the last log file and cut it back to the last complete record after a crash	server/storage/wal/repair.go	32-106	Repair	3ae4aeee
+walk every key in the database at boot to rebuild the in-memory index and reattach leases	server/storage/mvcc/kvstore.go	317-426	store.restore	996631e5
+record that a key is gone by writing a marker at the next revision and detaching its lease	server/storage/mvcc/kvstore_txn.go	308-346	storeTxnWrite.delete	c119fd73
+serve a read by combining pending in-memory writes with what the on-disk bucket holds	server/storage/backend/read_tx.go	78-122	baseReadTx.UnsafeRange	c6119081
+sign a bearer token carrying the user name and auth revision after a successful login	server/auth/jwt.go	93-125	tokenJWT.assign	7ccffbac
+give a role read or write access over a span of keys and refresh the cached permissions	server/auth/store.go	808-857	authStore.RoleGrantPermission	56d828b7
+decide whether a non-voting replica has caught up enough to become a full member	server/etcdserver/server.go	1549-1594	EtcdServer.isLearnerReady	7d308ae6
+drop outgoing traffic to members that were removed and warn when heartbeats go out late	server/etcdserver/raft.go	357-402	raftNode.processMessages	f54bb926
+set up the pipeline, streams and message pumps for talking to another cluster member	server/etcdserver/api/rafthttp/peer.go	131-234	startPeer	c26c018f
+turn a snapshot file into a fresh data directory a brand new member can boot from	etcdutl/snapshot/v3_snapshot.go	257-348	v3Manager.Restore	7aa12a39
+merge watchers reading from the same point into one shared connection so fewer are opened upstream	server/proxy/grpcproxy/watch_broadcasts.go	53-83	watchBroadcasts.coalesce	58c7ab4b
+refuse a transaction whose puts and deletes touch overlapping key ranges, nested branches included	server/etcdserver/api/v3rpc/key.go	236-315	checkIntervals	d7176758
+try a failed call again and fetch a new auth token when the old one was rejected	client/v3/retry_interceptor.go	41-102	Client.unaryClientInterceptor	f2d78f7e
+periodically tell the server the leases this client holds are still in use	client/v3/lease.go	593-626	lessor.sendKeepAliveLoop	7394272a
+pick the storage size limit, falling back to a default and warning when it is too large	server/storage/quota.go	75-124	NewBackendQuota	142cd4c1

--- a/tests/eval/queries/ilspy.tsv
+++ b/tests/eval/queries/ilspy.tsv
@@ -1,0 +1,55 @@
+# Retrieval eval set for ILSpy. See tests/eval/README.md for the format.
+#
+# repository: https://github.com/icsharpcode/ILSpy
+# revision: d29aeb3eaae54efc841cff307dca01c7218e477c
+#
+# Targets are declarations of 21-150 lines in main source, never under a
+# `*.Tests/` path. `ICSharpCode.Decompiler.Tests/TestCases/` is a tree of
+# synthetic decompiler fixtures whose file names match these queries by
+# construction; before suffixed test directories were recognised it took 10% of
+# the top-10 slots and test projects took 17%, which measured how well the
+# ranker avoids a decoy rather than how well it retrieves.
+#
+# Two rows target code no adapter can see: one file is wholly inside
+# `#if DEBUG`, the other inside `#if !NET8_0_OR_GREATER`, and `ast-bro map`
+# reports zero declarations for both. Their spans are written by hand, which
+# the symbol form could not express.
+#
+# 26% of callable names here repeat within their file, and `Instructions.cs`
+# alone contributes a third of that with roughly 300 `AcceptVisitor` methods.
+# Prefer a name unique in its file when extending the set.
+#
+# Rows 1-15 and 16-30 were written separately and score the same (recall@5 27%
+# and 27%), which is the exception among the shipped sets rather than the rule.
+# Judge a ranking change by the per-query diff, never by the summary line, and
+# never by comparing this corpus's summary against another one's.
+decide whether a stream holds plain text, xml or raw binary data	ICSharpCode.ILSpyX/Util/GuessFileType.cs	31-85	DetectFileType	e873d66a
+find and open the debug database that belongs to a loaded module	ICSharpCode.ILSpyX/PdbProvider/DebugInfoUtils.cs	35-62	LoadSymbols	1ef18f33
+escape the special characters of a string constant so the printed source still compiles	ICSharpCode.Decompiler/CSharp/OutputVisitor/TextWriterTokenWriter.cs	499-511	ConvertString	a426f73b
+collapse dot and dot-dot segments of a path into one canonical form	ICSharpCode.Decompiler/Util/FileUtility.cs	34-167	NormalizePath	45fac4ac
+rewrite an absolute path so it is expressed from a base directory instead	ICSharpCode.Decompiler/Util/FileUtility.cs	220-258	GetRelativePath	24dac57b
+group items into disjoint sets and look up which one an item belongs to	ICSharpCode.Decompiler/Util/UnionFind.cs	60-63	Find	fa6ec4d7
+visit every reachable node of a graph exactly once by following its edges	ICSharpCode.Decompiler/Util/GraphTraversal.cs	44-115	DepthFirstSearch	b1429911
+turn a compiler-generated iterator class back into yield statements	ICSharpCode.Decompiler/IL/ControlFlow/YieldReturnDecompiler.cs	121-259	Run	179a726c
+work out where control leaves the body of a loop	ICSharpCode.Decompiler/IL/ControlFlow/LoopDetection.cs	314-399	FindExitPoint	6b2f46d4
+recognise the shape a compiler emits when a switch is done over string values	ICSharpCode.Decompiler/IL/Transforms/SwitchOnStringTransform.cs	39-129	Run	dc43b7a8
+read one opcode out of the byte stream and build the matching instruction	ICSharpCode.Decompiler/IL/ILReader.cs	795-1277	DecodeInstruction	d221de9d
+convert a boxed value from one numeric type to another and fail when it overflows	ICSharpCode.Decompiler/Util/CSharpPrimitiveCast.cs	47-407	CSharpPrimitiveCastChecked	0ced9af0
+emit a standalone debug database alongside the decompiled output	ICSharpCode.Decompiler/DebugInfo/PortablePdbWriter.cs	91-328	WritePdb	75c7c122
+scan method bodies for a constant value the user typed into the search box	ICSharpCode.ILSpyX/Search/LiteralSearchStrategy.cs	144-272	MethodIsLiteralMatch	0e57ea77
+read the resource directory tree embedded in a PE image	ICSharpCode.Decompiler/Util/Win32Resources.cs	44-75	ReadWin32Resources	90706f76
+pick one concrete type for a generic placeholder from everything it must convert to and from	ICSharpCode.Decompiler/CSharp/Resolver/TypeInference.cs	1059-1186	FindTypesInBounds	00d422d2
+when two candidate methods both accept the same call, apply the tie-breaking rules that pick a winner	ICSharpCode.Decompiler/CSharp/Resolver/OverloadResolution.cs	730-836	BetterFunctionMember	6c1ae0b8
+flatten the nested chain the compiler builds for a value group with more than seven members	ICSharpCode.Decompiler/TypeSystem/TupleType.cs	167-210	GetTupleElementTypes	14bf1884
+recognise the instruction sequence emitted right before a generated method suspends itself, and cut it away	ICSharpCode.Decompiler/IL/ControlFlow/AsyncAwaitDecompiler.cs	1615-1716	AnalyzeAwaitBlock	5e982dd1
+for every basic block, work out the nearest earlier block that all paths from the entry must pass through	ICSharpCode.Decompiler/FlowAnalysis/Dominance.cs	44-108	ComputeDominance	c4b6807b
+decide whether a jump table would read better as a case statement or as a chain of if tests	ICSharpCode.Decompiler/IL/ControlFlow/SwitchDetection.cs	442-501	UseCSharpSwitch	a5fa3272
+find the narrowest block that encloses every use of a temporary so its declaration can go there	ICSharpCode.Decompiler/CSharp/Transforms/DeclareVariables.cs	294-394	FindInsertionPoints	11ce970d
+work out how tightly each kind of expression binds so redundant brackets can be left out	ICSharpCode.Decompiler/CSharp/OutputVisitor/InsertParenthesesVisitor.cs	69-165	GetPrecedence	53c2f607
+express a floating point value as the closest ratio of two whole numbers under a size limit	ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs	1725-1779	FractionApprox	b161ae8f
+read one attribute parameter value out of the binary blob according to the tag that describes it	ICSharpCode.Decompiler/Metadata/CustomAttributeDecoder.cs	116-200	DecodeArgument	647e1330
+insert a byte-offset range into a tree of ranges, rejecting it when it only partly overlaps a sibling	ICSharpCode.Decompiler/Disassembler/ILStructure.cs	169-208	AddNestedStructure	df5a2ab9
+rebuild the compact drawing-command text for a shape outline from its compiled binary form	ICSharpCode.BamlDecompiler/Xaml/XamlPathDeserializer.cs	89-196	Deserialize	8872c186
+try each registered pattern from the newest backwards until one of them rewrites the word	ICSharpCode.Decompiler/Humanizer/Vocabulary.cs	159-192	ApplyRules	8ad02fa9
+find the position of the lowest set bit of a machine word without a hardware instruction	ICSharpCode.Decompiler/Util/BitOperations.cs	20-59	TrailingZeroCount	433c6ec4
+dump a method's block layout to a dot file, render it with the external tool and open the picture	ILSpy/Commands/ShowCFGContextMenuEntry.cs	48-95	ExportGraph	7a01c9d9

--- a/tests/eval/queries/pgjdbc.tsv
+++ b/tests/eval/queries/pgjdbc.tsv
@@ -1,0 +1,49 @@
+# Retrieval eval set for the pgjdbc JDBC driver.
+#
+# One query per line: <natural-language query> TAB <file> TAB <symbol>
+# [TAB <line>]. The optional line pins which declaration is meant when the name
+# is overloaded — without it the harness takes the first and says so loudly, and
+# a query whose answer is the *second* overload can never be a hit.
+# The symbol is the answer; run_eval.py resolves it to a line range at
+# run time, so renames show up as unresolved rather than as silent misses.
+#
+# repository: https://github.com/pgjdbc/pgjdbc
+# revision: 29bbe0268c1e55cc2037fa171d61dcdafca39a7a
+#
+# The revision is pinned because a score is only comparable against another
+# score from the same corpus. run_eval.py checks it and refuses to run on a
+# different one — measuring a change on today's master against a baseline from
+# last month's compares two things at once.
+#
+#   git clone https://github.com/pgjdbc/pgjdbc && cd pgjdbc
+#   git checkout 29bbe0268c1e55cc2037fa171d61dcdafca39a7a
+where the driver sends the Terminate message before closing the connection	pgjdbc/src/main/java/org/postgresql/core/QueryExecutorCloseAction.java	56-75	close	6718f80d
+release a savepoint on the server	pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java	549-561	releaseSavePoint	29ac1525
+parse the RowDescription message into field metadata	pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java	2936-2961	receiveFields	5bb00e7b
+decide whether a query should use a named server-side prepared statement	pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java	435-442	isOneShotQuery	12f94e35
+read a COPY data block sent by the server	pgjdbc/src/main/java/org/postgresql/core/v3/CopyOutImpl.java	43-46	handleCopydata	9e59411d
+deliver an asynchronous notification to the client	pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java	248-255	getNotifications	54e8e9e4
+GSS Kerberos authentication handshake	pgjdbc/src/main/java/org/postgresql/gss/MakeGSS.java	121-188	authenticate	2fa85394
+cancel a running query by opening a second connection	pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java	188-230	sendQueryCancel	253cc06f
+apply the socket read timeout while waiting for a backend response	pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java	992-1002	setSocketTimeout	31ef5833
+build the SCRAM client first message during SASL authentication	pgjdbc/src/main/java/org/postgresql/core/v3/ScramAuthenticator.java	158-173	handleAuthenticationSASL	651259dc
+turn a server error response into a SQLException	pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java	2977-3000	receiveErrorResponse	7459dca1
+rewrite JDBC escape syntax into native SQL	pgjdbc/src/main/java/org/postgresql/core/Parser.java	47-331	parseJdbcSql	975d78d1
+convert a numeric value from its binary wire representation	pgjdbc/src/main/java/org/postgresql/util/ByteConverter.java	112-114	numeric	0e2a5981
+list the columns of a table for database metadata	pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java	1709-1963	getColumns	84c82680
+negotiate an SSL connection with the server	pgjdbc/src/main/java/org/postgresql/ssl/MakeSSL.java	33-68	convert	ab6a2c98
+encode a password for SCRAM-SHA-256 verification	pgjdbc/src/main/java/org/postgresql/util/PasswordUtil.java	51-76	encodeScramSha256	596dd9df
+send a bind and execute message for one query	pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java	1836-1972	sendBind	ed7c409e
+refresh the cached transaction isolation level	pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java	1077-1108	getTransactionIsolation	a67813da
+close a portal or statement on the backend	pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java	3070-3074	sendCloseMessage	a34aed7a
+grow the read buffer when more bytes are needed	pgjdbc/src/main/java/org/postgresql/core/VisibleBufferedInputStream.java	143-145	ensureBytes	8a633160
+set the value of a prepared statement parameter to null	pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java	222-303	setNull	b3b26f87
+add the current parameter set to the batch	pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java	1175-1192	addBatch	75f4ba04
+escape a string literal so it is safe to embed in SQL	pgjdbc/src/main/java/org/postgresql/core/Utils.java	47-54	escapeLiteral	c55a27a0
+compute the MD5 hash used for password authentication	pgjdbc/src/main/java/org/postgresql/util/MD5Digest.java	31-55	encode	2db0da38
+look up the primary keys of a table	pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java	2427-2490	getPrimaryKeys	1ff9bbfa
+move the result set cursor to an absolute row number	pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java	332-372	absolute	487af8a8
+write a large object in chunks to the server	pgjdbc/src/main/java/org/postgresql/largeobject/LargeObject.java	273-279	write	6f83ce53
+decide which client encoding to request at startup	pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java	517-537	createPostgresTimeZone	7bd71b56
+roll back the transaction to a named savepoint	pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java	1897-1903	rollback	995f7a0a
+report whether the connection is still usable	pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java	1578-1621	isValid	db99fc02

--- a/tests/eval/queries/prometheus.tsv
+++ b/tests/eval/queries/prometheus.tsv
@@ -1,0 +1,50 @@
+# Retrieval eval set for prometheus. See tests/eval/README.md for the format.
+#
+# repository: https://github.com/prometheus/prometheus
+# revision: bf5a9810e60d5f4cdbb4035119fd61668790b1b7
+#
+# Targets are callables of 21-150 lines. 77% of Go callables here are 20 lines
+# or shorter and cannot reach IoU 0.3 at any search quality, so a set that does
+# not filter by length scores near zero for reasons unrelated to retrieval.
+#
+# Expect roughly 13% of result slots to go to Markdown, on 1.9% of chunks:
+# docs/ describes these behaviours in the words the queries use. That is real
+# and should not be suppressed, but a change that only shifts the code/docs
+# balance moves the score without improving code retrieval.
+#
+# Rows 1-15 and 16-30 were written separately and score differently (recall@5 13% and 47%).
+# The gap tracks how strictly each author avoided reusing the domain words that
+# appear in the answer, not retrieval quality: the half that leans on them hands
+# the lexical retriever free hits. Judge a ranking change by the per-query diff,
+# never by the summary line, and never by comparing this corpus's summary
+# against another one's.
+drop a sample whose timestamp is older than what the series already holds	tsdb/head_append.go	436-506	Append	e3db722f
+mark the series of a target as gone once it stops being scraped	scrape/scrape.go	1473-1539	endOfRunStaleness	5be77b1c
+work out how many parallel senders are needed to keep up with the incoming rate	storage/remote/queue_manager.go	1156-1229	calculateDesiredShards	736405bc
+retry a rejected batch, waiting longer before each attempt	storage/remote/queue_manager.go	1750-1852	sendSamplesWithBackoff	5a49f7d7
+choose which persisted blocks should be merged together next	tsdb/compact.go	285-344	plan	3bb84505
+delete write-ahead log segments that fall below the retained time range	tsdb/head.go	1521-1592	truncateWAL	7455224c
+snapshot the in-memory state so older log segments can be discarded	tsdb/wlog/checkpoint.go	112-438	Checkpoint	96bd1644
+recover from a torn record by cutting the log back to the last good point	tsdb/wlog/wlog.go	400-505	Repair	02bc8b10
+turn a set of label matchers into the series that satisfy all of them	tsdb/querier.go	269-415	PostingsForMatchers	7c64fe17
+check that a metric rewriting rule carries the fields its action requires	model/relabel/relabel.go	120-192	Validate	b773d45f
+evaluate an alert expression and decide which alerts should fire	rules/alerting.go	387-551	Eval	124ac8dc
+per-second increase of a native histogram over a time range	promql/functions.go	640-757	histogramRate	461b7a00
+stream compressed chunks back to the caller instead of decoded samples	storage/remote/read_handler.go	188-257	remoteReadStreamedXORChunks	6d822aaa
+accept a pushed batch of samples over HTTP and store them	storage/remote/write_handler.go	149-218	write	36054698
+record a request to delete matching samples from a persisted block	tsdb/block.go	607-672	Delete	029a4f2c
+try each domain suffix from resolv.conf until a name resolves	discovery/dns/dns.go	292-323	lookupWithSearchPath	acfffbc1
+build one scrape target per container port on a pod, falling back to the pod IP when no ports are declared	discovery/kubernetes/pod.go	366-440	buildPod	dbf563a7
+read a native histogram out of a protobuf-encoded scrape into the in-memory form	model/textparse/protobufparse.go	188-282	Histogram	aaceaa70
+read a numeric literal while tokenizing, allowing hex, exponents and underscore separators	promql/parser/lex.go	1024-1107	scanNumber	9582922e
+evaluate a nested expression on its own step grid inside an outer range query	promql/engine.go	1932-1989	runSubquery	bfc8eb2f
+interpolate a percentile inside the classic bucket that contains the rank	promql/quantile.go	105-170	BucketQuantile	11676648
+store a trace exemplar for a series in a fixed-size ring, overwriting the oldest entry	tsdb/exemplar.go	384-489	AddExemplar	7bf5a346
+write a float sample into a chunk as a delta-of-delta timestamp and a bit-packed value	tsdb/chunkenc/xor.go	161-218	Append	1fdfe14b
+follow the write-ahead log as it is written, moving on once a newer segment appears	tsdb/wlog/watcher.go	392-478	watch	e364a0fe
+pick the oldest blocks to drop once stored data exceeds the configured disk limit	tsdb/db.go	2273-2313	BeyondSizeRetention	1f0266a0
+turn samples that arrived late into encoded chunks, starting a new one when the sample type changes	tsdb/ooo_head.go	78-162	ToEncodedChunks	060c365f
+bring pending alerts back to their previous age after a restart	rules/group.go	739-867	RestoreForState	23a45c58
+encode a batch of firing alerts as JSON and post them to the alertmanager	notifier/sendloop.go	209-249	sendAll	7c63d9d1
+validate the start, end and step parameters of an HTTP request before evaluating the expression over that interval	web/api/v1/api.go	660-754	queryRange	644f0ec0
+render an annotation template into text without letting a broken template crash the process	template/template.go	326-356	Expand	70f47b50

--- a/tests/eval/queries/self.tsv
+++ b/tests/eval/queries/self.tsv
@@ -1,0 +1,29 @@
+# Retrieval eval set for ast-bro itself, so the harness runs against a checkout
+# that is always present. Smaller and Rust-only, so treat it as a smoke test
+# rather than as evidence — pgjdbc.tsv is the set to judge a change on.
+#
+# No pinned revision: this set runs against the working tree on purpose, since
+# the corpus is the code you are changing. That also means its scores are not
+# comparable across commits — use pgjdbc.tsv for that.
+#
+# One query per line: <natural-language query> TAB <file> TAB <symbol>.
+widen a buffer of half precision values into single precision	src/search/embed.rs	decode_f16_le
+turn a string into a normalized embedding vector	src/search/embed.rs	encode_one
+find the nearest embedding rows by cosine similarity	src/search/embed.rs	cosine_topk
+decide where to cut a source file into indexable pieces	src/search/chunker.rs	collect_split_points
+build the signature-only documents for a file	src/search/chunker.rs	build_outline_chunks
+group split regions into chunks under the size target	src/search/chunker.rs	pack
+label a chunk with the declaration that encloses it	src/search/chunker.rs	assign_breadcrumbs
+rank files by how well their outline matches the query	src/search/index.rs	file_prior
+promote chunks whose file scored well earlier	src/search/index.rs	apply_file_prior
+which text is handed to the embedding model	src/search/index.rs	embed_text
+add the file name and breadcrumb to the lexical document	src/search/index.rs	enrich_for_bm25
+apply path penalties and pick the final results	src/search/ranking.rs	rerank_topk
+lift a file whose chunks all score well	src/search/ranking.rs	boost_multi_chunk_files
+penalise test files and generated code by path	src/search/ranking.rs	file_path_penalty
+blend two ranked lists using reciprocal rank fusion	src/search/fusion.rs	rrf_scores
+choose how much weight the dense retriever gets	src/search/fusion.rs	resolve_alpha
+break a camelCase identifier into separate words	src/search/tokens.rs	split_identifier
+peel language and path filters out of a raw query	src/search/query.rs	parse_query
+detect which files changed since the index was built	src/search/cache.rs	compute_delta
+score documents with the BM25 ranking formula	src/search/bm25.rs	get_scores

--- a/tests/eval/run_eval.py
+++ b/tests/eval/run_eval.py
@@ -1,0 +1,519 @@
+#!/usr/bin/env python3
+"""Score `ast-bro search` against a query set with known answers.
+
+Ground truth is a line span plus a digest of the text it designates. Spans need
+no language adapter, so a set can target any language ast-grep parses and any
+symbol `ast-bro map` cannot see; the digest is what makes a span self-checking,
+turning a corpus that moved under the set into a loud excluded row rather than
+a plausible number. `--resolve` writes spans from the older symbol form, which
+is still accepted and is the right choice for a set with no pinned revision.
+
+Two scorings run together and they disagree on purpose.
+
+IoU asks whether a result resembles the answer, thresholded by `--min-iou`.
+The threshold is the part that matters: bare overlap rewards coarse chunking,
+since a result spanning a whole 4000-line class overlaps every symbol in that
+file by construction. Under bare overlap this repository's own pre-hierarchy
+chunker scores 57% on pgjdbc against 50% for the current one; at IoU 0.3 it
+scores 3% against 23%.
+
+Cost asks whether a result carries the answer, or sits inside it, and charges
+for everything read on the way. It catches what IoU calls a miss for being the
+wrong zoom rather than the wrong place — a six-line method inside a 34-line
+chunk — and it prices the coarse chunker without needing a threshold at all.
+
+Usage:
+    tests/eval/run_eval.py --repo ~/src/pgjdbc --queries tests/eval/queries/pgjdbc.tsv
+
+Add `--verbose` for the per-query ranks and costs, which is what tells you
+*which* query a change helped or hurt. Compare two variants by their per-query
+rows rather than the summary lines: a one-query difference on a 30-query set is
+noise, and four queries improving with none regressing is worth more than a
+bigger number with churn underneath it.
+"""
+
+import argparse
+import hashlib
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_binary(binary, repo, args, expect_json=True):
+    """Run the ast-bro binary in `repo`, returning parsed stdout."""
+    proc = subprocess.run(
+        [binary, *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+    # A non-zero exit means the call itself was wrong (bad path, unknown
+    # symbol). Never treat that as "no results" — the two are different, and
+    # conflating them turns a broken harness into a plausible-looking score.
+    if proc.returncode != 0:
+        sys.exit(f"{binary} {' '.join(args)} failed:\n{proc.stderr.strip()}")
+    if not expect_json:
+        return proc.stdout
+    return json.loads(proc.stdout)
+
+
+def walk_declarations(declarations):
+    for decl in declarations:
+        yield decl
+        yield from walk_declarations(decl.get("children", []))
+
+
+def resolve_gold(binary, repo, path, symbol, near=None):
+    """Line range of `symbol` in `path`, or None when it no longer exists.
+
+    Returns `(start, end, ambiguous)`. A name can be declared several times in
+    one file — overloads, or an interface method beside its implementation — and
+    picking the first silently scores the query against whichever the parser
+    happened to emit first. `near` disambiguates by choosing the declaration
+    containing that line, or the nearest one.
+    """
+    doc = run_binary(binary, repo, ["map", path, "--json", "--compact"])
+    matches = [
+        decl
+        for f in doc["files"]
+        for decl in walk_declarations(f["declarations"])
+        if decl.get("name") == symbol
+    ]
+    if not matches:
+        return None
+    if near is not None:
+        matches.sort(
+            key=lambda d: (
+                not (d["start_line"] <= near <= d["end_line"]),
+                abs(d["start_line"] - near),
+            )
+        )
+        return matches[0]["start_line"], matches[0]["end_line"], False
+    return matches[0]["start_line"], matches[0]["end_line"], len(matches) > 1
+
+
+SPAN_RE = re.compile(r"^(\d+)(?::(\d+))?-(\d+)(?::(\d+))?$")
+
+
+def parse_span(field):
+    """`L1-L2`, or `L1:C1-L2:C2`. None when the field is a symbol name."""
+    m = SPAN_RE.match(field)
+    if not m:
+        return None
+    start_line, start_col, end_line, end_col = m.groups()
+    return {
+        "start_line": int(start_line),
+        "end_line": int(end_line),
+        "start_col": int(start_col) if start_col else None,
+        "end_col": int(end_col) if end_col else None,
+    }
+
+
+def span_text(repo, path, span):
+    """Exactly the text a span designates, or None if it runs past the file.
+
+    Columns are 1-indexed and inclusive. The end column is applied before the
+    start column so a single-line span slices correctly.
+    """
+    try:
+        lines = (repo / path).read_text(errors="replace").splitlines()
+    except OSError:
+        return None
+    if span["start_line"] < 1 or span["end_line"] > len(lines):
+        return None
+    body = lines[span["start_line"] - 1 : span["end_line"]]
+    if span["end_col"] is not None:
+        body[-1] = body[-1][: span["end_col"]]
+    if span["start_col"] is not None:
+        body[0] = body[0][span["start_col"] - 1 :]
+    return "\n".join(body)
+
+
+def digest_of(text):
+    """Short content hash of an answer, which is what makes a span self-checking.
+
+    A symbol-based set was checked by `ast-bro map`: rename the symbol and the
+    query dropped out loudly. A line span has no such property on its own — bump
+    the pinned revision and every span silently points at whatever now occupies
+    those lines, and the eval still prints a plausible number. Hashing the text
+    restores the guarantee without needing a language adapter, and it also
+    catches a hand-edited line number, which `map` never did.
+    """
+    return hashlib.sha256(text.encode()).hexdigest()[:8]
+
+
+def load_queries(path):
+    """Queries plus the header directives, if the set pins a corpus."""
+    rows, meta = [], {}
+    for lineno, raw in enumerate(path.read_text().splitlines(), 1):
+        if not raw.strip():
+            continue
+        if raw.startswith("#"):
+            directive = raw.lstrip("#").strip()
+            for key in ("repository", "revision"):
+                prefix = f"{key}:"
+                if directive.startswith(prefix):
+                    meta[key] = directive[len(prefix):].strip()
+            continue
+        fields = raw.split("\t")
+        if len(fields) < 3:
+            sys.exit(f"{path}:{lineno}: expected at least 3 tab-separated fields")
+        query, file, third = fields[0], fields[1], fields[2]
+        span = parse_span(third)
+        if span is not None:
+            # query, path, span, label, digest — the span form needs no adapter,
+            # so it can target any language and any symbol `map` cannot see.
+            rows.append({
+                "query": query,
+                "path": file,
+                "kind": "span",
+                "span": span,
+                "label": fields[3] if len(fields) > 3 else f"{file}:{third}",
+                "digest": fields[4] if len(fields) > 4 else "-",
+            })
+            continue
+        near = None
+        if len(fields) > 3:
+            try:
+                near = int(fields[3])
+            except ValueError:
+                sys.exit(
+                    f"{path}:{lineno}: 4th field must be a line number when the 3rd"
+                    f" is a symbol, got {fields[3]!r}"
+                )
+        rows.append({
+            "query": query,
+            "path": file,
+            "kind": "symbol",
+            "symbol": third,
+            "label": third,
+            "near": near,
+        })
+    return rows, meta
+
+
+def check_revision(repo, meta, allow_drift):
+    """Refuse to score a pinned set against a different checkout.
+
+    Two scores are only comparable when they come from the same corpus. A
+    baseline taken on last month's master and a candidate taken on today's
+    differ by both the change and a month of upstream commits, and nothing in
+    the summary line says so.
+    """
+    wanted = meta.get("revision")
+    if not wanted:
+        return
+    proc = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        sys.exit(f"{repo} is not a git checkout, but the query set pins {wanted[:12]}")
+    actual = proc.stdout.strip()
+    if actual == wanted:
+        return
+    message = (
+        f"{repo} is at {actual[:12]}, but the query set pins {wanted[:12]}.\n"
+        f"  git -C {repo} checkout {wanted}"
+    )
+    if allow_drift:
+        print(f"!! {message}\n!! --any-revision given; scores are not comparable")
+    else:
+        sys.exit(message)
+
+
+def overlap_iou(hit, gold_start, gold_end):
+    """Intersection over union of a result's line range and the answer's."""
+    lo = max(hit["start_line"], gold_start)
+    hi = min(hit["end_line"], gold_end)
+    if hi < lo:
+        return 0.0
+    intersection = hi - lo + 1
+    union = (
+        max(hit["end_line"], gold_end) - min(hit["start_line"], gold_start) + 1
+    )
+    return intersection / union if union else 0.0
+
+
+def coverage(hit, gold_start, gold_end):
+    """Share of the answer's lines a result actually carries."""
+    lo = max(hit["start_line"], gold_start)
+    hi = min(hit["end_line"], gold_end)
+    if hi < lo:
+        return 0.0
+    return (hi - lo + 1) / (gold_end - gold_start + 1)
+
+
+def answer_cost(results, gold_path, gold_start, gold_end, count_outlines, min_coverage):
+    """Rank of the first result carrying the answer, and what reading it cost.
+
+    IoU asks whether a result *resembles* the answer. This asks whether it
+    *contains* the answer, and how much text the reader got through first.
+    The two disagree in both directions, which is the point.
+
+    A six-line method packed beside its neighbours into one 34-line chunk
+    scores IoU 0.2 and counts as a miss, even though the answer is on screen
+    after 34 lines of reading. Ruby and Go are full of such methods, and their
+    IoU scores measure method length more than they measure retrieval.
+
+    A chunk spanning a whole 4400-line file also contains the answer. IoU
+    rejects it via a threshold; this rejects it by charging for it, which
+    needs no arbitrary constant — the budget it is compared against is a
+    context window, which is a real quantity.
+
+    A result answers when it carries most of the symbol, *or* when it lies
+    inside the symbol. The second case is the `Part` chunk of a large method:
+    a 19-line slice of a 165-line function covers 12% of it, yet it is the
+    precise pointer, and charging it as a miss would punish exactly the
+    precision the hierarchy was built for. Requiring coverage alone scored
+    prometheus at 0 of 15 while IoU scored 2 — the targets there are long
+    functions retrieved through their parts.
+
+    What the pair rejects is a neighbouring chunk that grazes the answer by a
+    line or two: it neither carries the symbol nor sits within it.
+
+    Cost counts every result up to and including the one that answers, outline
+    chunks included: the reader pays for whatever the search returned, whether
+    or not it was allowed to count as the answer.
+    """
+    spent = 0
+    for position, hit in enumerate(results, 1):
+        spent += len(hit.get("content", ""))
+        if not count_outlines and hit.get("kind") == "outline":
+            continue
+        if hit["path"] != gold_path:
+            continue
+        inside = hit["start_line"] >= gold_start and hit["end_line"] <= gold_end
+        if inside or coverage(hit, gold_start, gold_end) >= min_coverage:
+            return position, spent
+    return None, spent
+
+
+def rank_of_hit(results, gold_path, gold_start, gold_end, count_outlines, min_iou):
+    """Rank of the first result that answers the query, or None.
+
+    `min_iou` is what keeps the score honest. Bare overlap rewards coarse
+    chunking: a result spanning a whole 4000-line class overlaps every symbol
+    in the file by construction, so a chunker that never splits scores higher
+    than one that points at the method. Requiring the ranges to actually
+    resemble each other prices that in — "the answer is somewhere in this file"
+    is not an answer.
+    """
+    for position, hit in enumerate(results, 1):
+        if not count_outlines and hit.get("kind") == "outline":
+            # An outline spans its whole region for the same reason.
+            continue
+        if hit["path"] != gold_path:
+            continue
+        iou = overlap_iou(hit, gold_start, gold_end)
+        # `iou > 0` is required separately: at `min_iou = 0` the threshold
+        # alone would accept a result that does not touch the answer at all,
+        # which is file-level recall rather than the loosest line-level test.
+        if iou > 0 and iou >= min_iou:
+            return position
+    return None
+
+
+def resolve_set(binary, repo, path):
+    """Print the query set in span form, resolving symbols through `ast-bro map`.
+
+    `map` stops being a runtime dependency and becomes an authoring convenience:
+    it writes the spans once, and scoring afterwards needs no adapter, so a
+    language with no adapter — or a symbol an adapter cannot see, such as a C++
+    header declaration or a Ruby `class << self` method — is still targetable by
+    writing its span by hand.
+    """
+    for raw in path.read_text().splitlines():
+        if not raw.strip() or raw.startswith("#"):
+            print(raw)
+            continue
+        fields = raw.split("\t")
+        query, file, third = fields[0], fields[1], fields[2]
+        if parse_span(third) is not None:
+            print(raw)
+            continue
+        near = int(fields[3]) if len(fields) > 3 else None
+        resolved = resolve_gold(binary, repo, file, third, near)
+        if resolved is None:
+            print(f"# UNRESOLVED, span it by hand: {raw}")
+            continue
+        start, end, _ = resolved
+        span = {"start_line": start, "end_line": end, "start_col": None, "end_col": None}
+        text = span_text(repo, file, span)
+        digest = digest_of(text) if text is not None else "-"
+        print(f"{query}\t{file}\t{start}-{end}\t{third}\t{digest}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, type=Path, help="repository to search")
+    parser.add_argument("--queries", required=True, type=Path, help="TSV query set")
+    parser.add_argument("--binary", default=shutil.which("ast-bro") or "ast-bro")
+    parser.add_argument("--top-k", type=int, default=10)
+    parser.add_argument("--recall-at", type=int, default=5)
+    parser.add_argument(
+        "--count-outlines",
+        action="store_true",
+        help="let an outline hit count, scoring file-level rather than line-level recall",
+    )
+    parser.add_argument(
+        "--min-iou",
+        type=float,
+        default=0.3,
+        help="how much a result's line range must resemble the answer's (0 = bare overlap)",
+    )
+    parser.add_argument(
+        "--any-revision",
+        action="store_true",
+        help="score even when the checkout differs from the pinned revision",
+    )
+    parser.add_argument(
+        "--min-coverage",
+        type=float,
+        default=0.5,
+        help="share of the answer a result must carry to count, for the cost metric",
+    )
+    parser.add_argument(
+        "--budget",
+        type=int,
+        nargs="+",
+        default=[8000, 32000],
+        help="reading budgets in characters, for answered@budget",
+    )
+    parser.add_argument(
+        "--resolve",
+        action="store_true",
+        help="print the set in span form (query, path, span, label, digest) and exit",
+    )
+    parser.add_argument("--verbose", action="store_true", help="print per-query ranks")
+    args = parser.parse_args()
+
+    # A cutoff wider than the result list reports a recall the search was never
+    # asked for: the harness retrieves `--top-k` results and would still label
+    # the number `recall@--recall-at`. The rest are ordinary bounds — a metric
+    # that silently accepts a nonsensical setting produces a quotable number
+    # from it.
+    if args.top_k < 1:
+        parser.error("--top-k must be positive")
+    if args.recall_at < 1:
+        parser.error("--recall-at must be positive")
+    if args.recall_at > args.top_k:
+        parser.error(f"--recall-at {args.recall_at} exceeds --top-k {args.top_k}")
+    if not 0.0 <= args.min_iou <= 1.0:
+        parser.error("--min-iou must be between 0 and 1")
+    if not 0.0 <= args.min_coverage <= 1.0:
+        parser.error("--min-coverage must be between 0 and 1")
+
+    if not args.repo.is_dir():
+        sys.exit(f"no such repository: {args.repo}")
+
+    if args.resolve:
+        resolve_set(args.binary, args.repo, args.queries)
+        return
+
+    queries, meta = load_queries(args.queries)
+    check_revision(args.repo, meta, args.any_revision)
+    hits, reciprocal_rank, rows, unresolved, ambiguous = 0, 0.0, [], [], []
+    costs, stale, unpinned = [], [], []
+
+    for q in queries:
+        query, path, symbol = q["query"], q["path"], q["label"]
+        if q["kind"] == "span":
+            text = span_text(args.repo, path, q["span"])
+            if text is None:
+                unresolved.append(f"{path}:{symbol} (span runs past the file)")
+                continue
+            if q["digest"] == "-":
+                unpinned.append(symbol)
+            elif digest_of(text) != q["digest"]:
+                stale.append(f"{path}:{symbol}")
+                continue
+            gold, is_ambiguous = [q["span"]["start_line"], q["span"]["end_line"]], False
+        else:
+            resolved = resolve_gold(args.binary, args.repo, path, q["symbol"], q["near"])
+            if resolved is None:
+                unresolved.append(f"{path}:{symbol}")
+                continue
+            *gold, is_ambiguous = resolved
+        if is_ambiguous:
+            ambiguous.append(symbol)
+        payload = run_binary(
+            args.binary,
+            args.repo,
+            ["search", query, "-k", str(args.top_k), "--json", "--compact"],
+        )
+        rank = rank_of_hit(
+            payload["results"], path, *gold, args.count_outlines, args.min_iou
+        )
+        cost_rank, cost = answer_cost(
+            payload["results"], path, *gold, args.count_outlines, args.min_coverage
+        )
+        if rank and rank <= args.recall_at:
+            hits += 1
+        if rank:
+            reciprocal_rank += 1.0 / rank
+        costs.append(cost if cost_rank else None)
+        rows.append((symbol, rank, cost_rank, cost))
+
+    scored = len(rows)
+    if scored == 0:
+        sys.exit("no queries resolved — is --repo the right checkout?")
+
+    if args.verbose:
+        for symbol, rank, cost_rank, cost in rows:
+            iou_col = f"rank={rank if rank else 'miss'}"
+            cost_col = (
+                f"cost={cost} chars @rank {cost_rank}" if cost_rank else "cost=unanswered"
+            )
+            print(f"   {symbol:<30} {iou_col:<12} {cost_col}")
+    if unresolved:
+        # Loud, because a silently shrinking query set makes a score look
+        # better than it is.
+        print(f"!! {len(unresolved)} unresolved, excluded: {', '.join(unresolved)}")
+    if stale:
+        # The corpus and the set disagree about what lives at those lines. Loud
+        # and excluded, because scoring them would compare against whatever code
+        # happens to occupy the span now.
+        print(
+            f"!! {len(stale)} stale digest(s), excluded: {', '.join(stale)}"
+            "\n!! re-run with --resolve, or fix the span by hand"
+        )
+    if unpinned:
+        print(
+            f"!! {len(unpinned)} span(s) carry no digest and are unverified:"
+            f" {', '.join(unpinned)}"
+        )
+    if ambiguous:
+        # Equally loud: an ambiguous answer can make a query unhittable at any
+        # search quality, which reads as a miss rather than as a bad question.
+        print(
+            f"!! {len(ambiguous)} ambiguous, scored against the first declaration:"
+            f" {', '.join(ambiguous)}"
+        )
+        print("!! add a 4th tab-separated field with the intended line to pin them")
+
+    print(
+        f"recall@{args.recall_at} = {hits}/{scored} = {100 * hits / scored:.0f}%"
+        f"   MRR@{args.top_k} = {reciprocal_rank / scored:.3f}"
+        f"   (min-iou {args.min_iou})"
+    )
+
+    answered = [c for c in costs if c is not None]
+    budgets = "   ".join(
+        f"answered@{b // 1000}k = {sum(1 for c in answered if c <= b)}/{scored}"
+        f" = {100 * sum(1 for c in answered if c <= b) / scored:.0f}%"
+        for b in sorted(args.budget)
+    )
+    median = sorted(answered)[len(answered) // 2] if answered else None
+    print(
+        f"{budgets}   median cost = {median if median is not None else 'n/a'} chars"
+        f"   (min-coverage {args.min_coverage})"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/wiki/search.md
+++ b/wiki/search.md
@@ -2,6 +2,17 @@
 
 Two new subcommands — `search` and `find-related` — and a per-repo persistent index. This page documents the internal architecture. For the user-facing surface see the README. For network/TLS behaviour see [network-security.md](network-security.md). For what gets indexed see [file-filtering.md](file-filtering.md).
 
+Every number quoted here comes from [tests/eval](../tests/eval/README.md), a
+30-query set over pgjdbc at a pinned revision, with symbol-level ground truth.
+Measure a change there before adopting it — several that looked obviously right
+measured flat, one that looked wrong measured well, and the harness is what
+caught the ranking non-determinism described under [Determinism](#determinism).
+
+Scores are quoted at `--min-iou 0.3`: a result counts only when its line range
+resembles the answer's. Bare overlap instead rewards coarse chunking, since a
+result spanning a whole class overlaps every symbol in it by construction — the
+pre-hierarchy chunker leads on that metric and collapses to 3% on this one.
+
 ## Pipeline
 
 ```
@@ -9,17 +20,23 @@ search "<query>":
   parse_query(query)                   peel lang:/path:/name: filters; rest = text
     → mask = language ∧ path-substring ∧ name-substring ∧ query_scope ∧ live
   tokenize(text)
-    ├─ BM25.get_scores(tokens, mask)  → top_k × 5 candidates
-    └─ encode_one(text) → cosine_topk(embeddings, mask)  → top_k × 5 candidates
+    ├─ BM25.get_scores(tokens, mask)  → 100 candidates (fixed, see below)
+    └─ encode_one(text) → cosine_topk(embeddings, mask)  → same count
   RRF normalize each (k = 60)
   combine(alpha-weighted)              alpha auto: 0.3 symbol query, 0.5 NL
   boost_multi_chunk_files(...)         file coherence (+20% × file_sum/max_file_sum)
+  file_prior(...)                      phase one: rank files by their Outline
+                                       chunks alone; chunks in a liked file are
+                                       multiplied by 1 + 1.0 × prior
   apply_query_boost(...)               definition (3×), embedded symbol (1.5×),
                                        file-stem matches for NL queries
   rerank_topk(top_k, penalise_paths=True)
+                                       chunk kind: Enclosing 0.7×, Outline 0.8×;
                                        test files 0.3×, compat dirs 0.3×,
                                        generated files 0.3×, __init__.py 0.5×,
-                                       .d.ts 0.7×, file-saturation decay (0.5^extra)
+                                       .d.ts 0.7×, file-saturation decay (0.5^extra);
+                                       an Enclosing chunk drops when one of its
+                                       own Parts is also a candidate
 
 find-related <file>:<line>:
   resolve_chunk(file, line)             prefer chunks where start ≤ line < end
@@ -27,6 +44,117 @@ find-related <file>:<line>:
   cosine_topk(embeddings, mask)         mask: same language, exclude self
   return top_k
 ```
+
+The candidate count is fixed at 100, not derived from `top_k`. Deriving it made
+`top_k` change the *order* of results and not only how many come back, since
+the reranker sees a different candidate set. A *floor* of 100 over `top_k × 5`
+was not enough: it only moved the coupling past `k = 20`, where the multiplier
+overtakes the floor again — eight of thirty eval queries still had a
+`k`-dependent top-3 and three a `k`-dependent top-1. With the pool fixed it is
+zero of thirty. It moves neither recall@5 nor MRR@10, and costs one wider
+selection over scores both retrievers compute for every chunk anyway.
+
+## Chunk hierarchy
+
+Chunking emits overlapping levels, not a partition. `ChunkKind` says which:
+
+| Kind | What it covers |
+| --- | --- |
+| `Source` | A slice of the file packed at member boundaries |
+| `Enclosing` | A member too large for one chunk, kept whole |
+| `Part` | A body-level slice of an `Enclosing` member |
+| `Outline` | Synthesized signature list, no body text |
+
+`Source` and `Enclosing` tile the file exactly once. `Part` chunks re-cover the
+inside of a large member on purpose, so a query can match the statement or the
+method containing it; ranking prefers the `Part` and drops the `Enclosing` when
+both are candidates.
+
+Splitting descends through *type containers* — class bodies, `impl` blocks,
+inline modules — but never into a callable. That is what keeps a chunk boundary
+off the middle of an expression. Descending into anything oversized instead put
+`list.forEach` and `(item -> {` in different chunks, and separated a nested
+class header from its body.
+
+"Callable" has to include constructors and destructors, which are named
+`*_declaration` rather than anything containing `method`. Leaving them out made
+them containers: descent entered the body, and `local_variable_declaration`
+carries the `_declaration` suffix too, so it became a split point in the middle
+of a constructor. `is_member_kind` rejects `local_*` for the same reason — they
+are statements wearing a declaration suffix.
+
+The effect is largest where a language forces one top-level declaration per
+file. Splitting only at top level left a whole Java class as a single chunk: on
+pgjdbc, 85% of indexed characters sat in chunks above the size target, and
+`PgResultSet.java` was one 139 KB chunk of 4397 lines. Per-member splitting
+brings that to 41%, and p90 chunk height from 196 lines to 57. Rust gains less
+(53% → 39%), since it already has many top-level items and only `impl` blocks
+are affected. Go and C barely change.
+
+### Breadcrumbs
+
+Every chunk carries the declaration path that encloses it (`QueryExecutorBase >
+sendQueryCancel`), rendered in results and present in `--json`. It also goes
+into the text handed to the embedder, which is not the obvious choice —
+`potion-code-16M` is static and never saw such headers in training. It measures
+well anyway: dropping it costs recall@5 23% → 17% and MRR@10 0.226 → 0.148.
+Averaging is likely why it works, since a body-level chunk that never names its
+own method gets those tokens pulled into its mean. BM25 keeps the breadcrumb
+too, where it carries the effect alone but adds nothing on top of the embedder.
+
+### Outline documents
+
+One synthesized chunk per file, listing member signatures with no bodies. A
+signature ends where the AST says the body starts, not at the first `{` or
+newline: a brace can sit inside a parameter list — `fn unpack(Config { host,
+port }: Config)`, or any destructured TypeScript prop — and stopping at the
+newline dropped the parameters of every signature wrapped across lines.
+Declarations with no body at all, such as interface methods, keep their whole
+text.
+
+Outlines answer "which file exposes this API" for queries that name a type or
+method, where body-level chunks each match only weakly. They sit beside the
+source chunks rather than replacing them.
+
+A wrapper node is transparent, detected by shape rather than by kind name: a
+node holding a member that ends where it ends. Left opaque, `export_statement`
+hid every exported declaration, so a TypeScript outline listed exactly the ones
+that were *not* part of the public API, and Python's `decorated_definition`
+listed `@decorator` as a member of its own.
+
+Markdown gets them too, built from its headings — a heading is to a document
+what a signature is to a class. Heading detection follows CommonMark where it
+is cheap to: at most three spaces of indentation (four makes it a code block),
+setext underlines as well as `#`, nothing inside a fenced block, and no YAML
+front matter — whose closing `---` otherwise reads as a setext underline and
+promoted the last metadata line into a heading. Skipping it was not neutral: the phase-one
+prior can only *raise* a file's score, so a file with no outline could not
+compete with one that had them, and documents lost to code on queries the
+document answered. The file type was deciding the ranking, not the relevance.
+
+A long outline is split at `OUTLINE_MAX_CHARS = 3000`, well under the
+embedder's own cap. An outline above that cap is dropped from the dense index
+entirely, and the files with the longest outlines are the large central ones —
+leaving them unembedded made phase-one file retrieval miss exactly
+`QueryExecutorImpl`, `PgConnection` and `PgResultSet`. Splitting them raised
+phase-one file recall@5 from 33% to 60%, and top-1 from 23% to 40%.
+
+The pieces do not overlap. Carrying signatures across the boundary measured
+worse at every setting tried: an outline is a list of independent signatures
+rather than prose, so no evidence straddles the cut, and overlap only
+duplicates terms and makes near-identical pieces compete.
+
+## Two-phase retrieval
+
+`file_prior` ranks *files* using only their `Outline` chunks, then phase two
+multiplies each chunk by `1 + 1.0 × prior[file]`. The prior only ever promotes:
+a hard filter would zero out recall for every query whose file the outlines
+miss, and phase one finds the right file in roughly half of them.
+
+Measured on the pinned pgjdbc set: MRR@10 0.204 → 0.226 at unchanged recall@5,
+with two queries improving and none regressing. Anything from 0.5 to 2.0
+performs about the same, so the weight sits on a plateau. Latency is unchanged
+— phase one is a masked pass over embeddings already in memory.
 
 ## Field-qualified queries
 
@@ -91,7 +219,25 @@ encode_one(text):
 
 That's it. Cost is dominated by tokenization (~10–100 µs); embedding lookup is essentially free. Output is always L2-normalized so cosine similarity reduces to a dot product.
 
-`Embedder::open(model_dir)` mmaps `model.safetensors` (~64 MB) — the matrix stays paged in but never copied. `vocab × 256 × 4 bytes` = ~64 MB regardless of repo size. (`f16` tensors are also accepted and decoded once into an owned `f32` buffer at open time, for any future model that ships one — see "Adding a new model" below.)
+`Embedder::open(model_dir)` mmaps `model.safetensors` (~64 MB) — the matrix stays paged in but never copied. `vocab × 256 × 4 bytes` = ~64 MB regardless of repo size.
+
+`f16` tensors are also accepted and decoded once into an owned `f32` buffer at
+open time, so nothing downstream of `Embedder` has to know the on-disk dtype.
+
+### Tokenizer
+
+WordPiece with `lowercase: true`, vocabulary ~62 k. Note the order: the
+normalizer lowercases *before* WordPiece splits, so `sendQueryCancel` becomes
+`sendquerycancel` and the case boundaries — the only signal of where the words
+are — are gone by the time splitting happens. `send`, `query` and `cancel` are
+all in the vocabulary; the model just cannot reach them.
+
+Feeding the word-split form alongside the identifier is therefore a real
+mechanism, and it measures small: +1 query on recall@5 over 30, with MRR@10
+inside run-to-run noise, and one regression where splitting diluted the rare
+term `SASL` across many chunks. Not enabled. The lexical half already splits
+identifiers via `split_identifier`, which is most of why the dense-side gain is
+so thin.
 
 ## Cosine top-k: brute-force SIMD
 
@@ -131,7 +277,27 @@ Then four boosting / penalty passes:
 1. **`boost_multi_chunk_files`** — files with multiple high-scoring chunks get their top chunk lifted by `0.2 × max_score × (file_sum / max_file_sum)`.
 2. **Symbol queries** trigger `_boost_symbol_definitions`: chunks that *define* the queried name get `3× max_score` (1.5× multiplier if the file stem matches the symbol). Also scans non-candidate chunks whose file stem matches.
 3. **NL queries** trigger `_boost_stem_matches` (file/dir name overlap with query keywords) + `_boost_embedded_symbols` (PascalCase / camelCase identifiers in the query, half-strength definition boost).
-4. **`rerank_topk`** applies multiplicative path penalties (test files 0.3×, compat/legacy dirs 0.3×, examples 0.3×, generated files 0.3×, `.d.ts` 0.7×, `__init__.py` / `package-info.java` 0.5×) and greedy file-saturation decay (2nd chunk from the same file × 0.5, 3rd × 0.25, ...).
+4. **`rerank_topk`** applies the chunk-kind penalty (`Enclosing` 0.7×, `Outline` 0.8×), multiplicative path penalties (test files 0.3×, compat/legacy dirs 0.3×, examples 0.3×, generated files 0.3×, `.d.ts` 0.7×, `__init__.py` / `package-info.java` 0.5×) and greedy file-saturation decay (2nd chunk from the same file × 0.5, 3rd × 0.25, ...).
+
+### Determinism
+
+Ranking must not depend on `HashMap` iteration order, which Rust randomizes per
+process. Three places did, and together they made the same query over the same
+index return different results run to run. Five identical runs on the pinned
+corpus spanned recall@5 23–27% and MRR@10 0.196–0.223 — wide enough to hide or
+invent a change worth adopting.
+
+- `boost_multi_chunk_files` accumulated a per-file score sum in map order.
+  Float addition is not associative, so the sum differed each run; on an exact
+  tie the "best chunk" of a file also went to whichever id came first.
+- `file_prior` folded a file's several `Outline` pieces into one entry, letting
+  the last piece in iteration order set the file's prior.
+- `rerank_topk` sorted by score with no tiebreak, and ties are common because
+  RRF maps scores onto the small discrete set `1 / (k + rank)`.
+
+All three now walk ids in order or break ties on id. `file_coherence_boost_is_
+independent_of_map_order` guards the first by rebuilding the map in reverse
+insertion order and demanding bit-identical scores.
 
 **Generated-file down-ranking.** `generated_file_re` (`ranking.rs`) classifies machine-generated paths by suffix/marker: protobuf & gRPC stubs (`.pb.go`, `_grpc.pb.go`, `_pb2.py`, `.pb.{cc,h,dart,ts}`, …), Dart/Flutter codegen (`.g.dart`, `.freezed.dart`), C# designer output (`.Designer.cs`, `.g.cs`), gomock files (`_mock(s).go`, `mock_*.go`), minified bundles (`.min.js`, `.bundle.js`), and anything under a `generated/` / `__generated__/` directory. Suffixes are anchored to `$` and the directory marker requires an exact path component, so look-alikes (`general.rs`, `genesis.rs`, `codegen.rs`) never match. This stops a query like `Send` against a protobuf-heavy repo from burying the hand-written implementation under a dozen generated stubs.
 
@@ -149,7 +315,23 @@ Then four boosting / penalty passes:
     └── lock                 # advisory exclusive lock during writes
 ```
 
-Loader refuses if `meta.json.schema != "ast-bro.search-index.v1"`, model id mismatches, or `chunks.len() × 256 × 4 != len(embeddings.f32)`. Each binary is read via bincode with `serde::Deserialize`. Embeddings are read into memory in v1 (mmap is a v2 swap that won't change the format).
+Loader refuses if `meta.json.schema != "ast-bro.search-index.v2"`, model id mismatches, or `chunks.len() × 256 × 4 != len(embeddings.f32)`. Each binary is read via bincode with `serde::Deserialize`. Embeddings are read into memory (mmap is a later swap that won't change the format).
+
+Schema v2 adds `breadcrumb` and `kind` to `Chunk`, which changes the bincode
+layout of `chunks.bin`. A v1 index cannot be decoded, so the loader rejects it
+outright — including the pre-rename `ast-outline.*` names — and the caller
+rebuilds. There is no migration path and there does not need to be: the index
+is a cache.
+
+A chunk above `MAX_EMBED_CHARS = 6000` gets a non-finite embedding rather than a
+real one, so `cosine_topk` drops it and only BM25 can retrieve it. A zero vector
+would not do: its dot product is a finite `0.0`, which outranks every negative
+similarity and enters the pool whenever the corpus is smaller than the pool.
+`potion-code-16M` encodes a chunk as the mean of its token vectors, so a 40 KB
+class drifts toward the centroid of the language and matches everything weakly —
+past that size the vector carries less signal than the noise it adds. The
+content stays reachable densely through the member's `Part` chunks. On pgjdbc
+this affects 1.4% of chunks.
 
 `embeddings.f32` is row-major so a single chunk's vector is one cache-friendly slice — friendly to both the in-memory and future-mmap paths.
 
@@ -171,5 +353,12 @@ On `Index::open`, a non-empty delta is applied incrementally (`apply_delta`): th
 1. Add a constructor to `download::ModelInfo` listing its files (config.json, tokenizer.json, model.safetensors).
 2. Verify the embedding tensor inside the safetensors is named `embeddings` and is `f32` or `f16` (model2vec convention). `f16` tensors are decoded to `f32` once at open time (`decode_f16_le` in `embed.rs`); any other dtype is rejected.
 3. If the dimension differs from 256, the `DIM` constant in [`src/search/embed.rs`](../src/search/embed.rs) needs to follow. Most of the code is generic over `DIM`, but the const is the single source of truth — bumping it requires re-indexing existing repos (the schema check in `Meta::model.dim` will catch this and force a rebuild).
+
+Measure the swap on [tests/eval](../tests/eval/README.md) before taking it. A
+better public benchmark is not enough on its own: `potion-code-16M-v2` shares
+this model's dimension and teacher and scores higher on CoIR (NDCG@10 39.08 vs
+37.05), yet dropped recall@5 from 27% to 17% and MRR@10 from 0.223 to 0.117 on
+the pinned pgjdbc set. CoIR leans on docstring-to-function tasks, and these
+queries describe behaviour over a real codebase.
 
 The `AST_OUTLINE_MODEL_SOURCE` env var lets ops point at a custom HF-compatible mirror without code changes.


### PR DESCRIPTION
## Why

`sb search` returned file-level results on Java-like codebases. Chunking split only at top-level named children, so in class-per-file languages the single top-level declaration *is* the whole class and the file became one chunk. On pgjdbc that put **85% of indexed characters in chunks above the size target**, with `PgResultSet.java` as a single 139 KB chunk of 4397 lines — line ranges pointed at nothing usable and `search -k 8` printed 138 KB of output.

Fixing that surfaced two further problems: file-level retrieval was crippled because the largest outline documents exceeded the embedder's size cap, and ranking read `HashMap` iteration order in three places, so **the same query over the same index returned different results run to run**.

## Measured

All figures are `--min-iou 0.3` on pgjdbc pinned at `29bbe0268`, 30 queries, with the determinism fix in place so runs are comparable.

**This branch against `main`:**

```text
threshold        main               this branch
overlap > 0      57%  MRR 0.388     50%  MRR 0.375
IoU >= 0.1       17%  MRR 0.124     43%  MRR 0.330
IoU >= 0.3        3%  MRR 0.037     23%  MRR 0.226
IoU >= 0.5        0%  MRR 0.004     17%  MRR 0.159
```

A result counts as a hit when its line range **resembles** the answer's, as intersection over union. Bare overlap — the first row — rewards the exact defect being fixed: a result spanning a whole 4400-line class overlaps every symbol in that file by construction, so a chunker that never splits scores higher than one that points at the method. `main` leads on that row alone and collapses to 3% as soon as the result has to look anything like the answer. Quote the threshold with any number from this harness; that is why.

**Where the gain comes from**, by ablation on the final tree:

```text
full                     recall@5 23%   MRR 0.226
breadcrumbs dropped               17%       0.148
outline left unsplit              20%       0.188
file prior removed                23%       0.204
candidate pool derived from k     23%       0.226   (no change; see below)
```

**Chunk shape**, same corpus:

```text
p90 chunk height              196 -> 57 lines
characters in oversized chunks 85% -> 41%
search -k 8 output            138 KB -> 8.9 KB
```

Rust gains less (53% → 39%) since only `impl` blocks are affected; Go and C barely change. Index cost on this repository: 1075 → 1881 chunks, `embeddings.f32` 1.0 → 1.8 MB, build time unchanged at 0.5 s.

## What

Ten commits, each building and green on its own, and none repairing another.

| | |
|---|---|
| `feat: chunk at member boundaries with an overlapping hierarchy` | The walk descends through type containers, never into a callable, and packs at member boundaries. `ChunkKind` tags the levels: `Source`/`Enclosing` tile the file once, `Part` re-covers a large member's interior, `Outline` lists signatures. Breadcrumbs on every chunk. Most of the work is the kind predicates, which serve every grammar `ast-grep` parses and need naming rather than matching for Ruby, C/C++, C# and TypeScript. Schema v2. |
| `test: guard chunking with a per-language fixture table` | One fixture per `SupportLang`, checked against `all_langs()` so a new language fails the build; a second table covers several spellings per language, because one fixture measures the style it happens to use. `KNOWN_GAPS` records what still collapses, with a test asserting each gap reproduces. |
| `feat: rank files by their outlines before ranking chunks` | Phase one scores files by their `Outline` chunks; phase two multiplies each chunk by its file's prior. Candidate pool fixed rather than derived from `top_k`. |
| `fix: make search results reproducible across runs` | Three sites read hash-map order, including a float sum whose non-associativity changed scores each run. |
| `fix: keep the non-finite embedding sentinel sortable` | NaN has no ordering, so unembedded rows could occupy the top-k window and the dense pool came back short — empty, on a corpus whose unembedded rows sort first. |
| `fix: recognise suffixed test directories, not just exact names` | `Foo.Tests/` read as production code in both the walk filter and the search ranker, which carry separate implementations of one rule. |
| `feat: report byte offsets on search results` | The chunk already knows them; a consumer comparing against a sub-line answer did not. |
| `test: add a retrieval eval harness` | Ground truth is a line span plus a content digest, so a set can target any language and any symbol `map` cannot see. Two scorings: IoU, and the cost of reading far enough to reach the answer. |
| `test: add pinned 30-query sets for Go, Ruby, and C#` | prometheus, etcd, Homebrew, ILSpy — thirty queries each on pinned revisions. |
| `docs: document the chunk hierarchy and two-phase retrieval` | The wiki described a single-level chunker and a one-pass pipeline. |

### Two decisions worth flagging

**The candidate pool is fixed, not derived from `top_k`.** Deriving it made `top_k` change the *order* of results and not only how many came back, since the reranker sees a different candidate set. A floor of 100 over `top_k * 5` is not enough — it only moves the coupling past `k = 20`, where the multiplier overtakes the floor again, and eight of thirty queries still had a `k`-dependent top-3 with three a `k`-dependent top-1. Fixed, it is zero of thirty. It buys no score at all; it buys the same query answering the same way whatever `-k` it was asked with.

**Markdown gets outline documents too.** Not cosmetic: the phase-one prior can only *raise* a file's score, so a file without outlines structurally cannot compete with one that has them. Without this, documents lost to code on queries the documents answered — the file type decided the ranking rather than the relevance.

**Signatures come from the AST, not from scanning for `{`.** A brace can sit inside a parameter list — `fn unpack(Config { host, port }: Config)`, or any destructured TypeScript prop — and stopping at the first newline drops the parameters of every signature written across lines. Likewise a wrapper node has to be transparent, or `export function` never reaches the member walk and a TypeScript outline lists exactly the declarations that are *not* exported.

## Notable negative results

Recorded in the code and wiki so they are not re-tried from scratch:

- **Sliding windows over long methods** — the one query that improved was won by a `Part` chunk, not a window: the gain came from windows perturbing corpus statistics. pgjdbc's longest method is 462 lines and only 11 of 505 large members exceed 200, so there is little interior a `Part` does not already cover. Not merged.
- **Overlapping outline pieces** — worse at every setting tried. An outline is a list of independent signatures, not prose, so no evidence straddles the cut; overlap only duplicates terms and makes near-identical pieces compete.
- **Identifier splitting for the embedder** — the tokenizer analysis motivating it is real (the normalizer lowercases *before* WordPiece splits, so case boundaries are gone by the time splitting happens), but feeding the word-split form back measured inside run-to-run noise, with one regression where it diluted the rare term `SASL`. Not enabled.
- **`potion-code-16M-v2`** — same dimension and teacher, higher CoIR (NDCG@10 39.08 vs 37.05), yet 27% → 17% here. CoIR leans on docstring-to-function tasks; these queries describe behaviour over a real codebase. `main` reached the same conclusion independently in `ea940d6`; the wiki now carries the measured figures alongside it.

## How to verify

```bash
cargo test --release
```

```bash
git clone https://github.com/pgjdbc/pgjdbc ~/src/pgjdbc && git -C ~/src/pgjdbc checkout 29bbe0268c1e55cc2037fa171d61dcdafca39a7a
```

```bash
tests/eval/run_eval.py --repo ~/src/pgjdbc --queries tests/eval/queries/pgjdbc.tsv --binary target/release/ast-bro
```

`tests/eval/queries/self.tsv` runs against this repository and needs no external checkout, but it is a smoke test — twenty Rust queries over a small codebase cannot separate two ranking variants. Read `tests/eval/README.md` first: on 30 queries a one-query difference is noise, and what carries weight is the per-query diff.

## Breaking

Existing search indexes are rejected and rebuilt on next use. `Chunk` gained two fields, so the bincode layout of `chunks.bin` changed and there is no migration path — the index is a cache.

## Note

`tests/deps_e2e.rs::go_module_prefix_strips_correctly` fails here and on `main` alike, unrelated to these changes. It has its own pull request now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search results now show hierarchical breadcrumbs and clearly identify source, enclosing, part, and outline matches.
  * Added signature and Markdown heading outlines to improve navigation and discovery.
  * Improved ranking with deterministic ordering, file coherence, and better handling of overlapping results.

* **Documentation**
  * Expanded search documentation and added guidance for evaluating retrieval quality.

* **Tests**
  * Broadened coverage for chunk hierarchy, outlines, signatures, Markdown parsing, embeddings, and ranking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



