### PR TITLE
ci: run the test suite on GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,60 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  RUST_BACKTRACE: 1
+
+jobs:
+  test:
+    name: cargo test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install the stable toolchain
+        id: toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
+          rustc --version
+          echo "version=$(rustc --version | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache cargo registry and build artifacts
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            target
+          # Cargo.lock pins the dependency set; the rustc version is part of the
+          # key because target/ is not portable across toolchain upgrades.
+          key: cargo-${{ runner.os }}-${{ steps.toolchain.outputs.version }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            cargo-${{ runner.os }}-${{ steps.toolchain.outputs.version }}-
+
+      - name: Build tests
+        run: cargo test --locked --no-run
+
+      - name: Run tests
+        run: cargo test --locked


### PR DESCRIPTION
## Why

The repository has no CI, so nothing runs `cargo test` except a contributor who remembers to. A regression can sit on `main` unnoticed — and one currently does, see the note below.

## Sample execution

* https://github.com/vlsi/ast-bro/actions/runs/30874440294/job/91882937637

## What

Adds `.github/workflows/tests.yml`:

- Triggers on push to `main`, on every pull request, and manually via `workflow_dispatch`. Concurrent runs are cancelled for PRs only, so `main` keeps a complete history of results.
- `permissions: contents: read` — the workflow only needs to check out code.
- Matrix over `ubuntu-latest` and `macos-latest`, `fail-fast: false`. Windows is left out on purpose: several `deps`/`calls` tests assert on rendered paths with `/` separators and would fail on a backslash platform.
- Toolchain comes from the runner's preinstalled `rustup` (`stable`, `--profile minimal`), so no third-party action is involved.
- Caches `~/.cargo/registry/{index,cache}`, `~/.cargo/git/db` and `target`, keyed on OS + `rustc` version + `Cargo.lock` hash. The compiler version is part of the key because `target/` is not portable across toolchain upgrades.
- Build and run are separate steps (`cargo test --locked --no-run`, then `cargo test --locked`), so a compilation failure is distinguishable from a test failure at a glance.

Both actions are pinned by commit SHA with the version in a trailing comment — the form Renovate and Dependabot keep up to date:

- `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1`
- `actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0`

## Heads-up: one test already fails on `main`

`deps_e2e::go_module_prefix_strips_correctly` fails on `ee600cd`, before this change. The first CI run will be red, and that is the pre-existing defect rather than a workflow problem.

Cause: `src/deps/manifest.rs:28` reads `go.mod` from the project root (`root.join("go.mod")`), while the fixture's `go.mod` lives in `tests/fixtures/deps/go_module/`. Root detection lands on the `ast-bro` repository, which has no `go.mod`, so `src/deps/resolver/resolve.rs:145` drops every Go import to `[external]`.

Fixing the resolver is out of scope here. Happy to follow up in a separate PR, or to mark the test `#[ignore]` in this one if you would rather merge green.

## How to verify

```
cargo test --locked
```

Everything passes except the `go_module_prefix_strips_correctly` case described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)