### PR TITLE
fix: deliver a map for a Read the host refuses outright

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,14 +331,16 @@ call, so the map arrives beside the error rather than in place of
 anything.
 
 Whatever the channel, the map is capped at 64 KB. A map that would run
-over sheds detail first, in order of what it costs: doc comments and
-attributes, then fields and private items, then members past 50 per
-type. Only when that still does not fit is the map trimmed line by line
-— a minified bundle, where the size is sheer declaration count, or a
-single generated declaration too wide to fit at all. A trim drops a
-declaration's members along with it rather than filing them under the
-previous one. Either way the payload ends with a note saying what is
-missing and the `ast-bro map` command that returns it.
+over can shed detail — doc comments and attributes first, then fields and
+private items, with a per-type member cap as a last backstop that rarely
+comes up — or keep the detail and drop whole entries instead. Which one you get is decided by how many
+declarations each delivers, not by which fits first: a mostly-private
+file would fit the moment private items went, and hand you the public
+few, so it is trimmed at a richer level instead. A trim drops a
+declaration together with its doc comment and its members, rather than
+leaving them to read as someone else's. Either way the payload ends with
+a note saying what is missing and the `ast-bro map` command that returns
+it.
 
 ### Claude Code subagent shadowing
 

--- a/README.md
+++ b/README.md
@@ -339,10 +339,11 @@ went, and hand you the public few, so it is trimmed at a richer level
 instead.
 
 A trim spends the 64 KB in the order that ladder ranks: whatever survives
-furthest down it goes in first, so a file's public surface arrives whole
-before its private helpers get the rest. Filling in file order instead
-handed back 1733 private items and none of that file's 500 public ones,
-because the publics ran to the end of a file twice the budget. What a
+furthest down it goes in first, so a file's public surface is what the
+budget buys before anything else — all of it, unless the public surface
+alone is over the cap. Filling in file order instead handed back 1733
+private items and none of that file's 500 public ones, because the
+publics ran to the end of a file twice the budget. What a
 trim drops, it drops entire — a declaration leaves with its doc comment
 and its members, rather than leaving them to read as someone else's. The
 payload then ends with a note saying what is missing and the

--- a/README.md
+++ b/README.md
@@ -324,23 +324,29 @@ the read the host refuses outright — measured against its file-size
 limit, 256 KB on Claude Code 2.1.223. That limit counts bytes, not lines,
 so it catches files no `--min-lines` threshold does: a 90-line file of
 355 KB trips it. Without this the agent gets a bare error and nothing
-else. That event cannot replace a result, only
-add context, which is all the map needs when the result carries no file
-contents. Nothing is blocked on that path: the host already failed the
-call, so the map arrives beside the error rather than in place of
-anything.
+else. That event cannot replace a result, only add context, which is all
+the map needs when the result carries no file contents. Nothing is
+blocked on that path: the host already failed the call, so the map
+arrives beside the error rather than in place of anything.
 
 Whatever the channel, the map is capped at 64 KB. A map that would run
 over can shed detail — doc comments and attributes first, then fields and
 private items, with a per-type member cap as a last backstop that rarely
-comes up — or keep the detail and drop whole entries instead. Which one you get is decided by how many
-declarations each delivers, not by which fits first: a mostly-private
-file would fit the moment private items went, and hand you the public
-few, so it is trimmed at a richer level instead. A trim drops a
-declaration together with its doc comment and its members, rather than
-leaving them to read as someone else's. Either way the payload ends with
-a note saying what is missing and the `ast-bro map` command that returns
-it.
+comes up — or keep the detail and drop whole entries instead. Which one
+you get is decided by how many declarations each delivers, not by which
+fits first: a mostly-private file would fit the moment private items
+went, and hand you the public few, so it is trimmed at a richer level
+instead.
+
+A trim spends the 64 KB in the order that ladder ranks: whatever survives
+furthest down it goes in first, so a file's public surface arrives whole
+before its private helpers get the rest. Filling in file order instead
+handed back 1733 private items and none of that file's 500 public ones,
+because the publics ran to the end of a file twice the budget. What a
+trim drops, it drops entire — a declaration leaves with its doc comment
+and its members, rather than leaving them to read as someone else's. The
+payload then ends with a note saying what is missing and the
+`ast-bro map` command that returns it.
 
 ### Claude Code subagent shadowing
 

--- a/README.md
+++ b/README.md
@@ -300,9 +300,45 @@ ast-bro status
 
 Supported targets: `claude-code`, `gemini`, `tabnine`, `cursor`,
 `aider`, `codex`, `copilot`, `opencode`. Claude Code, Gemini, and Tabnine also get
-a tool-call hook that intercepts `Read` on supported source files when
-they exceed `--min-lines` (default 200) and substitutes the map output.
+a tool-call hook that intercepts `Read` on supported source files above
+`--min-lines` (default 200) and substitutes the map output. On Claude
+Code it also covers a read the host refuses outright, at any line count.
 The other targets do not install a read-interceptor hook.
+
+The substitution reaches the agent as a blocked tool call whose first
+line says that nothing failed. For a read that has not run yet, that is
+the only channel available: the map has to arrive instead of the file, so
+the read must be refused, and a refusal is what the host reports.
+
+Claude Code has a second event that would report a success instead,
+`PostToolUse` with `hookSpecificOutput.updatedToolOutput`, and
+`ast-bro install` does not register it. Measured on Claude Code 2.1.223:
+that field replaces the result of an MCP tool and is ignored for the
+built-in `Read`, so registering it would deliver no map and send the
+whole file to the model. Registering a `PostToolUse` entry by hand does
+nothing useful for `Read` on that version, for the same reason. See
+[issue #34](https://github.com/aeroxy/ast-bro/issues/34).
+
+On Claude Code the hook also registers under `PostToolUseFailure`, for
+the read the host refuses outright — measured against its file-size
+limit, 256 KB on Claude Code 2.1.223. That limit counts bytes, not lines,
+so it catches files no `--min-lines` threshold does: a 90-line file of
+355 KB trips it. Without this the agent gets a bare error and nothing
+else. That event cannot replace a result, only
+add context, which is all the map needs when the result carries no file
+contents. Nothing is blocked on that path: the host already failed the
+call, so the map arrives beside the error rather than in place of
+anything.
+
+Whatever the channel, the map is capped at 64 KB. A map that would run
+over sheds detail first, in order of what it costs: doc comments and
+attributes, then fields and private items, then members past 50 per
+type. Only when that still does not fit is the map trimmed line by line
+— a minified bundle, where the size is sheer declaration count, or a
+single generated declaration too wide to fit at all. A trim drops a
+declaration's members along with it rather than filing them under the
+previous one. Either way the payload ends with a note saying what is
+missing and the `ast-bro map` command that returns it.
 
 ### Claude Code subagent shadowing
 
@@ -313,7 +349,7 @@ containing the full ast-bro prompt.
 
 When you run `ast-bro install --target claude-code`, you get:
 - `CLAUDE.md` — main agent prompt (global or local per-repo)
-- `.claude/settings.json` — `Read` tool hook
+- `.claude/settings.json` — `Read` hooks on `PreToolUse` and `PostToolUseFailure`
 - `.claude/agents/Explore.md` — Explore subagent with the prompt injected
 
 This solves the "why doesn't my subagent use ast-bro?" problem — subagents

--- a/src/core.rs
+++ b/src/core.rs
@@ -620,17 +620,31 @@ fn _size_label(line_count: usize) -> &'static str {
 
 
 pub fn render_map(result: &ParseResult, opts: &MapOptions) -> String {
-    let mut lines = vec![_format_file_header(
+    render_map_units(result, opts).join("\n")
+}
+
+/// The map as the units it is assembled from, rather than as one string.
+///
+/// A unit is the file header, a warning, one declaration together with its doc
+/// comment, a `... +N more member(s)` marker, or a blank separator. Text is what
+/// [`render_map`] joins these into; a caller that has to *shorten* a map needs
+/// the units, because a physical line does not tell you what nests under what:
+/// a doc comment keeps the indentation it had in the source, so its continuation
+/// lines land at arbitrary columns, and a separator has no indentation at all.
+/// The unit's own indentation is the render prefix, and children are separate
+/// units indented one level deeper.
+pub fn render_map_units(result: &ParseResult, opts: &MapOptions) -> Vec<String> {
+    let mut units = vec![_format_file_header(
         &format!("# {}", result.path.display()),
         result,
     )];
     if let Some(warn) = _format_error_warning(result) {
-        lines.push(warn);
+        units.push(warn);
     }
     for decl in &result.declarations {
-        _render_decl(decl, opts, 0, &mut lines);
+        _render_decl(decl, opts, 0, &mut units);
     }
-    lines.join("\n")
+    units
 }
 fn _format_file_header(prefix: &str, result: &ParseResult) -> String {
     let counts = _collect_counts(&result.declarations);
@@ -739,8 +753,12 @@ fn _render_decl(decl: &Declaration, opts: &MapOptions, indent: usize, out: &mut 
 
     let prefix = "    ".repeat(indent);
 
+    // The declaration and its doc comment go out as one unit, so a consumer that
+    // drops the declaration cannot leave the comment behind to read as
+    // documentation of whatever follows it.
+    let mut unit: Vec<String> = Vec::new();
     if opts.include_docs && !decl.docs.is_empty() && !decl.docs_inside {
-        push_docs(&prefix, out);
+        push_docs(&prefix, &mut unit);
     }
 
     let attrs_prefix = if opts.include_attributes && !decl.attrs.is_empty() {
@@ -756,13 +774,13 @@ fn _render_decl(decl: &Declaration, opts: &MapOptions, indent: usize, out: &mut 
     };
 
     if decl.kind == Namespace {
-        out.push(format!(
+        unit.push(format!(
             "{}namespace {}",
             prefix,
             decl.name.magenta().bold()
         ));
     } else {
-        out.push(format!(
+        unit.push(format!(
             "{}{}{}{}",
             prefix, attrs_prefix, decl.signature, suffix
         ));
@@ -770,8 +788,9 @@ fn _render_decl(decl: &Declaration, opts: &MapOptions, indent: usize, out: &mut 
 
     if opts.include_docs && !decl.docs.is_empty() && decl.docs_inside {
         let inner_prefix = "    ".repeat(indent + 1);
-        push_docs(&inner_prefix, out);
+        push_docs(&inner_prefix, &mut unit);
     }
+    out.push(unit.join("\n"));
 
     // `--max-members` caps how many members a type renders; the remainder
     // is reported, never silently dropped (issues #37 / #32).

--- a/src/core.rs
+++ b/src/core.rs
@@ -620,29 +620,82 @@ fn _size_label(line_count: usize) -> &'static str {
 
 
 pub fn render_map(result: &ParseResult, opts: &MapOptions) -> String {
-    render_map_units(result, opts).join("\n")
+    render_map_units(result, opts)
+        .iter()
+        .map(|u| u.text.as_str())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// What a map is assembled from: one piece of text plus the structure that text
+/// does not carry.
+///
+/// [`render_map`] joins the text and drops the rest, which is all a reader needs.
+/// A caller that has to *shorten* a map needs the rest: which declaration a piece
+/// renders, and which declaration encloses it. Rendered text answers neither
+/// question. Indentation looks like an answer and is not one — a doc comment
+/// keeps the indentation it had in the source, so its continuation lines land at
+/// arbitrary columns, and a separator has no indentation at all.
+#[derive(Debug, Clone)]
+pub struct MapUnit {
+    /// The text [`render_map`] writes for this piece.
+    pub text: String,
+    /// What this piece is, and for a declaration, which one.
+    pub kind: MapUnitKind,
+    /// The declaration this piece nests under, `None` at the top level.
+    pub parent: Option<usize>,
+}
+
+/// What a [`MapUnit`] is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MapUnitKind {
+    /// The file header or a parse warning: not a declaration, and a map missing
+    /// one reads as a map of a different file.
+    Preamble,
+    /// One declaration together with its doc comment.
+    ///
+    /// `id` numbers the declaration in pre-order over the whole tree, counting
+    /// the declarations [`MapOptions`] filtered out as well, so the number means
+    /// the same thing in every render of one file and two renders can be matched
+    /// against each other.
+    Declaration { id: usize },
+    /// A `... +N more member(s)` marker: a statement about the enclosing type
+    /// rather than a declaration of its own.
+    MoreMembers,
+    /// The blank line between items, which carries no structure.
+    Separator,
+}
+
+impl MapUnit {
+    fn preamble(text: String) -> Self {
+        Self {
+            text,
+            kind: MapUnitKind::Preamble,
+            parent: None,
+        }
+    }
+
+    fn separator() -> Self {
+        Self {
+            text: String::new(),
+            kind: MapUnitKind::Separator,
+            parent: None,
+        }
+    }
 }
 
 /// The map as the units it is assembled from, rather than as one string.
-///
-/// A unit is the file header, a warning, one declaration together with its doc
-/// comment, a `... +N more member(s)` marker, or a blank separator. Text is what
-/// [`render_map`] joins these into; a caller that has to *shorten* a map needs
-/// the units, because a physical line does not tell you what nests under what:
-/// a doc comment keeps the indentation it had in the source, so its continuation
-/// lines land at arbitrary columns, and a separator has no indentation at all.
-/// The unit's own indentation is the render prefix, and children are separate
-/// units indented one level deeper.
-pub fn render_map_units(result: &ParseResult, opts: &MapOptions) -> Vec<String> {
-    let mut units = vec![_format_file_header(
+pub fn render_map_units(result: &ParseResult, opts: &MapOptions) -> Vec<MapUnit> {
+    let mut units = vec![MapUnit::preamble(_format_file_header(
         &format!("# {}", result.path.display()),
         result,
-    )];
+    ))];
     if let Some(warn) = _format_error_warning(result) {
-        units.push(warn);
+        units.push(MapUnit::preamble(warn));
     }
+    let mut next_id = 0usize;
     for decl in &result.declarations {
-        _render_decl(decl, opts, 0, &mut units);
+        _render_decl(decl, opts, 0, None, &mut next_id, &mut units);
     }
     units
 }
@@ -734,7 +787,14 @@ fn _collect_counts(decls: &[Declaration]) -> std::collections::HashMap<&'static 
     out
 }
 
-fn _render_decl(decl: &Declaration, opts: &MapOptions, indent: usize, out: &mut Vec<String>) {
+fn _render_decl(
+    decl: &Declaration,
+    opts: &MapOptions,
+    indent: usize,
+    parent: Option<usize>,
+    next_id: &mut usize,
+    out: &mut Vec<MapUnit>,
+) {
     use DeclarationKind::*;
 
     let push_docs = |prefix: &str, lines_out: &mut Vec<String>| {
@@ -747,7 +807,14 @@ fn _render_decl(decl: &Declaration, opts: &MapOptions, indent: usize, out: &mut 
         }
     };
 
+    let id = *next_id;
+    *next_id += 1;
+
     if !_map_eligible(decl, opts) {
+        // Number the subtree anyway: a declaration's number has to name the same
+        // declaration whatever the options dropped, or two renders of one file
+        // cannot be matched against each other.
+        *next_id += _decl_count(decl);
         return;
     }
 
@@ -790,7 +857,11 @@ fn _render_decl(decl: &Declaration, opts: &MapOptions, indent: usize, out: &mut 
         let inner_prefix = "    ".repeat(indent + 1);
         push_docs(&inner_prefix, &mut unit);
     }
-    out.push(unit.join("\n"));
+    out.push(MapUnit {
+        text: unit.join("\n"),
+        kind: MapUnitKind::Declaration { id },
+        parent,
+    });
 
     // `--max-members` caps how many members a type renders; the remainder
     // is reported, never silently dropped (issues #37 / #32).
@@ -806,21 +877,24 @@ fn _render_decl(decl: &Declaration, opts: &MapOptions, indent: usize, out: &mut 
         if visible(child) && _counts_toward_member_cap(&child.kind) {
             if shown >= cap {
                 hidden += 1;
+                *next_id += 1 + _decl_count(child);
                 continue;
             }
             shown += 1;
         }
-        _render_decl(child, opts, indent + 1, out);
+        _render_decl(child, opts, indent + 1, Some(id), next_id, out);
     }
     if hidden > 0 {
-        out.push(
-            format!(
+        out.push(MapUnit {
+            text: format!(
                 "{}    ... +{} more member(s) (raise --max-members)",
                 prefix, hidden
             )
             .dimmed()
             .to_string(),
-        );
+            kind: MapUnitKind::MoreMembers,
+            parent: Some(id),
+        });
     }
 
     if indent == 0
@@ -829,8 +903,13 @@ fn _render_decl(decl: &Declaration, opts: &MapOptions, indent: usize, out: &mut 
             Class | Struct | Interface | Record | Enum | Namespace
         )
     {
-        out.push(String::new());
+        out.push(MapUnit::separator());
     }
+}
+
+/// Declarations under `decl`, `decl` itself excluded.
+fn _decl_count(decl: &Declaration) -> usize {
+    decl.children.iter().map(|c| 1 + _decl_count(c)).sum()
 }
 
 fn _clip_docs(docs: &[String], limit: usize) -> Vec<String> {

--- a/src/hook/claude_code.rs
+++ b/src/hook/claude_code.rs
@@ -1,22 +1,32 @@
-//! Claude Code PreToolUse hook protocol shim.
+//! Claude Code hook protocol shim, for both events that can carry a map.
 //!
-//! Claude Code's PreToolUse event JSON shape:
-//!   { "tool_name": "Read",
+//! Claude Code's tool-call event JSON shape:
+//!   { "hook_event_name": "PostToolUse",
+//!     "tool_name": "Read",
 //!     "tool_input": { "file_path": "...", "offset": ..., "limit": ... } }
 //!
-//! Response shape is shared with Gemini — see `super::io`.
+//! `hook_event_name` picks the response channel, so one command serves an
+//! entry registered under either event and `ast-bro install` can move the
+//! entry without changing the command string. Response shapes live in
+//! `super::io`.
 
 use std::path::PathBuf;
 
 use serde::Deserialize;
 
 use super::decide::DecideOpts;
-use super::event::ToolCallEvent;
+use super::event::{Channel, ToolCallEvent};
 use super::io::{dispatch, emit_pass_through, read_stdin};
 
 #[derive(Debug, Deserialize)]
 struct InputEvent {
     tool_name: String,
+    /// The event that fired, absent on a host too old to send it. Only
+    /// `PostToolUse` can replace a delivered result and only
+    /// `PostToolUseFailure` reaches a read the host rejected, so everything
+    /// else — including a missing value — falls back to refusing the call.
+    #[serde(default)]
+    hook_event_name: Option<String>,
     #[serde(default)]
     tool_input: ToolInput,
 }
@@ -43,6 +53,11 @@ pub fn run(opts: DecideOpts) -> i32 {
             return emit_pass_through();
         }
     };
+    let channel = match event.hook_event_name.as_deref() {
+        Some("PostToolUse") => Channel::Replace,
+        Some("PostToolUseFailure") => Channel::Augment,
+        _ => Channel::Deny,
+    };
     dispatch(
         ToolCallEvent {
             tool_name: event.tool_name,
@@ -51,6 +66,7 @@ pub fn run(opts: DecideOpts) -> i32 {
                 || event.tool_input.limit.is_some(),
         },
         &opts,
+        channel,
     )
 }
 
@@ -64,5 +80,13 @@ mod tests {
         let e: InputEvent = serde_json::from_str(json).unwrap();
         assert_eq!(e.tool_name, "Read");
         assert_eq!(e.tool_input.file_path, Some(PathBuf::from("a.rs")));
+        assert_eq!(e.hook_event_name, None);
+    }
+
+    #[test]
+    fn input_event_parses_hook_event_name() {
+        let json = r#"{"hook_event_name":"PostToolUse","tool_name":"Read","tool_input":{}}"#;
+        let e: InputEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(e.hook_event_name.as_deref(), Some("PostToolUse"));
     }
 }

--- a/src/hook/decide.rs
+++ b/src/hook/decide.rs
@@ -2,6 +2,9 @@ use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use super::event::{Channel, Decision, ToolCallEvent};
+// The ceiling and the room the channel notice takes out of it both belong to the
+// module that assembles a payload; what this one needs is the budget that leaves.
+use super::io::{MAP_BUDGET, MAX_MAP_BYTES};
 use crate::core::{MapUnit, MapUnitKind};
 
 #[derive(Debug, Clone)]
@@ -58,26 +61,6 @@ fn line_count_at_least(path: &Path, threshold: usize) -> std::io::Result<bool> {
     }
     Ok(false)
 }
-
-/// Ceiling on what the hook delivers, in bytes, notice included.
-///
-/// The host refuses a read at roughly 25k tokens, so answering with a payload of
-/// the same order defeats the point. 64 KB is about 16k tokens: under the limit
-/// the refusal was about, and above every real map measured — Apache Calcite's
-/// `SqlFunctions.java`, 7771 hand-written lines and the largest map in that
-/// repository, fits once doc comments and attributes are shed. What does not fit
-/// is a minified bundle, whose size is declaration count rather than detail, and
-/// that is what [`cap_map`] is for.
-///
-/// The ceiling is hard: [`MAP_BUDGET`] holds back room for the channel notice and
-/// the marker, both of which are built before anything is cut.
-pub(super) const MAX_MAP_BYTES: usize = 64 * 1024;
-
-/// What a map may occupy once the channel notice is accounted for.
-///
-/// `io::payload` prepends a notice to every map, so a map sized against
-/// [`MAX_MAP_BYTES`] alone would be delivered above it.
-pub(super) const MAP_BUDGET: usize = MAX_MAP_BYTES - super::io::MAX_NOTICE_BYTES;
 
 /// Detail the hook sheds, in order, to bring a map under [`MAP_BUDGET`].
 ///

--- a/src/hook/decide.rs
+++ b/src/hook/decide.rs
@@ -71,13 +71,13 @@ fn line_count_at_least(path: &Path, threshold: usize) -> std::io::Result<bool> {
 ///
 /// The ceiling is hard: [`MAP_BUDGET`] holds back room for the channel notice and
 /// the marker, both of which are built before anything is cut.
-const MAX_MAP_BYTES: usize = 64 * 1024;
+pub(super) const MAX_MAP_BYTES: usize = 64 * 1024;
 
 /// What a map may occupy once the channel notice is accounted for.
 ///
 /// `io::payload` prepends a notice to every map, so a map sized against
 /// [`MAX_MAP_BYTES`] alone would be delivered above it.
-const MAP_BUDGET: usize = MAX_MAP_BYTES - super::io::MAX_NOTICE_BYTES;
+pub(super) const MAP_BUDGET: usize = MAX_MAP_BYTES - super::io::MAX_NOTICE_BYTES;
 
 /// Detail the hook sheds, in order, to bring a map under [`MAP_BUDGET`].
 ///
@@ -135,7 +135,7 @@ fn render_map_for(path: &Path) -> Option<String> {
     // and a different one: it funds by rank, which on a file of wide type headers
     // and cheap members buys fewer declarations than file order would, and buys
     // the right ones.
-    let mut best: Option<(usize, String)> = None;
+    let mut best: Option<Candidate> = None;
     for (i, (shed, opts)) in levels.iter().enumerate() {
         if rendered.len() == i {
             rendered.push(crate::core::render_map_units(&res, opts));
@@ -151,21 +151,36 @@ fn render_map_for(path: &Path) -> Option<String> {
         } else {
             shed_note(shed, path)
         };
-        let fits = map_bytes(&rendered[i]) + note.len() <= MAP_BUDGET;
-        let (payload, delivered) = if fits {
-            (
-                with_note(join_units(&rendered[i]), &note),
-                entry_count(&rendered[i]),
-            )
+        // Measured on the assembled payload rather than on its parts: `with_note`
+        // puts the note on a line of its own, and a fit decision that leaves that
+        // byte out is a ceiling resting on how the renderer happened to end the
+        // last unit.
+        let whole = with_note(join_units(&rendered[i]), &note);
+        let fits = whole.len() <= MAP_BUDGET;
+        let candidate = if fits {
+            let delivered = entry_count(&rendered[i]);
+            Candidate {
+                payload: whole,
+                required: delivered,
+                delivered,
+            }
         } else {
             for (_, leaner) in levels.iter().skip(rendered.len()) {
                 rendered.push(crate::core::render_map_units(&res, leaner));
             }
-            cap_map(&rendered[i], &rendered[i + 1..], shed, full_bytes, path)
+            let required = required_ids(&rendered[i + 1..], &levels[i + 1..], path);
+            cap_map(
+                &rendered[i],
+                &rendered[i + 1..],
+                &required,
+                shed,
+                full_bytes,
+                path,
+            )
         };
         // Strictly greater, so the richest level wins a tie.
-        if best.as_ref().is_none_or(|(most, _)| delivered > *most) {
-            best = Some((delivered, payload));
+        if best.as_ref().is_none_or(|b| candidate.score() > b.score()) {
+            best = Some(candidate);
         }
         if fits {
             // No later level can deliver more: every level after this one only
@@ -177,7 +192,65 @@ fn render_map_for(path: &Path) -> Option<String> {
             break;
         }
     }
-    best.map(|(_, payload)| payload)
+    let payload = best.map(|b| b.payload);
+    debug_assert!(
+        payload.as_ref().is_none_or(|p| p.len() <= MAP_BUDGET),
+        "a payload left the hook over the budget"
+    );
+    payload
+}
+
+/// One level's answer, and what it costs to prefer another level's.
+struct Candidate {
+    payload: String,
+    /// Declarations it carries that a whole leaner candidate would carry too.
+    required: usize,
+    /// Declarations it carries at all.
+    delivered: usize,
+}
+
+impl Candidate {
+    /// What a candidate is chosen by, richest first.
+    ///
+    /// Declarations decide it, but not before the public surface does. A trim
+    /// that runs out of budget inside the top rank can still out-count the leaner
+    /// candidate that fits whole — it skips the one unit too wide to fit and
+    /// spends the remainder on cheaper ones a rank below — and that payload is
+    /// missing declarations a cheaper answer would have delivered. Counting the
+    /// required set first makes that trade impossible to win.
+    fn score(&self) -> (usize, usize) {
+        (self.required, self.delivered)
+    }
+}
+
+/// The declarations a trimmed candidate must carry to be worth preferring.
+///
+/// They are the leanest whole answer available: the richest of the leaner levels
+/// whose map fits, which is the level the loop in [`render_map_for`] would stop
+/// at. Empty when no leaner level fits, where nothing is owed and the count
+/// decides alone.
+fn required_ids(
+    leaner: &[Vec<MapUnit>],
+    levels: &[(&'static str, crate::core::MapOptions)],
+    path: &Path,
+) -> HashSet<usize> {
+    for (units, (shed, _)) in leaner.iter().zip(levels) {
+        let note = shed_note(shed, path);
+        if with_note(join_units(units), &note).len() <= MAP_BUDGET {
+            return declaration_ids(units);
+        }
+    }
+    HashSet::new()
+}
+
+fn declaration_ids(units: &[MapUnit]) -> HashSet<usize> {
+    units
+        .iter()
+        .filter_map(|u| match u.kind {
+            MapUnitKind::Declaration { id } => Some(id),
+            _ => None,
+        })
+        .collect()
 }
 
 /// The declarations a map carries, which is what one candidate is compared to
@@ -241,15 +314,7 @@ fn shed_note(shed: &str, path: &Path) -> String {
 fn survival_ranks(units: &[MapUnit], leaner: &[Vec<MapUnit>]) -> Vec<usize> {
     let sets: Vec<HashSet<usize>> = leaner
         .iter()
-        .map(|render| {
-            render
-                .iter()
-                .filter_map(|u| match u.kind {
-                    MapUnitKind::Declaration { id } => Some(id),
-                    _ => None,
-                })
-                .collect()
-        })
+        .map(|render| declaration_ids(render))
         .collect();
     let mut by_decl: HashMap<usize, usize> = HashMap::new();
     let mut ranks = Vec::with_capacity(units.len());
@@ -296,14 +361,21 @@ fn survival_ranks(units: &[MapUnit], leaner: &[Vec<MapUnit>]) -> Vec<usize> {
 ///
 /// And a dropped declaration takes everything nested under it, because a member
 /// kept without its type header reads as a member of the previous type — a map
-/// asserting a structure the file does not have.
+/// asserting a structure the file does not have. That rule needs its parent
+/// decided first, and the funding order gives it that: `_render_decl` returns
+/// before rendering anything for a declaration the options exclude, so a child
+/// reaches a render only where every one of its ancestors did. A parent
+/// therefore survives at least as far down the ladder as its members, its rank
+/// is never lower, and a stable sort leaves the two in file order when the ranks
+/// are equal.
 fn cap_map(
     units: &[MapUnit],
     leaner: &[Vec<MapUnit>],
+    required: &HashSet<usize>,
     shed: &str,
     full_bytes: usize,
     path: &Path,
-) -> (String, usize) {
+) -> Candidate {
     // Size the marker against the widest numbers it can carry, so the budget it
     // comes out of is never too small; the real numbers are no wider, since what
     // is kept never exceeds the whole map and what is dropped never exceeds the
@@ -316,9 +388,7 @@ fn cap_map(
         .saturating_sub(1);
     let ranks = survival_ranks(units, leaner);
     let mut order: Vec<usize> = (0..units.len()).collect();
-    // A stable sort, so units of one rank keep the file's order — and with it the
-    // guarantee that a parent is decided before what nests under it, since a
-    // parent survives at least as far down the ladder as its members do.
+    // Stable, which is what decides a parent before its members.
     order.sort_by_key(|&i| std::cmp::Reverse(ranks[i]));
 
     let mut keep = vec![false; units.len()];
@@ -350,15 +420,21 @@ fn cap_map(
         .filter(|(_, k)| **k)
         .map(|(u, _)| u.text.as_str())
         .collect();
-    let delivered = units
-        .iter()
-        .zip(&keep)
-        .filter(|(u, k)| **k && matches!(u.kind, MapUnitKind::Declaration { .. }))
-        .count();
+    let (mut delivered, mut kept_required) = (0usize, 0usize);
+    for (unit, keep) in units.iter().zip(&keep) {
+        if let (true, MapUnitKind::Declaration { id }) = (*keep, unit.kind) {
+            delivered += 1;
+            kept_required += usize::from(required.contains(&id));
+        }
+    }
     let note = trim_note(len, full_bytes, dropped, shed, path);
     let out = with_note(kept.join("\n"), &note);
     debug_assert!(out.len() <= MAP_BUDGET, "trim overshot the budget");
-    (out, delivered)
+    Candidate {
+        payload: out,
+        required: kept_required,
+        delivered,
+    }
 }
 
 /// The line a trimmed map ends with. Separate from the cut so its width can be
@@ -647,7 +723,7 @@ mod tests {
             units.push(decl_unit("pub fn f() {}", id, None));
         }
         let full = map_bytes(&units);
-        let (out, _) = cap_map(&units, &[], "", full, Path::new("/tmp/x.rs"));
+        let out = cap_map(&units, &[], &HashSet::new(), "", full, Path::new("/tmp/x.rs")).payload;
         assert!(out.len() <= MAP_BUDGET, "{} bytes", out.len());
         assert!(out.starts_with("# header\n"));
         assert!(out.contains("map trimmed to"));
@@ -695,7 +771,7 @@ mod tests {
 
         for (label, units) in [("most of a map", many), ("header only", header_only)] {
             let full = map_bytes(&units);
-            let (out, _) = cap_map(&units, &[], "", full, Path::new("/tmp/x.rs"));
+            let out = cap_map(&units, &[], &HashSet::new(), "", full, Path::new("/tmp/x.rs")).payload;
             let (delivered, claimed) = delivered_and_claimed(&out);
             assert_eq!(delivered, claimed, "{label}: marker in {out:.0}");
             assert!(out.len() <= MAP_BUDGET, "{label}: {} bytes", out.len());
@@ -850,8 +926,22 @@ mod tests {
             ("no leaner render", Vec::new()),
             ("types outrank members", vec![types_only.clone()]),
         ] {
-            let (out, delivered) = cap_map(&units, &leaner, "", full, Path::new("/tmp/wide.java"));
-            assert!(delivered > 0, "{label}: the trim delivered nothing to check");
+            let Candidate {
+                payload: out,
+                delivered,
+                ..
+            } = cap_map(
+                &units,
+                &leaner,
+                &HashSet::new(),
+                "",
+                full,
+                Path::new("/tmp/wide.java"),
+            );
+            assert!(
+                delivered > 0,
+                "{label}: the trim delivered nothing to check"
+            );
             assert!(out.len() <= MAP_BUDGET, "{label}: {} bytes", out.len());
             assert!(out.contains("dropped"), "{label}: no trim was triggered");
 
@@ -962,6 +1052,122 @@ mod tests {
         );
     }
 
+    /// A payload never omits a declaration a whole candidate would have carried.
+    ///
+    /// The trim's budget is smaller than the fitting level's by the width of the
+    /// marker it has to carry, so a trim of a richer level can run out inside the
+    /// top rank. It then skips the one unit too wide for what is left and spends
+    /// the remainder on cheaper declarations a rank below, which out-counts the
+    /// whole candidate while missing part of the public surface that one carried.
+    /// The fixture is built for that: the public surface is grown to the largest
+    /// that still fits whole, its last member is wide enough to be the one
+    /// skipped, and the private methods behind it are cheap enough to more than
+    /// replace it by count.
+    #[test]
+    fn a_trimmed_candidate_never_omits_what_a_whole_one_carries() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("api.rs");
+        let surface = widest_public_surface_that_fits(&p);
+
+        write_public_surface(&p, surface);
+        match decide(&ev("Read", Some(p.clone()), false), &opts(), replacing()) {
+            Decision::Substitute { map } => {
+                assert!(map.len() <= MAP_BUDGET, "{} bytes", map.len());
+                assert_eq!(
+                    map.matches("pub fn api_").count(),
+                    surface,
+                    "the payload dropped part of a public surface that fits whole"
+                );
+                assert!(
+                    map.contains("pub fn wide"),
+                    "the wide public declaration is exactly the one a trim skips"
+                );
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    /// No payload crosses the ceiling, on either side of the fit boundary.
+    ///
+    /// The two paths size themselves differently — the trim reserves the byte its
+    /// marker sits on, a whole map is measured against the ceiling directly — so
+    /// the boundary between them is where a byte goes missing. Sampled below it,
+    /// on it, and above it, since a map measured *at* the ceiling is the one that
+    /// gets delivered over it when the marker's own line is not counted.
+    #[test]
+    fn no_payload_crosses_the_ceiling_around_the_fit_boundary() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("api.rs");
+        let surface = widest_public_surface_that_fits(&p);
+
+        let (mut whole, mut trimmed) = (0usize, 0usize);
+        for n in surface - 2..=surface + 2 {
+            write_public_surface(&p, n);
+            match decide(&ev("Read", Some(p.clone()), false), &opts(), replacing()) {
+                Decision::Substitute { map } => {
+                    assert!(
+                        map.len() <= MAP_BUDGET,
+                        "{n} public declarations delivered {} bytes",
+                        map.len()
+                    );
+                    if map.contains("map trimmed to") {
+                        trimmed += 1;
+                    } else {
+                        whole += 1;
+                    }
+                }
+                other => panic!("{n}: unexpected: {other:?}"),
+            }
+        }
+        assert!(
+            whole > 0 && trimmed > 0,
+            "the sweep stayed on one side of the boundary: {whole} whole, {trimmed} trimmed"
+        );
+    }
+
+    /// A type of `n` cheap public methods, one wide public method, and private
+    /// methods cheap enough that a trim can more than replace the wide one.
+    fn write_public_surface(path: &std::path::Path, n: usize) {
+        let params = (0..40)
+            .map(|k| format!("a{k}: u32"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let mut body = String::new();
+        for i in 0..n {
+            body.push_str(&format!(
+                "    pub fn api_{i:04}(&self, a: u32) -> u32 {{ a }}\n"
+            ));
+        }
+        body.push_str(&format!("    pub fn wide(&self, {params}) {{}}\n"));
+        for i in 0..2000 {
+            body.push_str(&format!("    fn h_{i:04}(&self) {{}}\n"));
+        }
+        std::fs::write(path, format!("pub struct S;\n\nimpl S {{\n{body}}}\n")).unwrap();
+    }
+
+    /// The largest public surface [`write_public_surface`] can give the file with
+    /// the shed level still fitting whole, which is the boundary both tests need.
+    fn widest_public_surface_that_fits(path: &std::path::Path) -> usize {
+        let fits = |n: usize| {
+            write_public_surface(path, n);
+            let res = crate::main_helpers::parse_file_for_hook(path).unwrap();
+            let units = crate::core::render_map_units(&res, &map_levels()[2].1);
+            with_note(join_units(&units), &shed_note(map_levels()[2].0, path)).len() <= MAP_BUDGET
+        };
+        let (mut small, mut large) = (1usize, 4000usize);
+        while small + 1 < large {
+            let mid = (small + large) / 2;
+            if fits(mid) {
+                small = mid;
+            } else {
+                large = mid;
+            }
+        }
+        assert!(fits(small), "no public surface fits whole");
+        assert!(!fits(small + 1), "{small} is not the boundary");
+        small
+    }
+
     /// A declaration keeps its number when the options drop its neighbours.
     ///
     /// [`survival_ranks`] matches two renders of one file by that number, so a
@@ -987,16 +1193,17 @@ mod tests {
                 })
                 .collect()
         };
-        let same_names = |part: &HashMap<usize, String>, whole: &HashMap<usize, String>, what: &str| {
-            for (id, text) in part {
-                assert_eq!(
-                    whole.get(id),
-                    Some(text),
-                    "{what}: declaration {id} is {text:?} in one render and {:?} in the other",
-                    whole.get(id)
-                );
-            }
-        };
+        let same_names =
+            |part: &HashMap<usize, String>, whole: &HashMap<usize, String>, what: &str| {
+                for (id, text) in part {
+                    assert_eq!(
+                        whole.get(id),
+                        Some(text),
+                        "{what}: declaration {id} is {text:?} in one render and {:?} in the other",
+                        whole.get(id)
+                    );
+                }
+            };
 
         let hidden = dir.path().join("hidden.rs");
         std::fs::write(

--- a/src/hook/decide.rs
+++ b/src/hook/decide.rs
@@ -126,12 +126,15 @@ fn render_map_for(path: &Path) -> Option<String> {
     // decide what to keep, and the loop reaches those levels next.
     let mut rendered: Vec<Vec<MapUnit>> = Vec::with_capacity(levels.len());
     let mut full_bytes = 0usize;
-    // The candidate that delivers the most declarations, not the first that fits.
-    // Shedding is lossy in a different currency from trimming: a file of 2900
-    // private and 100 public functions fits once private items go, and that
-    // "success" hands over 100 declarations while leaving 93% of the budget
-    // unused, where trimming the level before it carries 1871 — the same 100
-    // publics and 1771 of the helpers.
+    // Which level to spend the budget on is decided by the declarations it
+    // delivers, not by which one fits first: a file of 2900 private and 100
+    // public functions fits once private items go, and that "success" hands over
+    // 100 declarations while leaving 93% of the budget unused, where trimming the
+    // level before it carries 1871 — the same 100 publics and 1771 of the
+    // helpers. How the budget is then spent *within* a level is `cap_map`'s rule
+    // and a different one: it funds by rank, which on a file of wide type headers
+    // and cheap members buys fewer declarations than file order would, and buys
+    // the right ones.
     let mut best: Option<(usize, String)> = None;
     for (i, (shed, opts)) in levels.iter().enumerate() {
         if rendered.len() == i {
@@ -305,9 +308,12 @@ fn cap_map(
     // comes out of is never too small; the real numbers are no wider, since what
     // is kept never exceeds the whole map and what is dropped never exceeds the
     // declaration count.
-    let budget = MAP_BUDGET.saturating_sub(
-        trim_note(map_bytes(units), full_bytes, entry_count(units), shed, path).len(),
-    );
+    // One more byte is held back for the newline the marker goes on.
+    let budget = MAP_BUDGET
+        .saturating_sub(
+            trim_note(map_bytes(units), full_bytes, entry_count(units), shed, path).len(),
+        )
+        .saturating_sub(1);
     let ranks = survival_ranks(units, leaner);
     let mut order: Vec<usize> = (0..units.len()).collect();
     // A stable sort, so units of one rank keep the file's order — and with it the
@@ -317,14 +323,18 @@ fn cap_map(
 
     let mut keep = vec![false; units.len()];
     let mut dropped_parents: HashSet<usize> = HashSet::new();
+    // The bytes the kept units occupy once joined, which is the number the marker
+    // reports: a unit costs a newline only when it follows another.
     let mut len = 0usize;
+    let mut kept_units = 0usize;
     let mut dropped = 0usize;
     for i in order {
         let unit = &units[i];
         let orphaned = unit.parent.is_some_and(|p| dropped_parents.contains(&p));
-        let cost = unit.text.len() + 1;
+        let cost = unit.text.len() + usize::from(kept_units > 0);
         if !orphaned && len + cost <= budget {
             len += cost;
+            kept_units += 1;
             keep[i] = true;
             continue;
         }
@@ -645,6 +655,68 @@ mod tests {
         assert!(marker.starts_with("# note:"), "marker glued on: {marker}");
     }
 
+    /// The size a trimmed map reports is the size it delivers.
+    ///
+    /// That number is what a reader weighs against the full map's, so it has to
+    /// count the bytes above the marker rather than the trim's own bookkeeping —
+    /// charging every kept unit a newline overcounts by the one the last unit
+    /// does not get. Sampled where the trim keeps most of a map, where the
+    /// budget admits nothing but the header, and through `decide`, where a shed
+    /// label sits in the same marker.
+    #[test]
+    fn a_trim_reports_the_bytes_it_delivers() {
+        /// The bytes above the marker, and the number the marker claims for them.
+        fn delivered_and_claimed(out: &str) -> (usize, usize) {
+            let (map, marker) = match out.rfind("\n# note:") {
+                Some(at) => (&out[..at], &out[at + 1..]),
+                None => ("", out),
+            };
+            let claimed = marker
+                .split("map trimmed to ")
+                .nth(1)
+                .and_then(|rest| rest.split(' ').next())
+                .unwrap_or_else(|| panic!("no trim marker in: {marker}"))
+                .parse()
+                .unwrap();
+            (map.len(), claimed)
+        }
+
+        let mut many = vec![preamble("# header")];
+        while map_bytes(&many) <= MAX_MAP_BYTES * 2 {
+            let id = many.len();
+            many.push(decl_unit(&format!("pub fn f{id}() {{}}"), id, None));
+        }
+        // Nothing but the header can fit: every declaration is wider than the
+        // whole budget, which is the path that keeps a single unit.
+        let header_only = vec![
+            preamble("# header"),
+            decl_unit(&format!("pub fn wide({})", "a: u32, ".repeat(20_000)), 0, None),
+        ];
+
+        for (label, units) in [("most of a map", many), ("header only", header_only)] {
+            let full = map_bytes(&units);
+            let (out, _) = cap_map(&units, &[], "", full, Path::new("/tmp/x.rs"));
+            let (delivered, claimed) = delivered_and_claimed(&out);
+            assert_eq!(delivered, claimed, "{label}: marker in {out:.0}");
+            assert!(out.len() <= MAP_BUDGET, "{label}: {} bytes", out.len());
+        }
+
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("bundle.rs");
+        let doc = "/// ".to_string() + &"documented ".repeat(20);
+        let src: String = (0..8000)
+            .map(|i| format!("{doc}\npub fn f{i}() {{}}\n"))
+            .collect();
+        std::fs::write(&p, &src).unwrap();
+        match decide(&ev("Read", Some(p), false), &opts(), replacing()) {
+            Decision::Substitute { map } => {
+                let (delivered, claimed) = delivered_and_claimed(&map);
+                assert_eq!(delivered, claimed, "through decide");
+            }
+            other => panic!("expected a trimmed map: {other:?}"),
+        }
+    }
+
     /// One unreadably wide declaration must not take the rest of the map with it.
     ///
     /// Regression guard: the trim used to stop at the first line that did not fit,
@@ -712,10 +784,13 @@ mod tests {
     /// type — a map asserting a structure the file does not have, which is worse
     /// than a shorter one. The fixture puts the headers far above their members
     /// in width, which is the window where a header cannot fit and its members
-    /// still can, and hands `cap_map` no leaner render, so the budget is spent in
-    /// file order and the parent rule is the only thing holding. The invariant
-    /// checked is exactly the claim the function makes: every declaration the
-    /// trim kept still has all of its ancestors.
+    /// still can. Both funding orders are run over it: with no leaner render
+    /// every rank is equal and the budget goes out in file order, and with one
+    /// that carries the outer types alone a header is funded long after members
+    /// that precede it, which is the order a real ladder produces. The
+    /// invariants checked are the two claims the function makes — every
+    /// declaration it kept still has all of its ancestors, and what it kept is
+    /// written back in the file's order whatever order it was funded in.
     #[test]
     fn a_trim_never_keeps_a_unit_whose_parent_it_dropped() {
         let mut units = vec![preamble("# header")];
@@ -746,25 +821,18 @@ mod tests {
             units.push(separator());
             id += 4;
         }
-
-        let full = map_bytes(&units);
-        let (out, delivered) = cap_map(&units, &[], "", full, Path::new("/tmp/wide.java"));
-        assert!(delivered > 0, "the trim must deliver something to check");
-        assert!(out.len() <= MAP_BUDGET, "{} bytes", out.len());
-        assert!(out.contains("dropped"), "the fixture must trigger a trim");
+        // The leanest level of a ladder that keeps types and sheds their
+        // members: it gives every header a rank its members do not have.
+        let types_only: Vec<MapUnit> = units
+            .iter()
+            .filter(|u| u.parent.is_none() && matches!(u.kind, MapUnitKind::Declaration { .. }))
+            .cloned()
+            .collect();
 
         let parent_of: HashMap<usize, Option<usize>> = units
             .iter()
             .filter_map(|u| match u.kind {
                 MapUnitKind::Declaration { id } => Some((id, u.parent)),
-                _ => None,
-            })
-            .collect();
-        let kept: HashSet<usize> = units
-            .iter()
-            .filter(|u| out.contains(u.text.as_str()))
-            .filter_map(|u| match u.kind {
-                MapUnitKind::Declaration { id } => Some(id),
                 _ => None,
             })
             .collect();
@@ -776,21 +844,68 @@ mod tests {
                 .unwrap_or_default()
         };
 
-        let mut orphans: Vec<String> = Vec::new();
-        for &id in &kept {
-            let mut ancestor = parent_of[&id];
-            while let Some(a) = ancestor {
-                if !kept.contains(&a) {
-                    orphans.push(format!("{:?} kept without {:?}", text_of(id), text_of(a)));
+        let full = map_bytes(&units);
+        let mut headers_kept: Vec<usize> = Vec::new();
+        for (label, leaner) in [
+            ("no leaner render", Vec::new()),
+            ("types outrank members", vec![types_only.clone()]),
+        ] {
+            let (out, delivered) = cap_map(&units, &leaner, "", full, Path::new("/tmp/wide.java"));
+            assert!(delivered > 0, "{label}: the trim delivered nothing to check");
+            assert!(out.len() <= MAP_BUDGET, "{label}: {} bytes", out.len());
+            assert!(out.contains("dropped"), "{label}: no trim was triggered");
+
+            let mut kept: HashSet<usize> = HashSet::new();
+            let mut offsets: Vec<usize> = Vec::new();
+            let mut members = 0usize;
+            let mut headers = 0usize;
+            for unit in &units {
+                let MapUnitKind::Declaration { id } = unit.kind else {
+                    continue;
+                };
+                let Some(at) = out.find(unit.text.as_str()) else {
+                    continue;
+                };
+                kept.insert(id);
+                offsets.push(at);
+                if unit.parent.is_some() {
+                    members += 1;
+                } else {
+                    headers += 1;
                 }
-                ancestor = parent_of[&a];
             }
+            assert!(
+                members > 0,
+                "{label}: no member survived, so nothing exercises the parent rule"
+            );
+            assert!(
+                offsets.windows(2).all(|w| w[0] < w[1]),
+                "{label}: the kept units are not in the file's order"
+            );
+
+            let mut orphans: Vec<String> = Vec::new();
+            for &id in &kept {
+                let mut ancestor = parent_of[&id];
+                while let Some(a) = ancestor {
+                    if !kept.contains(&a) {
+                        orphans.push(format!("{:?} kept without {:?}", text_of(id), text_of(a)));
+                    }
+                    ancestor = parent_of[&a];
+                }
+            }
+            assert!(
+                orphans.is_empty(),
+                "{label}: orphaned units: {:#?}",
+                &orphans[..orphans.len().min(3)]
+            );
+            headers_kept.push(headers);
         }
-        assert!(!kept.is_empty(), "the fixture kept nothing to check");
+        // Without this the second case could be funding in file order too, and
+        // the run above would prove nothing the first one did not.
         assert!(
-            orphans.is_empty(),
-            "orphaned units: {:#?}",
-            &orphans[..orphans.len().min(3)]
+            headers_kept[1] > headers_kept[0],
+            "ranking changed nothing: {} headers either way",
+            headers_kept[0]
         );
     }
 
@@ -851,32 +966,20 @@ mod tests {
     ///
     /// [`survival_ranks`] matches two renders of one file by that number, so a
     /// number that shifted with the options would rank one declaration by
-    /// another's survival — and a shift is what a filtered-out *type* causes,
-    /// since its members are numbered too and never rendered. The fixture hides
-    /// a type with members behind `include_private`.
+    /// another's survival. Two paths drop a declaration without rendering it, and
+    /// each has to number what it skipped: the visibility filter, which skips a
+    /// type and everything under it, and the member cap, which skips a member and
+    /// everything under *that*. The cap is the one the leanest level of the
+    /// ladder sets, so its numbering is what the top rank is read from. It is
+    /// sampled below, at, and above the member count, since a cap equal to the
+    /// count is the one that cuts nothing.
     #[test]
     fn a_declaration_keeps_its_number_across_renders() {
         use crate::core::MapOptions;
         let dir = TempDir::new().unwrap();
-        let p = dir.path().join("hidden.rs");
-        std::fs::write(
-            &p,
-            "struct Hidden {\n    a: u32,\n    b: u32,\n}\n\npub fn api(x: u32) -> u32 { x }\n",
-        )
-        .unwrap();
-        let res = crate::main_helpers::parse_file_for_hook(&p).unwrap();
-        let full = crate::core::render_map_units(&res, &MapOptions::default());
-        let lean = crate::core::render_map_units(
-            &res,
-            &MapOptions {
-                include_private: false,
-                include_fields: false,
-                ..MapOptions::default()
-            },
-        );
-
-        let named = |units: &[MapUnit]| -> HashMap<usize, String> {
-            units
+        let numbered = |path: &std::path::Path, opts: &MapOptions| -> HashMap<usize, String> {
+            let res = crate::main_helpers::parse_file_for_hook(path).unwrap();
+            crate::core::render_map_units(&res, opts)
                 .iter()
                 .filter_map(|u| match u.kind {
                     MapUnitKind::Declaration { id } => Some((id, u.text.clone())),
@@ -884,28 +987,79 @@ mod tests {
                 })
                 .collect()
         };
-        let (full_by_id, lean_by_id) = (named(&full), named(&lean));
-        assert!(
-            full_by_id.len() > lean_by_id.len() + 1,
-            "the fixture must hide a type and its members: {} of {}",
-            lean_by_id.len(),
-            full_by_id.len()
+        let same_names = |part: &HashMap<usize, String>, whole: &HashMap<usize, String>, what: &str| {
+            for (id, text) in part {
+                assert_eq!(
+                    whole.get(id),
+                    Some(text),
+                    "{what}: declaration {id} is {text:?} in one render and {:?} in the other",
+                    whole.get(id)
+                );
+            }
+        };
+
+        let hidden = dir.path().join("hidden.rs");
+        std::fs::write(
+            &hidden,
+            "struct Hidden {\n    a: u32,\n    b: u32,\n}\n\npub fn api(x: u32) -> u32 { x }\n",
+        )
+        .unwrap();
+        let full = numbered(&hidden, &MapOptions::default());
+        let lean = numbered(
+            &hidden,
+            &MapOptions {
+                include_private: false,
+                include_fields: false,
+                ..MapOptions::default()
+            },
         );
-        for (id, text) in &lean_by_id {
-            assert_eq!(
-                full_by_id.get(id),
-                Some(text),
-                "declaration {id} is {text:?} in one render and {:?} in the other",
-                full_by_id.get(id)
-            );
+        assert!(
+            full.len() > lean.len() + 1,
+            "the fixture must hide a type and its members: {} of {}",
+            lean.len(),
+            full.len()
+        );
+        same_names(&lean, &full, "visibility filter");
+
+        // A type of six members, with a declaration after it whose number is the
+        // one the skip has to get right. No adapter nests a declaration inside a
+        // member, so the subtree half of that arithmetic is defensive and only
+        // the cut member itself can be pinned here.
+        let widget = dir.path().join("widget.py");
+        let mut src = String::from("class Widget:\n");
+        for i in 0..6 {
+            src.push_str(&format!("    def m{i}(self):\n        pass\n"));
         }
+        src.push_str("\ndef api():\n    pass\n");
+        std::fs::write(&widget, &src).unwrap();
+        let full = numbered(&widget, &MapOptions::default());
+        assert_eq!(
+            full.len(),
+            8,
+            "the fixture must be one type of six members plus a function: {full:?}"
+        );
+        let mut cut = 0usize;
+        for cap in [2usize, 6, 7] {
+            let capped = numbered(
+                &widget,
+                &MapOptions {
+                    max_members: Some(cap),
+                    ..MapOptions::default()
+                },
+            );
+            if capped.len() < full.len() {
+                cut += 1;
+            }
+            same_names(&capped, &full, &format!("member cap {cap}"));
+        }
+        assert_eq!(cut, 1, "only a cap below the member count may cut");
     }
 
     /// A trim spends the budget on the public surface before the rest.
     ///
     /// Filling in file order handed over 1733 private helpers and not one of a
     /// file's 500 public functions, because the publics run to the end of a file
-    /// three times the budget. The shed level that keeps exactly those publics is
+    /// twice the budget. The shed level that keeps exactly those publics is
     /// 19 KB, so that payload was worse than a candidate it outranked on count
     /// alone. Interleaving the two in the fixture is deliberate: with the publics
     /// in one block at the front, file order would keep them by luck.

--- a/src/hook/decide.rs
+++ b/src/hook/decide.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use super::event::{Decision, ToolCallEvent};
+use super::event::{Channel, Decision, ToolCallEvent};
 
 #[derive(Debug, Clone)]
 pub struct DecideOpts {
@@ -8,32 +8,32 @@ pub struct DecideOpts {
     pub always: bool,
 }
 
-pub fn decide(event: &ToolCallEvent, opts: &DecideOpts) -> Decision {
+pub fn decide(event: &ToolCallEvent, opts: &DecideOpts, channel: Channel) -> Decision {
     if event.tool_name != "Read" {
         return Decision::PassThrough;
     }
     let Some(path) = event.file_path.as_deref() else {
         return Decision::PassThrough;
     };
-    if event.has_offset_or_limit {
+    // A range request is the caller asking for source, so substituting would
+    // withhold what they asked for — unless the read already failed, in which
+    // case it returned no source and the map is purely additive. The host's own
+    // refusal tells the agent to retry with a range, so gating that retry out
+    // would leave the hole this event exists to close.
+    if event.has_offset_or_limit && !channel.is_additive() {
         return Decision::PassThrough;
     }
     if !crate::main_helpers::can_parse_for_hook(path) {
         return Decision::PassThrough;
     }
-    if !opts.always {
+    if !opts.always && !channel.is_additive() {
         match line_count_at_least(path, opts.min_lines) {
             Ok(true) => {}
             _ => return Decision::PassThrough,
         }
     }
     match render_map_for(path) {
-        Some(content) => Decision::Substitute {
-            content: format!(
-                "# ast-bro substituted this structure map for the full Read: nothing failed.\n# The map below is the answer, with line ranges. For more detail, re-read with\n# offset/limit, or `ast-bro show <file> <symbol>` for a symbol's body.\n\n{}\n",
-                content
-            ),
-        },
+        Some(map) => Decision::Substitute { map },
         None => Decision::PassThrough,
     }
 }
@@ -57,12 +57,176 @@ fn line_count_at_least(path: &Path, threshold: usize) -> std::io::Result<bool> {
     Ok(false)
 }
 
+/// Ceiling on what the hook delivers, in bytes, notice included.
+///
+/// The host refuses a read at roughly 25k tokens, so answering with a payload of
+/// the same order defeats the point. 64 KB is about 16k tokens: under the limit
+/// the refusal was about, and above every real map measured — Apache Calcite's
+/// `SqlFunctions.java`, 7771 hand-written lines and the largest map in that
+/// repository, fits once doc comments and attributes are shed. What does not fit
+/// is a minified bundle, whose size is declaration count rather than detail, and
+/// that is what [`cap_map`] is for.
+///
+/// The ceiling is hard: [`MAP_BUDGET`] holds back room for the channel notice and
+/// the marker, both of which are built before anything is cut.
+const MAX_MAP_BYTES: usize = 64 * 1024;
+
+/// What a map may occupy once the channel notice is accounted for.
+///
+/// `io::payload` prepends a notice to every map, so a map sized against
+/// [`MAX_MAP_BYTES`] alone would be delivered above it.
+const MAP_BUDGET: usize = MAX_MAP_BYTES - super::io::MAX_NOTICE_BYTES;
+
+/// Detail the hook sheds, in order, to bring a map under [`MAP_BUDGET`].
+///
+/// Shedding beats truncating because the reader needs every declaration: a map
+/// that stops halfway reads as a file that ends halfway, and they act on the
+/// absence. The order sheds what costs no declarations first — doc comments and
+/// attributes are detail about a declaration, private items and fields are
+/// declarations.
+///
+/// Measured on Apache Calcite's `SqlFunctions.java`, the largest map in that
+/// repository at 7771 hand-written lines: 142,692 bytes in full, 74,607 without
+/// docs or attributes with all 920 declarations intact, 64,146 once private items
+/// and fields go, keeping 799. No level under the budget keeps all 920, which is
+/// why the payload names what it shed and where to get the rest.
+fn map_levels() -> [(&'static str, crate::core::MapOptions); 4] {
+    use crate::core::MapOptions;
+    let lossless = MapOptions {
+        include_docs: false,
+        include_attributes: false,
+        ..MapOptions::default()
+    };
+    let lean = MapOptions {
+        include_private: false,
+        include_fields: false,
+        ..lossless.clone()
+    };
+    let leanest = MapOptions {
+        max_members: Some(50),
+        ..lean.clone()
+    };
+    [
+        ("", MapOptions::default()),
+        ("doc comments and attributes", lossless),
+        ("doc comments, attributes, fields, and private items", lean),
+        (
+            "doc comments, attributes, fields, private items, and members past 50 per type",
+            leanest,
+        ),
+    ]
+}
+
 fn render_map_for(path: &Path) -> Option<String> {
     let res = crate::main_helpers::parse_file_for_hook(path)?;
-    Some(crate::core::render_map(
-        &res,
-        &crate::core::MapOptions::default(),
-    ))
+    let mut full_bytes = 0usize;
+    // The smallest map any level produced, for the case where none of them fit
+    // and the marker has to say both what was shed and what was cut. Smallest
+    // rather than last: the `max_members` level trades members for `+N more`
+    // markers, which can leave it larger than the level before it.
+    let mut smallest: Option<(&'static str, String)> = None;
+    for (shed, opts) in map_levels() {
+        let map = crate::core::render_map(&res, &opts);
+        if shed.is_empty() {
+            full_bytes = map.len();
+        }
+        // Naming what is missing is the whole point: absence of a private helper
+        // from this map must not read as absence from the file. The note is built
+        // before the fit decision so it counts against the budget.
+        let note = if shed.is_empty() {
+            String::new()
+        } else {
+            shed_note(shed, path)
+        };
+        if map.len() + note.len() <= MAP_BUDGET {
+            return Some(map + &note);
+        }
+        if smallest.as_ref().is_none_or(|(_, best)| map.len() < best.len()) {
+            smallest = Some((shed, map));
+        }
+    }
+    let (shed, map) = smallest.expect("map_levels is never empty");
+    Some(cap_map(map, shed, full_bytes, path))
+}
+
+/// The line a shed map ends with, naming what is gone and how to get it.
+fn shed_note(shed: &str, path: &Path) -> String {
+    format!(
+        "# note: {shed} dropped to fit the {MAX_MAP_BYTES} byte cap; `ast-bro map {}` for the rest\n",
+        path.display()
+    )
+}
+
+/// Drops whole lines from `map` until it fits [`MAP_BUDGET`], saying what went.
+///
+/// The last resort, reached only when shedding every level of detail still left
+/// the map too big — a minified bundle, where the size is thousands of
+/// declarations rather than detail about a few. A silently short map is worse
+/// than a trimmed one: the reader treats a map as the file's whole shape and
+/// concludes a symbol does not exist, so the marker names what was shed on the
+/// way here, how many lines went, and the file's real size.
+///
+/// Over-long lines are skipped rather than ending the scan. One declaration can
+/// be arbitrarily wide — a generated signature with thousands of parameters — and
+/// stopping at it would drop every declaration after it, which is the failure
+/// this function exists to prevent.
+fn cap_map(map: String, shed: &str, full_bytes: usize, path: &Path) -> String {
+    let total_lines = map.split_inclusive('\n').count();
+    // Size the marker against the widest numbers it can carry, so the budget it
+    // comes out of is never too small; the real numbers are no wider, since
+    // `kept` never exceeds `map.len()` and `dropped` never exceeds `total_lines`.
+    let budget = MAP_BUDGET
+        .saturating_sub(trim_note(map.len(), full_bytes, total_lines, shed, path).len());
+    let mut kept = String::with_capacity(budget.min(map.len()));
+    let mut dropped = 0usize;
+    // Indentation is the only parent-child signal a map carries, so a skipped
+    // line takes its children with it. Keeping a member whose type header did
+    // not fit would file it under the previous type — a map that asserts a
+    // structure the file does not have, which is worse than a shorter one.
+    let mut skipped_parent: Option<usize> = None;
+    for line in map.split_inclusive('\n') {
+        let indent = line.len() - line.trim_start_matches(' ').len();
+        if let Some(level) = skipped_parent {
+            if indent > level {
+                dropped += 1;
+                continue;
+            }
+            skipped_parent = None;
+        }
+        if kept.len() + line.len() <= budget {
+            kept.push_str(line);
+        } else {
+            dropped += 1;
+            skipped_parent = Some(indent);
+        }
+    }
+    let note = trim_note(kept.len(), full_bytes, dropped, shed, path);
+    debug_assert!(
+        kept.len() + note.len() <= MAP_BUDGET,
+        "trim overshot the budget"
+    );
+    kept + &note
+}
+
+/// The line a trimmed map ends with. Separate from the cut so its width can be
+/// measured before the cut is chosen.
+fn trim_note(kept: usize, full_bytes: usize, dropped: usize, shed: &str, path: &Path) -> String {
+    let shed_clause = if shed.is_empty() {
+        String::new()
+    } else {
+        format!("{shed} dropped, then ")
+    };
+    format!(
+        "# note: {shed_clause}map trimmed to {kept} bytes from a {full_bytes} byte full map{}; \
+`ast-bro map {}` for the whole map, `ast-bro show {} <symbol>` for one body\n",
+        if dropped > 0 {
+            format!(", {dropped} line(s) dropped")
+        } else {
+            String::new()
+        },
+        path.display(),
+        path.display()
+    )
 }
 
 #[cfg(test)]
@@ -86,15 +250,25 @@ mod tests {
         }
     }
 
+    /// The channel a substitution replaces something on.
+    fn replacing() -> Channel {
+        Channel::Deny
+    }
+
+    /// The channel a substitution only adds to, after the read already failed.
+    fn additive() -> Channel {
+        Channel::Augment
+    }
+
     #[test]
     fn pass_through_for_non_read_tool() {
-        let d = decide(&ev("Bash", Some(PathBuf::from("a.rs")), false), &opts());
+        let d = decide(&ev("Bash", Some(PathBuf::from("a.rs")), false), &opts(), replacing());
         assert!(matches!(d, Decision::PassThrough));
     }
 
     #[test]
     fn pass_through_when_offset_or_limit_set() {
-        let d = decide(&ev("Read", Some(PathBuf::from("a.rs")), true), &opts());
+        let d = decide(&ev("Read", Some(PathBuf::from("a.rs")), true), &opts(), replacing());
         assert!(matches!(d, Decision::PassThrough));
     }
 
@@ -103,6 +277,7 @@ mod tests {
         let d = decide(
             &ev("Read", Some(PathBuf::from("img.png")), false),
             &opts(),
+            replacing(),
         );
         assert!(matches!(d, Decision::PassThrough));
     }
@@ -112,7 +287,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let p = dir.path().join("small.rs");
         std::fs::write(&p, "fn main() {}\n").unwrap();
-        let d = decide(&ev("Read", Some(p), false), &opts());
+        let d = decide(&ev("Read", Some(p), false), &opts(), replacing());
         assert!(matches!(d, Decision::PassThrough));
     }
 
@@ -125,30 +300,304 @@ mod tests {
             s.push_str(&format!("fn f{}() {{}}\n", i));
         }
         std::fs::write(&p, &s).unwrap();
-        let d = decide(&ev("Read", Some(p), false), &opts());
+        let d = decide(&ev("Read", Some(p), false), &opts(), replacing());
         match d {
-            Decision::Substitute { content } => {
-                assert!(content.contains("fn f"));
-                // The notice leads the payload and appears exactly once —
-                // a duplicated instruction is pure noise on the tool's
-                // highest-frequency output path.
-                assert!(content.starts_with("# ast-bro substituted"));
-                assert_eq!(
-                    content.matches("# ast-bro substituted").count(),
-                    1,
-                    "substitution notice must appear exactly once:\n{content}"
+            // The map arrives undecorated: the notice that leads it is the
+            // channel's business, and `io` is where it gets pinned.
+            Decision::Substitute { map } => {
+                assert!(map.contains("fn f"));
+                assert!(
+                    !map.contains("ast-bro substituted"),
+                    "decide() must not frame the map:\n{map}"
                 );
-                // The notice must tell the agent what it got and how to
-                // recover detail — not just that a substitution happened.
-                for phrase in ["structure map", "offset/limit", "ast-bro show"] {
-                    assert!(
-                        content.contains(phrase),
-                        "notice must mention '{phrase}':\n{content}"
-                    );
-                }
             }
             other => panic!("unexpected: {:?}", other),
         }
+    }
+
+    /// A read the host refused is substituted whatever its line count.
+    ///
+    /// The refusal counts bytes, not lines — a 90-line file of 355 KB trips
+    /// it — so gating on lines would silence the map for exactly the reads that
+    /// need it. Regression guard: this passed through before the gate was fixed.
+    #[test]
+    fn failed_read_substitutes_below_the_line_threshold() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("wide.rs");
+        let pad = "x".repeat(4000);
+        let mut src = String::new();
+        for i in 0..20 {
+            src.push_str(&format!("pub fn f{}() {{ let s = \"{}\"; let _ = s; }}\n", i, pad));
+        }
+        std::fs::write(&p, &src).unwrap();
+        assert!(src.lines().count() < 200, "the fixture must be under the threshold");
+
+        let e = ev("Read", Some(p.clone()), false);
+        assert!(
+            matches!(decide(&e, &opts(), replacing()), Decision::PassThrough),
+            "a successful read of a short file is still passed through"
+        );
+        match decide(&e, &opts(), additive()) {
+            Decision::Substitute { map } => assert!(map.contains("pub fn f0")),
+            other => panic!("a failed read must be substituted: {other:?}"),
+        }
+    }
+
+    /// A file the hook cannot parse has no map to offer, failed read or not.
+    #[test]
+    fn failed_read_still_needs_a_parseable_file() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("img.png");
+        std::fs::write(&p, "not source").unwrap();
+        let e = ev("Read", Some(p), false);
+        assert!(matches!(decide(&e, &opts(), additive()), Decision::PassThrough));
+    }
+
+    /// A ranged retry of a read the host refused still gets the map.
+    ///
+    /// The refusal tells the agent to retry with `offset`/`limit`, and a slice of
+    /// an over-large file can be refused again. Passing through there would hand
+    /// back a second bare error — the hole this event exists to close. On a
+    /// successful read the same range request is passed through, because there
+    /// the caller is asking for source and gets it.
+    #[test]
+    fn failed_ranged_read_is_substituted_but_a_successful_one_is_not() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("big.rs");
+        std::fs::write(&p, "fn f() {}\n".repeat(300)).unwrap();
+
+        let e = ev("Read", Some(p), true);
+        assert!(
+            matches!(decide(&e, &opts(), replacing()), Decision::PassThrough),
+            "a range on a successful read is the caller asking for source"
+        );
+        match decide(&e, &opts(), additive()) {
+            Decision::Substitute { map } => assert!(map.contains("fn f")),
+            other => panic!("a refused ranged read must still get the map: {other:?}"),
+        }
+    }
+
+    /// A minified bundle is bounded by truncation, and says so.
+    ///
+    /// Its size is declaration count, so shedding detail cannot help: the ladder
+    /// runs out and `cap_map` is the backstop. The marker has to name a route to
+    /// the rest, because the names a reader would `show` are what got dropped.
+    #[test]
+    fn a_minified_bundle_is_trimmed_and_points_at_the_whole_map() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("bundle.rs");
+        let src: String = (0..20000).map(|i| format!("pub fn f{i}() {{}} ")).collect();
+        std::fs::write(&p, &src).unwrap();
+
+        match decide(&ev("Read", Some(p.clone()), false), &opts(), additive()) {
+            Decision::Substitute { map } => {
+                assert!(
+                    map.len() <= MAP_BUDGET,
+                    "the budget counts the marker and the notice: {} bytes against {}",
+                    map.len(),
+                    MAP_BUDGET
+                );
+                assert!(map.contains("map trimmed to"), "no marker:\n{}", &map[..300]);
+                assert!(map.contains("ast-bro map "), "no route to the rest");
+                assert!(map.starts_with('#'), "the header line must survive");
+            }
+            other => panic!("expected a trimmed map: {other:?}"),
+        }
+    }
+
+    /// A hand-written file too big for the full map keeps every declaration.
+    ///
+    /// The reader needs the declarations, not the doc comments, so detail is shed
+    /// before anything is cut — and what was shed is named, or an absent private
+    /// helper reads as one that does not exist. Regression guard: under a
+    /// truncating-only cap this file lost most of its declarations.
+    #[test]
+    fn a_large_hand_written_file_sheds_detail_instead_of_declarations() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("wide.rs");
+        let doc = "/// ".to_string() + &"documentation ".repeat(40);
+        let mut src = String::new();
+        for i in 0..900 {
+            src.push_str(&format!("{doc}\npub fn f{i}(a: u32, b: u32) -> u32 {{ a + b }}\n"));
+        }
+        std::fs::write(&p, &src).unwrap();
+
+        let full = crate::core::render_map(
+            &crate::main_helpers::parse_file_for_hook(&p).unwrap(),
+            &crate::core::MapOptions::default(),
+        );
+        assert!(
+            full.len() > MAX_MAP_BYTES,
+            "fixture must exceed the cap: {} bytes",
+            full.len()
+        );
+
+        match decide(&ev("Read", Some(p), false), &opts(), additive()) {
+            Decision::Substitute { map } => {
+                assert!(map.len() <= MAP_BUDGET, "{} bytes", map.len());
+                assert!(!map.contains("map trimmed to"), "must shed, not truncate");
+                assert!(map.contains("doc comments"), "must name what it shed");
+                for name in ["pub fn f0", "pub fn f899"] {
+                    assert!(map.contains(name), "lost {name}: declarations must survive");
+                }
+            }
+            other => panic!("expected a shed map: {other:?}"),
+        }
+    }
+
+    /// A map under the cap is handed over byte for byte.
+    #[test]
+    fn a_map_under_the_cap_is_untouched() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("big.rs");
+        std::fs::write(&p, "fn f() {}\n".repeat(300)).unwrap();
+        match decide(&ev("Read", Some(p), false), &opts(), replacing()) {
+            Decision::Substitute { map } => {
+                assert!(map.len() < MAX_MAP_BYTES);
+                assert!(!map.contains("more line(s) dropped"));
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    /// `cap_map` cuts on a line boundary even when the last line has no newline,
+    /// which is what a file without a trailing newline produces.
+    #[test]
+    fn cap_map_handles_a_map_without_a_trailing_newline() {
+        let line = "pub fn f() {}\n";
+        let mut map = String::from("# header\n");
+        while map.len() <= MAX_MAP_BYTES * 2 {
+            map.push_str(line);
+        }
+        map.pop(); // last line now ends the string with no newline
+        let len = map.len();
+        let out = cap_map(map, "", len, Path::new("/tmp/x.rs"));
+        assert!(out.len() <= MAP_BUDGET, "{} bytes", out.len());
+        assert!(out.starts_with("# header\n"));
+        assert!(out.contains("map trimmed to"));
+    }
+
+    /// One unreadably wide declaration must not take the rest of the map with it.
+    ///
+    /// Regression guard: the trim used to stop at the first line that did not fit,
+    /// so a generated signature with thousands of parameters left a payload with
+    /// no declarations at all — the failure the trim exists to prevent.
+    #[test]
+    fn a_single_enormous_declaration_does_not_hide_the_rest() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("wide.rs");
+        let params: String = (0..9000).map(|i| format!("a{i}: u32, ")).collect();
+        let mut src = format!("pub fn enormous({params}) {{}}\n");
+        for i in 0..400 {
+            src.push_str(&format!("pub fn api_{i}() {{}}\n"));
+        }
+        std::fs::write(&p, &src).unwrap();
+
+        match decide(&ev("Read", Some(p), false), &opts(), replacing()) {
+            Decision::Substitute { map } => {
+                assert!(map.len() <= MAP_BUDGET, "{} bytes", map.len());
+                for name in ["pub fn api_0", "pub fn api_399"] {
+                    assert!(map.contains(name), "lost {name}:\n{}", &map[..300]);
+                }
+                assert!(map.contains("line(s) dropped"), "must say what it dropped");
+            }
+            other => panic!("expected a trimmed map: {other:?}"),
+        }
+    }
+
+    /// A payload that both shed detail and got trimmed says so, and quotes the
+    /// real file's map size rather than the already-shed one.
+    #[test]
+    fn a_trimmed_payload_still_names_what_was_shed() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("both.rs");
+        let doc = "/// ".to_string() + &"documented ".repeat(20);
+        let mut src = String::new();
+        for i in 0..4000 {
+            src.push_str(&format!("{doc}\nfn secret_helper_{i}() {{}}\n"));
+            src.push_str(&format!("{doc}\npub fn api_{i}() {{}}\n"));
+        }
+        std::fs::write(&p, &src).unwrap();
+
+        let full = crate::core::render_map(
+            &crate::main_helpers::parse_file_for_hook(&p).unwrap(),
+            &crate::core::MapOptions::default(),
+        );
+        match decide(&ev("Read", Some(p), false), &opts(), replacing()) {
+            Decision::Substitute { map } => {
+                assert!(map.len() <= MAP_BUDGET, "{} bytes", map.len());
+                let note = map.lines().last().unwrap();
+                assert!(note.contains("dropped, then"), "shed label missing: {note}");
+                assert!(
+                    note.contains(&full.len().to_string()),
+                    "must quote the full map's size ({}): {note}",
+                    full.len()
+                );
+            }
+            other => panic!("expected a trimmed map: {other:?}"),
+        }
+    }
+
+    /// A skipped line takes its children with it.
+    ///
+    /// Indentation is the only parent-child signal a map has, so a member kept
+    /// without its type header would be filed under the previous type — a map
+    /// asserting a structure the file does not have, which is worse than a
+    /// shorter one. The invariant checked is exactly that: every line the trim
+    /// kept still has each of its ancestors.
+    #[test]
+    fn a_trim_never_keeps_a_line_whose_parent_it_dropped() {
+        // Headers far wider than their members, so the budget runs out in the
+        // window where a header cannot fit but its members still can.
+        let mut map = String::from("# header\n");
+        let mut n = 2;
+        while map.len() <= MAP_BUDGET + 40_000 {
+            map.push_str(&format!("pub struct Wide{n}{}  L{n}\n", "X".repeat(2000)));
+            map.push_str(&format!("    pub fn m(&self)  L{}\n", n + 1));
+            map.push_str(&format!("    pub fn n(&self)  L{}\n", n + 2));
+            map.push('\n');
+            n += 4;
+        }
+
+        let indent_of = |l: &str| l.len() - l.trim_start_matches(' ').len();
+        // Each non-blank line's ancestors, by the nearest preceding line of
+        // smaller indent. Every line in the fixture is unique, so membership in
+        // the output is enough to tell kept from dropped.
+        let mut ancestors: Vec<(String, Vec<String>)> = Vec::new();
+        let mut stack: Vec<(usize, String)> = Vec::new();
+        for line in map.lines().filter(|l| !l.trim().is_empty()) {
+            let ind = indent_of(line);
+            while stack.last().is_some_and(|(i, _)| *i >= ind) {
+                stack.pop();
+            }
+            ancestors.push((
+                line.to_string(),
+                stack.iter().map(|(_, l)| l.clone()).collect(),
+            ));
+            stack.push((ind, line.to_string()));
+        }
+
+        let full = map.len();
+        let out = cap_map(map, "", full, Path::new("/tmp/wide.rs"));
+        assert!(out.len() <= MAP_BUDGET, "{} bytes", out.len());
+        assert!(out.contains("line(s) dropped"), "the fixture must trigger a trim");
+
+        let kept: std::collections::HashSet<&str> =
+            out.lines().map(|l| l.trim_end()).collect();
+        let mut checked = 0usize;
+        for (line, parents) in &ancestors {
+            if !kept.contains(line.trim_end()) {
+                continue;
+            }
+            for parent in parents {
+                assert!(
+                    kept.contains(parent.trim_end()),
+                    "kept {line:?} but dropped its parent {parent:?}"
+                );
+            }
+            checked += 1;
+        }
+        assert!(checked > 0, "the fixture kept nothing to check");
     }
 
     #[test]
@@ -162,6 +611,7 @@ mod tests {
                 min_lines: 200,
                 always: true,
             },
+            replacing(),
         );
         assert!(matches!(d, Decision::Substitute { .. }));
     }

--- a/src/hook/decide.rs
+++ b/src/hook/decide.rs
@@ -120,13 +120,15 @@ fn map_levels() -> [(&'static str, crate::core::MapOptions); 4] {
 fn render_map_for(path: &Path) -> Option<String> {
     let res = crate::main_helpers::parse_file_for_hook(path)?;
     let mut full_bytes = 0usize;
-    // The smallest map any level produced, for the case where none of them fit
-    // and the marker has to say both what was shed and what was cut. Smallest
-    // rather than last: the `max_members` level trades members for `+N more`
-    // markers, which can leave it larger than the level before it.
-    let mut smallest: Option<(&'static str, String)> = None;
+    // The candidate that delivers the most entries, not the first that fits.
+    // Shedding is lossy in a different currency from trimming: a file of 2900
+    // private and 100 public functions fits once private items go, and that
+    // "success" hands over 100 declarations while leaving 93% of the budget
+    // unused, where trimming the level before it carries about 1350.
+    let mut best: Option<(usize, String)> = None;
     for (shed, opts) in map_levels() {
-        let map = crate::core::render_map(&res, &opts);
+        let units = crate::core::render_map_units(&res, &opts);
+        let map = units.join("\n");
         if shed.is_empty() {
             full_bytes = map.len();
         }
@@ -138,15 +140,59 @@ fn render_map_for(path: &Path) -> Option<String> {
         } else {
             shed_note(shed, path)
         };
-        if map.len() + note.len() <= MAP_BUDGET {
-            return Some(map + &note);
+        let fits = map.len() + note.len() <= MAP_BUDGET;
+        let (payload, delivered) = if fits {
+            (with_note(map, &note), entry_count(&units))
+        } else {
+            cap_map(units, shed, full_bytes, path)
+        };
+        // Strictly greater, so the richest level wins a tie.
+        if best.as_ref().is_none_or(|(most, _)| delivered > *most) {
+            best = Some((delivered, payload));
         }
-        if smallest.as_ref().is_none_or(|(_, best)| map.len() < best.len()) {
-            smallest = Some((shed, map));
+        if fits {
+            // No later level can deliver more: every level after this one only
+            // removes declarations. (Shedding docs and attributes removes none —
+            // they live inside a declaration's unit rather than beside it — but
+            // that level comes earlier, so it is already considered.) Stopping
+            // here leaves the common case, a small file whose full map fits, at a
+            // single render.
+            break;
         }
     }
-    let (shed, map) = smallest.expect("map_levels is never empty");
-    Some(cap_map(map, shed, full_bytes, path))
+    best.map(|(_, payload)| payload)
+}
+
+/// Entries a map carries: everything but its separators.
+///
+/// Used only to compare one candidate against another, and it does not count
+/// quite the same things at every level — `... +N more member(s)` markers exist
+/// only where `max_members` is set, which is the last level alone, and they are
+/// counted there. That cannot change a choice. Against the level before it, a
+/// capped type contributes `1 + min(50, N) + 1` where that one contributes
+/// `1 + N` with `N >= 51`, so the capped count is never higher, and the one tie a
+/// marker can manufacture, at `N == 51`, goes to the earlier level on the strict
+/// comparison. To beat a *trimmed* earlier level it would have to fit whole while
+/// that one overflowed, which bounds it by the same budget the trim saturates.
+fn entry_count(units: &[String]) -> usize {
+    units.iter().filter(|u| unit_indent(u).is_some()).count()
+}
+
+/// Appends `note` to `map`, on its own line.
+///
+/// A map whose last unit is a declaration does not end in a newline — a file with
+/// no declarations at all ends at its header — so the note has to be given one or
+/// it reads as part of that line.
+fn with_note(map: String, note: &str) -> String {
+    if note.is_empty() {
+        return map;
+    }
+    let mut out = map;
+    if !out.is_empty() && !out.ends_with('\n') {
+        out.push('\n');
+    }
+    out.push_str(note);
+    out
 }
 
 /// The line a shed map ends with, naming what is gone and how to get it.
@@ -157,55 +203,76 @@ fn shed_note(shed: &str, path: &Path) -> String {
     )
 }
 
-/// Drops whole lines from `map` until it fits [`MAP_BUDGET`], saying what went.
+/// The column a unit sits at, or `None` for a separator.
+///
+/// A unit's own indentation is the render prefix, so it is a reliable depth
+/// signal where a physical line is not: a doc comment keeps the indentation it
+/// had in the source, so its continuation lines land at arbitrary columns. A
+/// separator carries no indentation and therefore no structure — treating its
+/// column as zero is what let members outlive the header they belong to.
+fn unit_indent(unit: &str) -> Option<usize> {
+    let first = unit.lines().next().unwrap_or("");
+    if first.trim().is_empty() {
+        return None;
+    }
+    Some(first.len() - first.trim_start_matches(' ').len())
+}
+
+/// Drops whole units from a map until it fits [`MAP_BUDGET`], saying what went.
 ///
 /// The last resort, reached only when shedding every level of detail still left
 /// the map too big — a minified bundle, where the size is thousands of
 /// declarations rather than detail about a few. A silently short map is worse
 /// than a trimmed one: the reader treats a map as the file's whole shape and
 /// concludes a symbol does not exist, so the marker names what was shed on the
-/// way here, how many lines went, and the file's real size.
+/// way here, how many entries went, and the file's real size.
 ///
-/// Over-long lines are skipped rather than ending the scan. One declaration can
-/// be arbitrarily wide — a generated signature with thousands of parameters — and
-/// stopping at it would drop every declaration after it, which is the failure
-/// this function exists to prevent.
-fn cap_map(map: String, shed: &str, full_bytes: usize, path: &Path) -> String {
-    let total_lines = map.split_inclusive('\n').count();
+/// Two rules keep the result truthful. An over-wide unit is skipped rather than
+/// ending the scan, because one generated signature with thousands of parameters
+/// would otherwise drop every declaration after it. And a dropped unit takes
+/// every following unit indented deeper than it, because indentation is the only
+/// parent-child signal a map carries and a member kept without its type header
+/// reads as a member of the previous type.
+fn cap_map(units: Vec<String>, shed: &str, full_bytes: usize, path: &Path) -> (String, usize) {
+    let total = units.iter().map(String::len).sum::<usize>() + units.len();
     // Size the marker against the widest numbers it can carry, so the budget it
-    // comes out of is never too small; the real numbers are no wider, since
-    // `kept` never exceeds `map.len()` and `dropped` never exceeds `total_lines`.
+    // comes out of is never too small; the real numbers are no wider, since what
+    // is kept never exceeds the whole map and what is dropped never exceeds the
+    // unit count. One byte is held back for the newline before the marker.
     let budget = MAP_BUDGET
-        .saturating_sub(trim_note(map.len(), full_bytes, total_lines, shed, path).len());
-    let mut kept = String::with_capacity(budget.min(map.len()));
+        .saturating_sub(trim_note(total, full_bytes, units.len(), shed, path).len())
+        .saturating_sub(1);
+    let mut kept: Vec<String> = Vec::new();
+    let mut len = 0usize;
     let mut dropped = 0usize;
-    // Indentation is the only parent-child signal a map carries, so a skipped
-    // line takes its children with it. Keeping a member whose type header did
-    // not fit would file it under the previous type — a map that asserts a
-    // structure the file does not have, which is worse than a shorter one.
     let mut skipped_parent: Option<usize> = None;
-    for line in map.split_inclusive('\n') {
-        let indent = line.len() - line.trim_start_matches(' ').len();
-        if let Some(level) = skipped_parent {
-            if indent > level {
+    for unit in units {
+        let indent = unit_indent(&unit);
+        if let (Some(level), Some(column)) = (skipped_parent, indent) {
+            if column > level {
                 dropped += 1;
                 continue;
             }
             skipped_parent = None;
         }
-        if kept.len() + line.len() <= budget {
-            kept.push_str(line);
+        let cost = unit.len() + usize::from(!kept.is_empty());
+        if len + cost <= budget {
+            len += cost;
+            kept.push(unit);
         } else {
-            dropped += 1;
-            skipped_parent = Some(indent);
+            // A separator carries no structure, so dropping one starts no
+            // subtree; leaving the state alone keeps the enclosing one in force.
+            if let Some(column) = indent {
+                dropped += 1;
+                skipped_parent = Some(column);
+            }
         }
     }
-    let note = trim_note(kept.len(), full_bytes, dropped, shed, path);
-    debug_assert!(
-        kept.len() + note.len() <= MAP_BUDGET,
-        "trim overshot the budget"
-    );
-    kept + &note
+    let note = trim_note(len, full_bytes, dropped, shed, path);
+    let delivered = kept.iter().filter(|u| unit_indent(u).is_some()).count();
+    let out = with_note(kept.join("\n"), &note);
+    debug_assert!(out.len() <= MAP_BUDGET, "trim overshot the budget");
+    (out, delivered)
 }
 
 /// The line a trimmed map ends with. Separate from the cut so its width can be
@@ -220,7 +287,7 @@ fn trim_note(kept: usize, full_bytes: usize, dropped: usize, shed: &str, path: &
         "# note: {shed_clause}map trimmed to {kept} bytes from a {full_bytes} byte full map{}; \
 `ast-bro map {}` for the whole map, `ast-bro show {} <symbol>` for one body\n",
         if dropped > 0 {
-            format!(", {dropped} line(s) dropped")
+            format!(", {dropped} entr{} dropped", if dropped == 1 { "y" } else { "ies" })
         } else {
             String::new()
         },
@@ -469,9 +536,10 @@ mod tests {
         while map.len() <= MAX_MAP_BYTES * 2 {
             map.push_str(line);
         }
-        map.pop(); // last line now ends the string with no newline
+        map.pop(); // the last unit now ends without a newline
         let len = map.len();
-        let out = cap_map(map, "", len, Path::new("/tmp/x.rs"));
+        let units: Vec<String> = map.split('\n').map(str::to_string).collect();
+        let (out, _) = cap_map(units, "", len, Path::new("/tmp/x.rs"));
         assert!(out.len() <= MAP_BUDGET, "{} bytes", out.len());
         assert!(out.starts_with("# header\n"));
         assert!(out.contains("map trimmed to"));
@@ -499,7 +567,7 @@ mod tests {
                 for name in ["pub fn api_0", "pub fn api_399"] {
                     assert!(map.contains(name), "lost {name}:\n{}", &map[..300]);
                 }
-                assert!(map.contains("line(s) dropped"), "must say what it dropped");
+                assert!(map.contains("dropped"), "must say what it dropped");
             }
             other => panic!("expected a trimmed map: {other:?}"),
         }
@@ -538,66 +606,142 @@ mod tests {
         }
     }
 
-    /// A skipped line takes its children with it.
+    /// A dropped unit takes its children with it, whatever the text looks like.
     ///
     /// Indentation is the only parent-child signal a map has, so a member kept
-    /// without its type header would be filed under the previous type — a map
+    /// without its type header reads as a member of the previous type — a map
     /// asserting a structure the file does not have, which is worse than a
-    /// shorter one. The invariant checked is exactly that: every line the trim
-    /// kept still has each of its ancestors.
+    /// shorter one. Two shapes in the fixture are the ones that broke it before:
+    /// a nested type emits a separator *inside* its parent's member list, and a
+    /// doc comment keeps its source indentation, so its continuation lines land
+    /// at columns like 3 that say nothing about depth. The invariant checked is
+    /// exactly the claim: every unit the trim kept still has all of its
+    /// ancestors.
     #[test]
-    fn a_trim_never_keeps_a_line_whose_parent_it_dropped() {
+    fn a_trim_never_keeps_a_unit_whose_parent_it_dropped() {
+        let joined_len = |u: &[String]| u.iter().map(String::len).sum::<usize>() + u.len();
         // Headers far wider than their members, so the budget runs out in the
         // window where a header cannot fit but its members still can.
-        let mut map = String::from("# header\n");
+        let mut units: Vec<String> = vec!["# header".into()];
         let mut n = 2;
-        while map.len() <= MAP_BUDGET + 40_000 {
-            map.push_str(&format!("pub struct Wide{n}{}  L{n}\n", "X".repeat(2000)));
-            map.push_str(&format!("    pub fn m(&self)  L{}\n", n + 1));
-            map.push_str(&format!("    pub fn n(&self)  L{}\n", n + 2));
-            map.push('\n');
-            n += 4;
+        while joined_len(&units) <= MAP_BUDGET + 40_000 {
+            units.push(format!("public class Outer{n}{}  L{n}", "X".repeat(3000)));
+            units.push(format!("    public static class Inner{n}  L{}", n + 1));
+            units.push(format!("        void inner{n}()  L{}", n + 2));
+            // The separator a nested type emits, sitting between its parent's
+            // members rather than after the last one.
+            units.push(String::new());
+            units.push(format!("    void survivor{n}()  L{}", n + 3));
+            // A Javadoc unit: prefixed first line, continuation lines carrying
+            // the indentation they had in the source.
+            units.push(format!(
+                "    /**\n   * Doc for docd{n}.\n   */\n    void docd{n}()  L{}",
+                n + 4
+            ));
+            units.push(String::new());
+            n += 8;
         }
 
-        let indent_of = |l: &str| l.len() - l.trim_start_matches(' ').len();
-        // Each non-blank line's ancestors, by the nearest preceding line of
-        // smaller indent. Every line in the fixture is unique, so membership in
-        // the output is enough to tell kept from dropped.
+        // Each unit's ancestors, by the nearest preceding unit of smaller
+        // indent. Computed here rather than through `unit_indent`, so the
+        // expectation does not depend on the function under test: a blank unit
+        // is not a node, and reading its column as zero is the very mistake
+        // being guarded against.
         let mut ancestors: Vec<(String, Vec<String>)> = Vec::new();
         let mut stack: Vec<(usize, String)> = Vec::new();
-        for line in map.lines().filter(|l| !l.trim().is_empty()) {
-            let ind = indent_of(line);
-            while stack.last().is_some_and(|(i, _)| *i >= ind) {
+        for unit in &units {
+            if unit.trim().is_empty() {
+                continue;
+            }
+            let first = unit.lines().next().unwrap_or("");
+            let column = first.len() - first.trim_start_matches(' ').len();
+            while stack.last().is_some_and(|(c, _)| *c >= column) {
                 stack.pop();
             }
             ancestors.push((
-                line.to_string(),
-                stack.iter().map(|(_, l)| l.clone()).collect(),
+                unit.clone(),
+                stack.iter().map(|(_, u)| u.clone()).collect(),
             ));
-            stack.push((ind, line.to_string()));
+            stack.push((column, unit.clone()));
         }
 
-        let full = map.len();
-        let out = cap_map(map, "", full, Path::new("/tmp/wide.rs"));
+        let full = joined_len(&units);
+        let (out, delivered) = cap_map(units, "", full, Path::new("/tmp/wide.java"));
+        assert!(delivered > 0, "the trim must deliver something to check");
         assert!(out.len() <= MAP_BUDGET, "{} bytes", out.len());
-        assert!(out.contains("line(s) dropped"), "the fixture must trigger a trim");
+        assert!(out.contains("dropped"), "the fixture must trigger a trim");
 
-        let kept: std::collections::HashSet<&str> =
-            out.lines().map(|l| l.trim_end()).collect();
         let mut checked = 0usize;
-        for (line, parents) in &ancestors {
-            if !kept.contains(line.trim_end()) {
+        let mut orphans: Vec<String> = Vec::new();
+        for (unit, parents) in &ancestors {
+            if !out.contains(unit.as_str()) {
                 continue;
             }
-            for parent in parents {
-                assert!(
-                    kept.contains(parent.trim_end()),
-                    "kept {line:?} but dropped its parent {parent:?}"
-                );
-            }
             checked += 1;
+            for parent in parents {
+                if !out.contains(parent.as_str()) {
+                    orphans.push(format!(
+                        "{:?} kept without {:?}",
+                        unit.lines().last().unwrap_or(unit),
+                        parent.chars().take(40).collect::<String>()
+                    ));
+                }
+            }
         }
         assert!(checked > 0, "the fixture kept nothing to check");
+        assert!(orphans.is_empty(), "orphaned units: {:#?}", &orphans[..orphans.len().min(3)]);
+    }
+
+    /// Shedding is chosen for what it delivers, not for fitting.
+    ///
+    /// A file that is mostly private fits the moment private items go, and that
+    /// "success" hands over only the public few while most of the budget goes
+    /// unspent — where trimming the level before it carries an order of
+    /// magnitude more. Regression guard: this file used to deliver 50
+    /// declarations, and an all-private one delivered none at all.
+    #[test]
+    fn a_mostly_private_file_keeps_private_declarations_by_trimming() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("mostly_private.rs");
+        let mut src = String::new();
+        for i in 0..2000 {
+            src.push_str(&format!("fn priv_{i:04}(a: u32) -> u32 {{ a }}\n"));
+        }
+        for i in 0..50 {
+            src.push_str(&format!("pub fn api_{i:03}(a: u32) -> u32 {{ a }}\n"));
+        }
+        std::fs::write(&p, &src).unwrap();
+
+        match decide(&ev("Read", Some(p), false), &opts(), replacing()) {
+            Decision::Substitute { map } => {
+                assert!(map.len() <= MAP_BUDGET, "{} bytes", map.len());
+                let private_kept = map.matches("fn priv_").count();
+                assert!(
+                    private_kept > 500,
+                    "only {private_kept} private declarations survived; the shed level \
+                     would have delivered none of them"
+                );
+                // The budget is there to be spent: a payload that fits with room
+                // to spare has thrown away declarations it could have carried.
+                assert!(
+                    map.len() > MAP_BUDGET / 2,
+                    "payload is {} bytes of a {MAP_BUDGET} budget",
+                    map.len()
+                );
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    /// A file with no declarations at all still gets a readable payload: the note
+    /// goes on its own line rather than gluing itself to the header.
+    #[test]
+    fn a_note_never_glues_itself_to_the_header_line() {
+        let header = "# /tmp/x.rs ([medium], 3000 lines, 1 chars, 3000 methods)".to_string();
+        let note = shed_note("doc comments", Path::new("/tmp/x.rs"));
+        let out = with_note(header.clone(), &note);
+        assert!(out.starts_with(&format!("{header}\n")), "{out}");
+        assert!(out.ends_with(&note), "{out}");
     }
 
     #[test]

--- a/src/hook/decide.rs
+++ b/src/hook/decide.rs
@@ -136,6 +136,7 @@ fn render_map_for(path: &Path) -> Option<String> {
     // and cheap members buys fewer declarations than file order would, and buys
     // the right ones.
     let mut best: Option<Candidate> = None;
+    let mut required: Option<HashSet<usize>> = None;
     for (i, (shed, opts)) in levels.iter().enumerate() {
         if rendered.len() == i {
             rendered.push(crate::core::render_map_units(&res, opts));
@@ -151,16 +152,12 @@ fn render_map_for(path: &Path) -> Option<String> {
         } else {
             shed_note(shed, path)
         };
-        // Measured on the assembled payload rather than on its parts: `with_note`
-        // puts the note on a line of its own, and a fit decision that leaves that
-        // byte out is a ceiling resting on how the renderer happened to end the
-        // last unit.
-        let whole = with_note(join_units(&rendered[i]), &note);
-        let fits = whole.len() <= MAP_BUDGET;
-        let candidate = if fits {
+        let whole = whole_payload(&rendered[i], &note);
+        let fits = whole.is_some();
+        let candidate = if let Some(payload) = whole {
             let delivered = entry_count(&rendered[i]);
             Candidate {
-                payload: whole,
+                payload,
                 required: delivered,
                 delivered,
             }
@@ -168,11 +165,15 @@ fn render_map_for(path: &Path) -> Option<String> {
             for (_, leaner) in levels.iter().skip(rendered.len()) {
                 rendered.push(crate::core::render_map_units(&res, leaner));
             }
-            let required = required_ids(&rendered[i + 1..], &levels[i + 1..], path);
+            // The same set at every level that reaches here, since the loop stops
+            // at the first level that fits: a scan from any earlier level finds
+            // that same one. Computed at the first, and reused.
+            let required = required
+                .get_or_insert_with(|| required_ids(&rendered[i + 1..], &levels[i + 1..], path));
             cap_map(
                 &rendered[i],
                 &rendered[i + 1..],
-                &required,
+                required,
                 shed,
                 full_bytes,
                 path,
@@ -223,6 +224,22 @@ impl Candidate {
     }
 }
 
+/// The payload `units` and `note` make, if it is one the hook may deliver.
+///
+/// The size is taken from the assembled payload rather than from its parts:
+/// [`with_note`] puts the note on a line of its own, and a fit decided without
+/// that byte is a ceiling resting on how the renderer happened to end its last
+/// unit. Assembling it costs a copy of the map, so the parts are added up first
+/// — the payload is never smaller than they are — and a level already over the
+/// ceiling by that measure is refused without the copy.
+fn whole_payload(units: &[MapUnit], note: &str) -> Option<String> {
+    if map_bytes(units) + note.len() > MAP_BUDGET {
+        return None;
+    }
+    let out = with_note(join_units(units), note);
+    (out.len() <= MAP_BUDGET).then_some(out)
+}
+
 /// The declarations a trimmed candidate must carry to be worth preferring.
 ///
 /// They are the leanest whole answer available: the richest of the leaner levels
@@ -235,8 +252,7 @@ fn required_ids(
     path: &Path,
 ) -> HashSet<usize> {
     for (units, (shed, _)) in leaner.iter().zip(levels) {
-        let note = shed_note(shed, path);
-        if with_note(join_units(units), &note).len() <= MAP_BUDGET {
+        if whole_payload(units, &shed_note(shed, path)).is_some() {
             return declaration_ids(units);
         }
     }

--- a/src/hook/decide.rs
+++ b/src/hook/decide.rs
@@ -729,6 +729,50 @@ mod tests {
         }
     }
 
+    /// A whole map is measured assembled, because its parts do not show the line
+    /// the marker takes.
+    ///
+    /// Every map a renderer produces ends in a newline — a top-level declaration
+    /// is followed by a separator — so on any real file the two measures agree
+    /// and the assembled check reads as redundant. It is not: on a map ending in
+    /// a declaration, parts adding up to exactly the budget are delivered a byte
+    /// over the ceiling. The three points are the budget on the nose, one byte
+    /// under it, and the same map ending in a separator, which is the shape that
+    /// hides the byte.
+    #[test]
+    fn a_map_is_measured_with_the_line_its_marker_takes() {
+        let note = shed_note(map_levels()[1].0, Path::new("/tmp/x.rs"));
+        let exact = MAP_BUDGET - note.len();
+
+        // Filled to just under the target, then one unit sized to land on it.
+        let mut units = vec![preamble("# header")];
+        while map_bytes(&units) + 300 < exact {
+            let id = units.len();
+            units.push(decl_unit("pub fn f() {}", id, None));
+        }
+        let last = exact - map_bytes(&units) - 1;
+        units.push(decl_unit(&"x".repeat(last), units.len(), None));
+        assert_eq!(map_bytes(&units), exact, "the fixture missed the boundary");
+
+        assert!(
+            whole_payload(&units, &note).is_none(),
+            "a map ending in a declaration costs a byte more than its parts"
+        );
+
+        let shorter = decl_unit(&"x".repeat(last - 1), units.len(), None);
+        units.pop();
+        units.push(shorter);
+        let payload = whole_payload(&units, &note).expect("one byte under the budget must fit");
+        assert_eq!(payload.len(), MAP_BUDGET, "the budget is there to be spent");
+
+        units.push(separator());
+        assert_eq!(map_bytes(&units), exact, "the separator restores the byte");
+        assert!(
+            whole_payload(&units, &note).is_some(),
+            "a map already ending in a newline pays nothing for the marker's line"
+        );
+    }
+
     /// A declaration unit ends without a newline, so `cap_map` has to give the
     /// marker a line of its own rather than glue it to the last declaration.
     #[test]

--- a/src/hook/decide.rs
+++ b/src/hook/decide.rs
@@ -1,6 +1,8 @@
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use super::event::{Channel, Decision, ToolCallEvent};
+use crate::core::{MapUnit, MapUnitKind};
 
 #[derive(Debug, Clone)]
 pub struct DecideOpts {
@@ -119,18 +121,24 @@ fn map_levels() -> [(&'static str, crate::core::MapOptions); 4] {
 
 fn render_map_for(path: &Path) -> Option<String> {
     let res = crate::main_helpers::parse_file_for_hook(path)?;
+    let levels = map_levels();
+    // Rendered lazily and kept: a level that overflows needs the leaner levels to
+    // decide what to keep, and the loop reaches those levels next.
+    let mut rendered: Vec<Vec<MapUnit>> = Vec::with_capacity(levels.len());
     let mut full_bytes = 0usize;
-    // The candidate that delivers the most entries, not the first that fits.
+    // The candidate that delivers the most declarations, not the first that fits.
     // Shedding is lossy in a different currency from trimming: a file of 2900
     // private and 100 public functions fits once private items go, and that
     // "success" hands over 100 declarations while leaving 93% of the budget
-    // unused, where trimming the level before it carries about 1350.
+    // unused, where trimming the level before it carries 1871 — the same 100
+    // publics and 1771 of the helpers.
     let mut best: Option<(usize, String)> = None;
-    for (shed, opts) in map_levels() {
-        let units = crate::core::render_map_units(&res, &opts);
-        let map = units.join("\n");
-        if shed.is_empty() {
-            full_bytes = map.len();
+    for (i, (shed, opts)) in levels.iter().enumerate() {
+        if rendered.len() == i {
+            rendered.push(crate::core::render_map_units(&res, opts));
+        }
+        if i == 0 {
+            full_bytes = map_bytes(&rendered[0]);
         }
         // Naming what is missing is the whole point: absence of a private helper
         // from this map must not read as absence from the file. The note is built
@@ -140,11 +148,17 @@ fn render_map_for(path: &Path) -> Option<String> {
         } else {
             shed_note(shed, path)
         };
-        let fits = map.len() + note.len() <= MAP_BUDGET;
+        let fits = map_bytes(&rendered[i]) + note.len() <= MAP_BUDGET;
         let (payload, delivered) = if fits {
-            (with_note(map, &note), entry_count(&units))
+            (
+                with_note(join_units(&rendered[i]), &note),
+                entry_count(&rendered[i]),
+            )
         } else {
-            cap_map(units, shed, full_bytes, path)
+            for (_, leaner) in levels.iter().skip(rendered.len()) {
+                rendered.push(crate::core::render_map_units(&res, leaner));
+            }
+            cap_map(&rendered[i], &rendered[i + 1..], shed, full_bytes, path)
         };
         // Strictly greater, so the richest level wins a tie.
         if best.as_ref().is_none_or(|(most, _)| delivered > *most) {
@@ -163,19 +177,26 @@ fn render_map_for(path: &Path) -> Option<String> {
     best.map(|(_, payload)| payload)
 }
 
-/// Entries a map carries: everything but its separators.
-///
-/// Used only to compare one candidate against another, and it does not count
-/// quite the same things at every level — `... +N more member(s)` markers exist
-/// only where `max_members` is set, which is the last level alone, and they are
-/// counted there. That cannot change a choice. Against the level before it, a
-/// capped type contributes `1 + min(50, N) + 1` where that one contributes
-/// `1 + N` with `N >= 51`, so the capped count is never higher, and the one tie a
-/// marker can manufacture, at `N == 51`, goes to the earlier level on the strict
-/// comparison. To beat a *trimmed* earlier level it would have to fit whole while
-/// that one overflowed, which bounds it by the same budget the trim saturates.
-fn entry_count(units: &[String]) -> usize {
-    units.iter().filter(|u| unit_indent(u).is_some()).count()
+/// The declarations a map carries, which is what one candidate is compared to
+/// another by.
+fn entry_count(units: &[MapUnit]) -> usize {
+    units
+        .iter()
+        .filter(|u| matches!(u.kind, MapUnitKind::Declaration { .. }))
+        .count()
+}
+
+/// The bytes `units` occupy once joined.
+fn map_bytes(units: &[MapUnit]) -> usize {
+    units.iter().map(|u| u.text.len()).sum::<usize>() + units.len().saturating_sub(1)
+}
+
+fn join_units(units: &[MapUnit]) -> String {
+    units
+        .iter()
+        .map(|u| u.text.as_str())
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 /// Appends `note` to `map`, on its own line.
@@ -203,73 +224,128 @@ fn shed_note(shed: &str, path: &Path) -> String {
     )
 }
 
-/// The column a unit sits at, or `None` for a separator.
+/// How far down the ladder each unit of `units` survives.
 ///
-/// A unit's own indentation is the render prefix, so it is a reliable depth
-/// signal where a physical line is not: a doc comment keeps the indentation it
-/// had in the source, so its continuation lines land at arbitrary columns. A
-/// separator carries no indentation and therefore no structure — treating its
-/// column as zero is what let members outlive the header they belong to.
-fn unit_indent(unit: &str) -> Option<usize> {
-    let first = unit.lines().next().unwrap_or("");
-    if first.trim().is_empty() {
-        return None;
+/// A declaration that is still there at the leanest level is the one the reader
+/// is least able to do without, so a trim spends the budget on it first. The
+/// ladder already ranks detail by what it costs to lose ([`map_levels`]), and
+/// this reads that ranking back off the renders rather than restating it.
+///
+/// Two units rank by inheritance instead. A `... +N more member(s)` marker takes
+/// its type's rank, being a statement about that type, and the header and the
+/// parse warning outrank everything: a map without them names no file and
+/// claims a shape the parser did not manage to read.
+fn survival_ranks(units: &[MapUnit], leaner: &[Vec<MapUnit>]) -> Vec<usize> {
+    let sets: Vec<HashSet<usize>> = leaner
+        .iter()
+        .map(|render| {
+            render
+                .iter()
+                .filter_map(|u| match u.kind {
+                    MapUnitKind::Declaration { id } => Some(id),
+                    _ => None,
+                })
+                .collect()
+        })
+        .collect();
+    let mut by_decl: HashMap<usize, usize> = HashMap::new();
+    let mut ranks = Vec::with_capacity(units.len());
+    for unit in units {
+        let rank = match unit.kind {
+            MapUnitKind::Preamble => usize::MAX,
+            MapUnitKind::Declaration { id } => {
+                let rank = sets.iter().filter(|s| s.contains(&id)).count();
+                by_decl.insert(id, rank);
+                rank
+            }
+            // The parent is rendered ahead of what nests under it, so its rank is
+            // already known.
+            MapUnitKind::MoreMembers => unit
+                .parent
+                .and_then(|p| by_decl.get(&p).copied())
+                .unwrap_or(0),
+            MapUnitKind::Separator => 0,
+        };
+        ranks.push(rank);
     }
-    Some(first.len() - first.trim_start_matches(' ').len())
+    ranks
 }
 
 /// Drops whole units from a map until it fits [`MAP_BUDGET`], saying what went.
 ///
-/// The last resort, reached only when shedding every level of detail still left
-/// the map too big — a minified bundle, where the size is thousands of
-/// declarations rather than detail about a few. A silently short map is worse
-/// than a trimmed one: the reader treats a map as the file's whole shape and
-/// concludes a symbol does not exist, so the marker names what was shed on the
-/// way here, how many entries went, and the file's real size.
+/// The last resort, reached only when a level of detail still leaves the map too
+/// big. A silently short map is worse than a trimmed one: the reader treats a map
+/// as the file's whole shape and concludes a symbol does not exist, so the marker
+/// names what was shed on the way here, how many entries went, and the file's
+/// real size.
 ///
-/// Two rules keep the result truthful. An over-wide unit is skipped rather than
-/// ending the scan, because one generated signature with thousands of parameters
-/// would otherwise drop every declaration after it. And a dropped unit takes
-/// every following unit indented deeper than it, because indentation is the only
-/// parent-child signal a map carries and a member kept without its type header
-/// reads as a member of the previous type.
-fn cap_map(units: Vec<String>, shed: &str, full_bytes: usize, path: &Path) -> (String, usize) {
-    let total = units.iter().map(String::len).sum::<usize>() + units.len();
+/// Three rules keep the result useful and truthful.
+///
+/// The budget is spent in [`survival_ranks`] order rather than front to back,
+/// because a map's public surface is routinely its last declarations: filling in
+/// file order delivers 1733 private items of one file and none of its 500 public
+/// ones, which no reader would choose. Order within a rank is the file's own, and
+/// so is the order the kept units are written back out in.
+///
+/// An over-wide unit is skipped rather than ending the scan, because one
+/// generated signature with thousands of parameters would otherwise drop every
+/// declaration after it.
+///
+/// And a dropped declaration takes everything nested under it, because a member
+/// kept without its type header reads as a member of the previous type — a map
+/// asserting a structure the file does not have.
+fn cap_map(
+    units: &[MapUnit],
+    leaner: &[Vec<MapUnit>],
+    shed: &str,
+    full_bytes: usize,
+    path: &Path,
+) -> (String, usize) {
     // Size the marker against the widest numbers it can carry, so the budget it
     // comes out of is never too small; the real numbers are no wider, since what
     // is kept never exceeds the whole map and what is dropped never exceeds the
-    // unit count. One byte is held back for the newline before the marker.
-    let budget = MAP_BUDGET
-        .saturating_sub(trim_note(total, full_bytes, units.len(), shed, path).len())
-        .saturating_sub(1);
-    let mut kept: Vec<String> = Vec::new();
+    // declaration count.
+    let budget = MAP_BUDGET.saturating_sub(
+        trim_note(map_bytes(units), full_bytes, entry_count(units), shed, path).len(),
+    );
+    let ranks = survival_ranks(units, leaner);
+    let mut order: Vec<usize> = (0..units.len()).collect();
+    // A stable sort, so units of one rank keep the file's order — and with it the
+    // guarantee that a parent is decided before what nests under it, since a
+    // parent survives at least as far down the ladder as its members do.
+    order.sort_by_key(|&i| std::cmp::Reverse(ranks[i]));
+
+    let mut keep = vec![false; units.len()];
+    let mut dropped_parents: HashSet<usize> = HashSet::new();
     let mut len = 0usize;
     let mut dropped = 0usize;
-    let mut skipped_parent: Option<usize> = None;
-    for unit in units {
-        let indent = unit_indent(&unit);
-        if let (Some(level), Some(column)) = (skipped_parent, indent) {
-            if column > level {
-                dropped += 1;
-                continue;
-            }
-            skipped_parent = None;
-        }
-        let cost = unit.len() + usize::from(!kept.is_empty());
-        if len + cost <= budget {
+    for i in order {
+        let unit = &units[i];
+        let orphaned = unit.parent.is_some_and(|p| dropped_parents.contains(&p));
+        let cost = unit.text.len() + 1;
+        if !orphaned && len + cost <= budget {
             len += cost;
-            kept.push(unit);
-        } else {
-            // A separator carries no structure, so dropping one starts no
-            // subtree; leaving the state alone keeps the enclosing one in force.
-            if let Some(column) = indent {
-                dropped += 1;
-                skipped_parent = Some(column);
-            }
+            keep[i] = true;
+            continue;
+        }
+        if let MapUnitKind::Declaration { id } = unit.kind {
+            dropped_parents.insert(id);
+            dropped += 1;
         }
     }
+
+    let kept: Vec<&str> = units
+        .iter()
+        .zip(&keep)
+        .filter(|(_, k)| **k)
+        .map(|(u, _)| u.text.as_str())
+        .collect();
+    let delivered = units
+        .iter()
+        .zip(&keep)
+        .filter(|(u, k)| **k && matches!(u.kind, MapUnitKind::Declaration { .. }))
+        .count();
     let note = trim_note(len, full_bytes, dropped, shed, path);
-    let delivered = kept.iter().filter(|u| unit_indent(u).is_some()).count();
     let out = with_note(kept.join("\n"), &note);
     debug_assert!(out.len() <= MAP_BUDGET, "trim overshot the budget");
     (out, delivered)
@@ -314,6 +390,30 @@ mod tests {
             tool_name: tool.to_string(),
             file_path: path,
             has_offset_or_limit: offset,
+        }
+    }
+
+    fn preamble(text: &str) -> MapUnit {
+        MapUnit {
+            text: text.to_string(),
+            kind: MapUnitKind::Preamble,
+            parent: None,
+        }
+    }
+
+    fn decl_unit(text: &str, id: usize, parent: Option<usize>) -> MapUnit {
+        MapUnit {
+            text: text.to_string(),
+            kind: MapUnitKind::Declaration { id },
+            parent,
+        }
+    }
+
+    fn separator() -> MapUnit {
+        MapUnit {
+            text: String::new(),
+            kind: MapUnitKind::Separator,
+            parent: None,
         }
     }
 
@@ -527,22 +627,22 @@ mod tests {
         }
     }
 
-    /// `cap_map` cuts on a line boundary even when the last line has no newline,
-    /// which is what a file without a trailing newline produces.
+    /// A declaration unit ends without a newline, so `cap_map` has to give the
+    /// marker a line of its own rather than glue it to the last declaration.
     #[test]
     fn cap_map_handles_a_map_without_a_trailing_newline() {
-        let line = "pub fn f() {}\n";
-        let mut map = String::from("# header\n");
-        while map.len() <= MAX_MAP_BYTES * 2 {
-            map.push_str(line);
+        let mut units = vec![preamble("# header")];
+        while map_bytes(&units) <= MAX_MAP_BYTES * 2 {
+            let id = units.len();
+            units.push(decl_unit("pub fn f() {}", id, None));
         }
-        map.pop(); // the last unit now ends without a newline
-        let len = map.len();
-        let units: Vec<String> = map.split('\n').map(str::to_string).collect();
-        let (out, _) = cap_map(units, "", len, Path::new("/tmp/x.rs"));
+        let full = map_bytes(&units);
+        let (out, _) = cap_map(&units, &[], "", full, Path::new("/tmp/x.rs"));
         assert!(out.len() <= MAP_BUDGET, "{} bytes", out.len());
         assert!(out.starts_with("# header\n"));
         assert!(out.contains("map trimmed to"));
+        let marker = out.lines().last().unwrap();
+        assert!(marker.starts_with("# note:"), "marker glued on: {marker}");
     }
 
     /// One unreadably wide declaration must not take the rest of the map with it.
@@ -606,90 +706,238 @@ mod tests {
         }
     }
 
-    /// A dropped unit takes its children with it, whatever the text looks like.
+    /// A dropped declaration takes everything nested under it.
     ///
-    /// Indentation is the only parent-child signal a map has, so a member kept
-    /// without its type header reads as a member of the previous type — a map
-    /// asserting a structure the file does not have, which is worse than a
-    /// shorter one. Two shapes in the fixture are the ones that broke it before:
-    /// a nested type emits a separator *inside* its parent's member list, and a
-    /// doc comment keeps its source indentation, so its continuation lines land
-    /// at columns like 3 that say nothing about depth. The invariant checked is
-    /// exactly the claim: every unit the trim kept still has all of its
-    /// ancestors.
+    /// A member kept without its type header reads as a member of the previous
+    /// type — a map asserting a structure the file does not have, which is worse
+    /// than a shorter one. The fixture puts the headers far above their members
+    /// in width, which is the window where a header cannot fit and its members
+    /// still can, and hands `cap_map` no leaner render, so the budget is spent in
+    /// file order and the parent rule is the only thing holding. The invariant
+    /// checked is exactly the claim the function makes: every declaration the
+    /// trim kept still has all of its ancestors.
     #[test]
     fn a_trim_never_keeps_a_unit_whose_parent_it_dropped() {
-        let joined_len = |u: &[String]| u.iter().map(String::len).sum::<usize>() + u.len();
-        // Headers far wider than their members, so the budget runs out in the
-        // window where a header cannot fit but its members still can.
-        let mut units: Vec<String> = vec!["# header".into()];
-        let mut n = 2;
-        while joined_len(&units) <= MAP_BUDGET + 40_000 {
-            units.push(format!("public class Outer{n}{}  L{n}", "X".repeat(3000)));
-            units.push(format!("    public static class Inner{n}  L{}", n + 1));
-            units.push(format!("        void inner{n}()  L{}", n + 2));
-            // The separator a nested type emits, sitting between its parent's
-            // members rather than after the last one.
-            units.push(String::new());
-            units.push(format!("    void survivor{n}()  L{}", n + 3));
-            // A Javadoc unit: prefixed first line, continuation lines carrying
-            // the indentation they had in the source.
-            units.push(format!(
-                "    /**\n   * Doc for docd{n}.\n   */\n    void docd{n}()  L{}",
-                n + 4
+        let mut units = vec![preamble("# header")];
+        let mut id = 0usize;
+        while map_bytes(&units) <= MAP_BUDGET + 40_000 {
+            let (outer, inner) = (id, id + 1);
+            units.push(decl_unit(
+                &format!("public class Outer{outer}{}  L1", "X".repeat(3000)),
+                outer,
+                None,
             ));
-            units.push(String::new());
-            n += 8;
+            units.push(decl_unit(
+                &format!("    public static class Inner{outer}  L2"),
+                inner,
+                Some(outer),
+            ));
+            units.push(decl_unit(
+                &format!("        void inner{outer}()  L3"),
+                inner + 1,
+                Some(inner),
+            ));
+            units.push(separator());
+            units.push(decl_unit(
+                &format!("    void survivor{outer}()  L4"),
+                inner + 2,
+                Some(outer),
+            ));
+            units.push(separator());
+            id += 4;
         }
 
-        // Each unit's ancestors, by the nearest preceding unit of smaller
-        // indent. Computed here rather than through `unit_indent`, so the
-        // expectation does not depend on the function under test: a blank unit
-        // is not a node, and reading its column as zero is the very mistake
-        // being guarded against.
-        let mut ancestors: Vec<(String, Vec<String>)> = Vec::new();
-        let mut stack: Vec<(usize, String)> = Vec::new();
-        for unit in &units {
-            if unit.trim().is_empty() {
-                continue;
-            }
-            let first = unit.lines().next().unwrap_or("");
-            let column = first.len() - first.trim_start_matches(' ').len();
-            while stack.last().is_some_and(|(c, _)| *c >= column) {
-                stack.pop();
-            }
-            ancestors.push((
-                unit.clone(),
-                stack.iter().map(|(_, u)| u.clone()).collect(),
-            ));
-            stack.push((column, unit.clone()));
-        }
-
-        let full = joined_len(&units);
-        let (out, delivered) = cap_map(units, "", full, Path::new("/tmp/wide.java"));
+        let full = map_bytes(&units);
+        let (out, delivered) = cap_map(&units, &[], "", full, Path::new("/tmp/wide.java"));
         assert!(delivered > 0, "the trim must deliver something to check");
         assert!(out.len() <= MAP_BUDGET, "{} bytes", out.len());
         assert!(out.contains("dropped"), "the fixture must trigger a trim");
 
-        let mut checked = 0usize;
+        let parent_of: HashMap<usize, Option<usize>> = units
+            .iter()
+            .filter_map(|u| match u.kind {
+                MapUnitKind::Declaration { id } => Some((id, u.parent)),
+                _ => None,
+            })
+            .collect();
+        let kept: HashSet<usize> = units
+            .iter()
+            .filter(|u| out.contains(u.text.as_str()))
+            .filter_map(|u| match u.kind {
+                MapUnitKind::Declaration { id } => Some(id),
+                _ => None,
+            })
+            .collect();
+        let text_of = |id: usize| {
+            units
+                .iter()
+                .find(|u| u.kind == MapUnitKind::Declaration { id })
+                .map(|u| u.text.chars().take(40).collect::<String>())
+                .unwrap_or_default()
+        };
+
         let mut orphans: Vec<String> = Vec::new();
-        for (unit, parents) in &ancestors {
-            if !out.contains(unit.as_str()) {
-                continue;
-            }
-            checked += 1;
-            for parent in parents {
-                if !out.contains(parent.as_str()) {
-                    orphans.push(format!(
-                        "{:?} kept without {:?}",
-                        unit.lines().last().unwrap_or(unit),
-                        parent.chars().take(40).collect::<String>()
-                    ));
+        for &id in &kept {
+            let mut ancestor = parent_of[&id];
+            while let Some(a) = ancestor {
+                if !kept.contains(&a) {
+                    orphans.push(format!("{:?} kept without {:?}", text_of(id), text_of(a)));
                 }
+                ancestor = parent_of[&a];
             }
         }
-        assert!(checked > 0, "the fixture kept nothing to check");
-        assert!(orphans.is_empty(), "orphaned units: {:#?}", &orphans[..orphans.len().min(3)]);
+        assert!(!kept.is_empty(), "the fixture kept nothing to check");
+        assert!(
+            orphans.is_empty(),
+            "orphaned units: {:#?}",
+            &orphans[..orphans.len().min(3)]
+        );
+    }
+
+    /// Units nest by the declaration tree, not by how their text came out.
+    ///
+    /// Rendered text answers no question about depth: the separator a nested type
+    /// emits sits between its parent's members rather than after the last one,
+    /// and a doc comment keeps the indentation it had in the source, so its
+    /// continuation lines land at columns like 3. Both used to file the member
+    /// after them under the wrong type. Regression guard for the class: what
+    /// nests under what is read off the tree, so no rendered line can lie
+    /// about it.
+    #[test]
+    fn map_units_nest_by_declaration_rather_than_by_rendered_text() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("Outer.java");
+        std::fs::write(
+            &p,
+            "public class Outer {\n\
+             \x20   public static class Inner {\n\
+             \x20       void innerMethod() {}\n\
+             \x20   }\n\
+             \n\
+             \x20   /**\n\
+             * Doc for afterInner.\n\
+             */\n\
+             \x20   void afterInner() {}\n\
+             }\n",
+        )
+        .unwrap();
+        let res = crate::main_helpers::parse_file_for_hook(&p).unwrap();
+        let units = crate::core::render_map_units(&res, &crate::core::MapOptions::default());
+        let unit_for = |needle: &str| {
+            units
+                .iter()
+                .find(|u| u.text.contains(needle))
+                .unwrap_or_else(|| panic!("no unit for {needle}:\n{}", join_units(&units)))
+        };
+        let id_for = |needle: &str| match unit_for(needle).kind {
+            MapUnitKind::Declaration { id } => id,
+            other => panic!("{needle} is {other:?}, not a declaration"),
+        };
+
+        assert_eq!(unit_for("class Inner").parent, Some(id_for("class Outer")));
+        assert_eq!(unit_for("innerMethod").parent, Some(id_for("class Inner")));
+        assert_eq!(
+            unit_for("afterInner").parent,
+            Some(id_for("class Outer")),
+            "a member after a nested type belongs to the enclosing type"
+        );
+        assert!(
+            units.iter().any(|u| u.kind == MapUnitKind::Separator),
+            "the fixture must render the separator the bug rode in on"
+        );
+    }
+
+    /// A declaration keeps its number when the options drop its neighbours.
+    ///
+    /// [`survival_ranks`] matches two renders of one file by that number, so a
+    /// number that shifted with the options would rank one declaration by
+    /// another's survival — and a shift is what a filtered-out *type* causes,
+    /// since its members are numbered too and never rendered. The fixture hides
+    /// a type with members behind `include_private`.
+    #[test]
+    fn a_declaration_keeps_its_number_across_renders() {
+        use crate::core::MapOptions;
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("hidden.rs");
+        std::fs::write(
+            &p,
+            "struct Hidden {\n    a: u32,\n    b: u32,\n}\n\npub fn api(x: u32) -> u32 { x }\n",
+        )
+        .unwrap();
+        let res = crate::main_helpers::parse_file_for_hook(&p).unwrap();
+        let full = crate::core::render_map_units(&res, &MapOptions::default());
+        let lean = crate::core::render_map_units(
+            &res,
+            &MapOptions {
+                include_private: false,
+                include_fields: false,
+                ..MapOptions::default()
+            },
+        );
+
+        let named = |units: &[MapUnit]| -> HashMap<usize, String> {
+            units
+                .iter()
+                .filter_map(|u| match u.kind {
+                    MapUnitKind::Declaration { id } => Some((id, u.text.clone())),
+                    _ => None,
+                })
+                .collect()
+        };
+        let (full_by_id, lean_by_id) = (named(&full), named(&lean));
+        assert!(
+            full_by_id.len() > lean_by_id.len() + 1,
+            "the fixture must hide a type and its members: {} of {}",
+            lean_by_id.len(),
+            full_by_id.len()
+        );
+        for (id, text) in &lean_by_id {
+            assert_eq!(
+                full_by_id.get(id),
+                Some(text),
+                "declaration {id} is {text:?} in one render and {:?} in the other",
+                full_by_id.get(id)
+            );
+        }
+    }
+
+    /// A trim spends the budget on the public surface before the rest.
+    ///
+    /// Filling in file order handed over 1733 private helpers and not one of a
+    /// file's 500 public functions, because the publics run to the end of a file
+    /// three times the budget. The shed level that keeps exactly those publics is
+    /// 19 KB, so that payload was worse than a candidate it outranked on count
+    /// alone. Interleaving the two in the fixture is deliberate: with the publics
+    /// in one block at the front, file order would keep them by luck.
+    #[test]
+    fn a_trim_keeps_the_public_surface_before_it_spends_the_rest() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("interleaved.rs");
+        let mut src = String::new();
+        for i in 0..500 {
+            src.push_str(&format!("pub fn api_{i:03}(a: u32) -> u32 {{ a }}\n"));
+            for j in 0..6 {
+                src.push_str(&format!("fn helper_{i:03}_{j}(a: u32) -> u32 {{ a }}\n"));
+            }
+        }
+        std::fs::write(&p, &src).unwrap();
+
+        match decide(&ev("Read", Some(p), false), &opts(), replacing()) {
+            Decision::Substitute { map } => {
+                assert!(map.len() <= MAP_BUDGET, "{} bytes", map.len());
+                assert_eq!(
+                    map.matches("pub fn api_").count(),
+                    500,
+                    "the public surface fits in a third of the budget and must survive whole"
+                );
+                let helpers = map.matches("fn helper_").count();
+                assert!(
+                    helpers > 500,
+                    "only {helpers} private helpers survived; the rest of the budget is theirs"
+                );
+            }
+            other => panic!("expected a trimmed map: {other:?}"),
+        }
     }
 
     /// Shedding is chosen for what it delivers, not for fitting.

--- a/src/hook/event.rs
+++ b/src/hook/event.rs
@@ -28,12 +28,15 @@ pub enum Channel {
     /// successful tool call rather than a failure that did not happen.
     ///
     /// Claude Code exposes this as `PostToolUse` `updatedToolOutput`, and
-    /// `ast-bro install` does **not** register it. Measured on 2.1.223: the
-    /// field replaces the result of an MCP tool and is ignored for the built-in
-    /// `Read` and `Bash`, so registering it would drop the substitution and
-    /// send the whole file to the model. Kept because the shim reaches it from
-    /// any hand-written `PostToolUse` entry, and because deleting it would
-    /// throw away the measurement. See issue #34.
+    /// `ast-bro install` does **not** register it. Measured on 2.1.223 through
+    /// this hook: the field replaced the result of an MCP tool and was ignored
+    /// for the built-in `Read` and `Bash`, so registering it would drop the
+    /// substitution and send the whole file to the model. Whether the host
+    /// declines it for every built-in tool or only for one lacking an output
+    /// schema is not settled — the two are indistinguishable from here, and
+    /// either way `Read` is on the wrong side of it. Kept because the shim
+    /// reaches it from any hand-written `PostToolUse` entry, and because
+    /// deleting it would throw away the measurement. See issue #34.
     Replace,
     /// Deliver the map beside a result the hook cannot replace. Claude Code's
     /// `PostToolUseFailure` offers only `additionalContext`, which is enough

--- a/src/hook/event.rs
+++ b/src/hook/event.rs
@@ -10,5 +10,47 @@ pub struct ToolCallEvent {
 #[derive(Debug, Clone)]
 pub enum Decision {
     PassThrough,
-    Substitute { content: String },
+    /// The map to put where the file contents would have gone, with no notice
+    /// wrapped around it. [`Channel`] owns that wording, because what the
+    /// notice has to disclaim depends on how the host reports the payload.
+    Substitute { map: String },
+}
+
+/// How a host lets a hook put its own content where a tool's output would go.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Channel {
+    /// Refuse the call and carry the map in the rejection. The read never
+    /// runs, and the host renders the refusal as a failed tool call, so the
+    /// payload has to open by saying that nothing failed. Gemini's
+    /// `BeforeTool` and Claude Code's `PreToolUse` offer only this.
+    Deny,
+    /// Let the read run and swap its output for the map, so the host reports a
+    /// successful tool call rather than a failure that did not happen.
+    ///
+    /// Claude Code exposes this as `PostToolUse` `updatedToolOutput`, and
+    /// `ast-bro install` does **not** register it. Measured on 2.1.223: the
+    /// field replaces the result of an MCP tool and is ignored for the built-in
+    /// `Read` and `Bash`, so registering it would drop the substitution and
+    /// send the whole file to the model. Kept because the shim reaches it from
+    /// any hand-written `PostToolUse` entry, and because deleting it would
+    /// throw away the measurement. See issue #34.
+    Replace,
+    /// Deliver the map beside a result the hook cannot replace. Claude Code's
+    /// `PostToolUseFailure` offers only `additionalContext`, which is enough
+    /// here: the read failed, so there is no file contents for the map to
+    /// compete with, and the alternative is an error with no map at all.
+    Augment,
+}
+
+impl Channel {
+    /// True when the payload is added to a result rather than replacing one.
+    ///
+    /// The gates that keep a substitution from withholding what the caller asked
+    /// for do not apply here: the read already ran and returned nothing, so the
+    /// map takes the place of nothing. It is also the only channel where a line
+    /// count is the wrong question — the host refuses on byte size, so a
+    /// 90-line file of 355 KB trips the refusal and no line threshold.
+    pub fn is_additive(self) -> bool {
+        matches!(self, Channel::Augment)
+    }
 }

--- a/src/hook/gemini.rs
+++ b/src/hook/gemini.rs
@@ -4,14 +4,15 @@
 //!   { "tool_name": "read_file",
 //!     "tool_input": { "absolute_path": "...", "offset": ..., "limit": ... } }
 //!
-//! Response shape is shared with Claude Code — see `super::io`.
+//! `BeforeTool` fires before the read, so a map can only reach the model
+//! through a refusal — see [`Channel::Deny`] and `super::io`.
 
 use std::path::PathBuf;
 
 use serde::Deserialize;
 
 use super::decide::DecideOpts;
-use super::event::ToolCallEvent;
+use super::event::{Channel, ToolCallEvent};
 use super::io::{dispatch, emit_pass_through, read_stdin};
 
 #[derive(Debug, Deserialize)]
@@ -57,6 +58,7 @@ pub fn run(opts: DecideOpts) -> i32 {
                 || event.tool_input.limit.is_some(),
         },
         &opts,
+        Channel::Deny,
     )
 }
 

--- a/src/hook/io.rs
+++ b/src/hook/io.rs
@@ -1,18 +1,67 @@
 //! Shared stdin/stdout plumbing for hook protocols.
 //!
-//! Both Claude Code and Gemini speak the same response shape:
-//!   pass-through: `{"continue": true}`
-//!   substitute:   `{"decision": "block", "reason": "<content>"}`
+//! Pass-through is one shape everywhere: `{"continue": true}`. A substitution
+//! has one shape per [`Channel`]: a `{"decision": "block"}` refusal the host
+//! reports as a failed call, a `hookSpecificOutput.updatedToolOutput`
+//! replacement it reports as a successful one, and a
+//! `hookSpecificOutput.additionalContext` payload for a result no hook may
+//! replace.
 //!
-//! Only the input parsing differs (field names, tool-name normalization),
-//! which lives in the protocol-specific shims (`claude_code.rs`, `gemini.rs`).
+//! Only the input parsing differs per host (field names, tool-name
+//! normalization), which lives in the protocol shims (`claude_code.rs`,
+//! `gemini.rs`).
 
 use std::io::{self, Read, Write};
 
 use serde::Serialize;
 
 use super::decide::{decide, DecideOpts};
-use super::event::{Decision, ToolCallEvent};
+use super::event::{Channel, Decision, ToolCallEvent};
+
+/// Notice leading a [`Channel::Deny`] payload. The host renders the refusal as
+/// a failed tool call, so the first line says outright that nothing failed —
+/// a reader who takes the wrapper at face value abandons the answer it holds.
+const DENY_NOTICE: &str = "\
+# ast-bro substituted this structure map for the full Read: nothing failed.
+# The map below is the answer, with line ranges. For more detail, re-read with
+# offset/limit, or `ast-bro show <file> <symbol>` for a symbol's body.";
+
+/// Notice leading a [`Channel::Replace`] payload. The read succeeded here, so
+/// this one has no failure to disclaim and spends its words on what arrived.
+const REPLACE_NOTICE: &str = "\
+# ast-bro replaced the file contents with this structure map, with line ranges.
+# For more detail, re-read with offset/limit, or `ast-bro show <file> <symbol>`
+# for a symbol's body.";
+
+/// Notice leading a [`Channel::Augment`] payload.
+///
+/// It states only what the hook knows. The event fires for every kind of tool
+/// failure and the shim reads no error field, so naming a cause or predicting
+/// that a retry fails again would be a guess — and a wrong one whenever the
+/// read failed for a reason a retry would clear.
+const AUGMENT_NOTICE: &str = "\
+# ast-bro supplies this structure map, with line ranges, because the Read did
+# not return the file. Read a range with offset/limit, or run
+# `ast-bro show <file> <symbol>` for one symbol's body.";
+
+/// The most a notice plus its separators can add to a map in [`payload`].
+///
+/// `decide` holds this back from its byte ceiling, so the ceiling bounds what is
+/// delivered rather than only the map inside it.
+pub(super) const MAX_NOTICE_BYTES: usize = widest(
+    DENY_NOTICE.len(),
+    REPLACE_NOTICE.len(),
+    AUGMENT_NOTICE.len(),
+) + 3; // payload joins with "\n\n" and ends with "\n"
+
+const fn widest(a: usize, b: usize, c: usize) -> usize {
+    let ab = if a > b { a } else { b };
+    if ab > c {
+        ab
+    } else {
+        c
+    }
+}
 
 #[derive(Debug, Serialize)]
 struct PassThroughResponse {
@@ -21,9 +70,35 @@ struct PassThroughResponse {
 }
 
 #[derive(Debug, Serialize)]
-struct SubstituteResponse {
+struct DenyResponse {
     decision: &'static str,
     reason: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ReplaceResponse {
+    hook_specific_output: PostToolUseOutput,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PostToolUseOutput {
+    hook_event_name: &'static str,
+    updated_tool_output: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AugmentResponse {
+    hook_specific_output: AdditionalContextOutput,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AdditionalContextOutput {
+    hook_event_name: &'static str,
+    additional_context: String,
 }
 
 pub fn read_stdin() -> io::Result<String> {
@@ -32,36 +107,48 @@ pub fn read_stdin() -> io::Result<String> {
     Ok(buf)
 }
 
-pub fn dispatch(event: ToolCallEvent, opts: &DecideOpts) -> i32 {
-    match decide(&event, opts) {
+pub fn dispatch(event: ToolCallEvent, opts: &DecideOpts, channel: Channel) -> i32 {
+    match decide(&event, opts, channel) {
         Decision::PassThrough => emit_pass_through(),
-        Decision::Substitute { content } => emit_substitute(content),
+        Decision::Substitute { map } => emit_substitute(channel, map),
     }
 }
 
 pub fn emit_pass_through() -> i32 {
-    let r = PassThroughResponse { cont: true };
-    match serde_json::to_string(&r) {
-        Ok(json) => match writeln!(io::stdout(), "{}", json) {
-            Ok(_) => 0,
-            Err(e) => {
-                let _ = writeln!(io::stderr(), "hook: stdout write failed: {}", e);
-                1
-            }
-        },
-        Err(e) => {
-            let _ = writeln!(io::stderr(), "hook: serialization failed: {}", e);
-            1
-        }
+    emit(&PassThroughResponse { cont: true })
+}
+
+pub fn emit_substitute(channel: Channel, map: String) -> i32 {
+    match channel {
+        Channel::Deny => emit(&DenyResponse {
+            decision: "block",
+            reason: payload(DENY_NOTICE, &map),
+        }),
+        Channel::Replace => emit(&ReplaceResponse {
+            hook_specific_output: PostToolUseOutput {
+                hook_event_name: "PostToolUse",
+                updated_tool_output: payload(REPLACE_NOTICE, &map),
+            },
+        }),
+        Channel::Augment => emit(&AugmentResponse {
+            hook_specific_output: AdditionalContextOutput {
+                hook_event_name: "PostToolUseFailure",
+                additional_context: payload(AUGMENT_NOTICE, &map),
+            },
+        }),
     }
 }
 
-pub fn emit_substitute(content: String) -> i32 {
-    let r = SubstituteResponse {
-        decision: "block",
-        reason: content,
-    };
-    match serde_json::to_string(&r) {
+/// Puts `notice` ahead of `map`, separated by a blank line. The notice leads
+/// and appears once: a duplicate at the end is noise on the tool's
+/// highest-frequency output path, and a reader who has scrolled that far has
+/// already decided what to do with the payload.
+fn payload(notice: &str, map: &str) -> String {
+    format!("{}\n\n{}\n", notice, map)
+}
+
+fn emit<T: Serialize>(response: &T) -> i32 {
+    match serde_json::to_string(response) {
         Ok(json) => match writeln!(io::stdout(), "{}", json) {
             Ok(_) => 0,
             Err(e) => {
@@ -80,6 +167,17 @@ pub fn emit_substitute(content: String) -> i32 {
 mod tests {
     use super::*;
 
+    /// Every channel, so a new one cannot slip past the notice tests below.
+    const ALL_CHANNELS: [Channel; 3] = [Channel::Deny, Channel::Replace, Channel::Augment];
+
+    fn notice_of(channel: Channel) -> &'static str {
+        match channel {
+            Channel::Deny => DENY_NOTICE,
+            Channel::Replace => REPLACE_NOTICE,
+            Channel::Augment => AUGMENT_NOTICE,
+        }
+    }
+
     #[test]
     fn pass_through_response_serializes_with_continue_true() {
         let r = PassThroughResponse { cont: true };
@@ -88,13 +186,120 @@ mod tests {
     }
 
     #[test]
-    fn substitute_response_serializes_with_decision_block() {
-        let r = SubstituteResponse {
+    fn deny_response_serializes_with_decision_block() {
+        let r = DenyResponse {
             decision: "block",
             reason: "x".into(),
         };
         let s = serde_json::to_string(&r).unwrap();
         assert!(s.contains("\"decision\":\"block\""));
         assert!(s.contains("\"reason\":\"x\""));
+    }
+
+    /// The replacement rides `hookSpecificOutput.updatedToolOutput` under the
+    /// host's camelCase spelling. A field the host does not recognize is
+    /// ignored in silence, which shows up as the full file reaching the model.
+    #[test]
+    fn replace_response_serializes_with_updated_tool_output() {
+        let r = ReplaceResponse {
+            hook_specific_output: PostToolUseOutput {
+                hook_event_name: "PostToolUse",
+                updated_tool_output: "x".into(),
+            },
+        };
+        let s = serde_json::to_string(&r).unwrap();
+        assert_eq!(
+            s,
+            r#"{"hookSpecificOutput":{"hookEventName":"PostToolUse","updatedToolOutput":"x"}}"#
+        );
+    }
+
+    /// Every channel's notice leads the payload, appears once, and names both
+    /// recovery routes — a substitution the reader cannot act on is a map they
+    /// will look up a second way.
+    #[test]
+    fn every_notice_leads_once_and_names_both_recovery_routes() {
+        for channel in ALL_CHANNELS {
+            let notice = notice_of(channel);
+            let p = payload(notice, "# map body\nfn f() L1-2");
+            assert!(p.starts_with("# ast-bro "), "{channel:?}: {p}");
+            assert_eq!(
+                p.matches("# ast-bro ").count(),
+                1,
+                "{channel:?}: notice must appear exactly once:\n{p}"
+            );
+            for phrase in ["structure map", "offset/limit", "ast-bro show"] {
+                assert!(
+                    p.contains(phrase),
+                    "{channel:?}: notice must mention '{phrase}':\n{p}"
+                );
+            }
+            assert!(p.contains("# map body"), "{channel:?}: {p}");
+        }
+    }
+
+    /// Every notice keeps its recovery command on one line.
+    ///
+    /// The notices are comment-prefixed and hard-wrapped, so a wrap inside the
+    /// backticks puts the next line's `#` between the command's arguments: the
+    /// reader copies `ast-bro show <file>` and a comment, and `show` exits 2 for
+    /// a missing symbol. Nothing else in the payload would look wrong.
+    #[test]
+    fn every_notice_keeps_its_command_on_one_line() {
+        for channel in ALL_CHANNELS {
+            let notice = notice_of(channel);
+            let line = notice
+                .lines()
+                .find(|l| l.contains("ast-bro show"))
+                .unwrap_or_else(|| panic!("{channel:?}: no line names `ast-bro show`"));
+            assert!(
+                line.contains("ast-bro show <file> <symbol>`"),
+                "{channel:?}: the command is split across lines: {line}"
+            );
+        }
+    }
+
+    /// Only the refusal disclaims a failure. Saying "nothing failed" on a
+    /// channel that reported success invents the very failure issue #34 is
+    /// about.
+    #[test]
+    fn only_the_deny_notice_disclaims_a_failure() {
+        assert!(DENY_NOTICE.contains("nothing failed"));
+        assert!(!REPLACE_NOTICE.contains("failed"));
+    }
+
+    /// The augment notice claims no cause and predicts no retry. The event
+    /// fires for every kind of failure and the shim reads no error field, so
+    /// either claim would be invented — and wrong whenever a retry would work.
+    #[test]
+    fn the_augment_notice_asserts_no_cause_and_no_prediction() {
+        // Assert the claim, not where it wraps: re-wrapping the notice is a
+        // legitimate edit, and `every_notice_keeps_its_command_on_one_line` is
+        // the guard that a wrap must not break.
+        let flowed = AUGMENT_NOTICE.replace("\n# ", " ");
+        assert!(flowed.contains("because the Read did not return the file"), "{flowed}");
+        for invented in ["nothing failed", "same way", "will fail", "too large", "exceeds"] {
+            assert!(
+                !flowed.contains(invented),
+                "notice must not claim '{invented}':\n{flowed}"
+            );
+        }
+    }
+
+    /// `additionalContext` is the only channel `PostToolUseFailure` offers, and
+    /// it must carry the host's own camelCase spelling or the map is dropped.
+    #[test]
+    fn augment_response_serializes_with_additional_context() {
+        let r = AugmentResponse {
+            hook_specific_output: AdditionalContextOutput {
+                hook_event_name: "PostToolUseFailure",
+                additional_context: "x".into(),
+            },
+        };
+        let s = serde_json::to_string(&r).unwrap();
+        assert_eq!(
+            s,
+            r#"{"hookSpecificOutput":{"hookEventName":"PostToolUseFailure","additionalContext":"x"}}"#
+        );
     }
 }

--- a/src/hook/io.rs
+++ b/src/hook/io.rs
@@ -52,7 +52,7 @@ pub(super) const MAX_NOTICE_BYTES: usize = widest(
     DENY_NOTICE.len(),
     REPLACE_NOTICE.len(),
     AUGMENT_NOTICE.len(),
-) + 3; // payload joins with "\n\n" and ends with "\n"
+) + 3;
 
 const fn widest(a: usize, b: usize, c: usize) -> usize {
     let ab = if a > b { a } else { b };
@@ -143,8 +143,19 @@ pub fn emit_substitute(channel: Channel, map: String) -> i32 {
 /// and appears once: a duplicate at the end is noise on the tool's
 /// highest-frequency output path, and a reader who has scrolled that far has
 /// already decided what to do with the payload.
+///
+/// This is where the byte ceiling is finally either kept or broken, since it is
+/// the last thing that adds to a map, so the claim is checked here rather than
+/// inferred from the two sizings that lead to it.
 fn payload(notice: &str, map: &str) -> String {
-    format!("{}\n\n{}\n", notice, map)
+    let out = format!("{}\n\n{}\n", notice, map);
+    debug_assert!(
+        out.len() <= super::decide::MAX_MAP_BYTES,
+        "delivered {} bytes against a {} byte ceiling",
+        out.len(),
+        super::decide::MAX_MAP_BYTES
+    );
+    out
 }
 
 fn emit<T: Serialize>(response: &T) -> i32 {
@@ -175,6 +186,30 @@ mod tests {
             Channel::Deny => DENY_NOTICE,
             Channel::Replace => REPLACE_NOTICE,
             Channel::Augment => AUGMENT_NOTICE,
+        }
+    }
+
+    /// A map that spends the whole budget lands exactly on the ceiling, whichever
+    /// notice leads it.
+    ///
+    /// [`MAX_NOTICE_BYTES`] is what `decide` holds back for this function, so a
+    /// separator it adds and the constant does not count is a byte over the
+    /// ceiling on every full-budget payload. Equality pins it in both directions:
+    /// short, and the ceiling breaks; wide, and the map is smaller than it needed
+    /// to be.
+    #[test]
+    fn a_full_budget_map_lands_exactly_on_the_ceiling() {
+        let map = "x".repeat(super::super::decide::MAP_BUDGET);
+        for channel in ALL_CHANNELS {
+            let notice = notice_of(channel);
+            let framed = payload(notice, &map).len();
+            let slack = super::super::decide::MAX_MAP_BYTES - framed;
+            assert_eq!(
+                slack,
+                MAX_NOTICE_BYTES - (notice.len() + 3),
+                "{channel:?}: {framed} bytes delivered, and only the notice's own \
+                 width may be under the ceiling"
+            );
         }
     }
 

--- a/src/hook/io.rs
+++ b/src/hook/io.rs
@@ -10,6 +10,11 @@
 //! Only the input parsing differs per host (field names, tool-name
 //! normalization), which lives in the protocol shims (`claude_code.rs`,
 //! `gemini.rs`).
+//!
+//! Assembling the payload is also what makes this the module that owns the byte
+//! ceiling — [`MAX_MAP_BYTES`], the notice it reserves room for, and the
+//! [`MAP_BUDGET`] that leaves for a map. `decide` sizes maps against the budget;
+//! it does not need to know what the framing costs.
 
 use std::io::{self, Read, Write};
 
@@ -17,6 +22,21 @@ use serde::Serialize;
 
 use super::decide::{decide, DecideOpts};
 use super::event::{Channel, Decision, ToolCallEvent};
+
+/// Ceiling on what the hook delivers, in bytes, notice included.
+///
+/// The host refuses a read at roughly 25k tokens, so answering with a payload of
+/// the same order defeats the point. 64 KB is about 16k tokens: under the limit
+/// the refusal was about, and above every real map measured — Apache Calcite's
+/// `SqlFunctions.java`, 7771 hand-written lines and the largest map in that
+/// repository, fits once doc comments and attributes are shed. What does not fit
+/// is a minified bundle, whose size is declaration count rather than detail, and
+/// that is what `decide::cap_map` is for.
+///
+/// It lives here because this is where a payload is finally assembled, and it is
+/// what [`MAP_BUDGET`] is derived from: `decide` sizes a map against the budget,
+/// and the notice this module wraps it in is the difference between the two.
+pub(super) const MAX_MAP_BYTES: usize = 64 * 1024;
 
 /// Notice leading a [`Channel::Deny`] payload. The host renders the refusal as
 /// a failed tool call, so the first line says outright that nothing failed —
@@ -50,9 +70,10 @@ const SEPARATOR_BYTES: usize = 3;
 
 /// The most a notice plus its separators can add to a map in [`payload`].
 ///
-/// `decide` holds this back from its byte ceiling, so the ceiling bounds what is
-/// delivered rather than only the map inside it.
-pub(super) const MAX_NOTICE_BYTES: usize = widest(
+/// Held back from [`MAX_MAP_BYTES`] so that ceiling bounds what is delivered
+/// rather than only the map inside it. Private, because that subtraction is this
+/// module's business: what `decide` needs is the [`MAP_BUDGET`] it leaves.
+const MAX_NOTICE_BYTES: usize = widest(
     DENY_NOTICE.len(),
     REPLACE_NOTICE.len(),
     AUGMENT_NOTICE.len(),
@@ -66,6 +87,12 @@ const fn widest(a: usize, b: usize, c: usize) -> usize {
         c
     }
 }
+
+/// What a map may occupy once the channel notice is accounted for.
+///
+/// [`payload`] prepends a notice to every map, so a map sized against
+/// [`MAX_MAP_BYTES`] alone would be delivered above it.
+pub(super) const MAP_BUDGET: usize = MAX_MAP_BYTES - MAX_NOTICE_BYTES;
 
 #[derive(Debug, Serialize)]
 struct PassThroughResponse {
@@ -154,10 +181,10 @@ pub fn emit_substitute(channel: Channel, map: String) -> i32 {
 fn payload(notice: &str, map: &str) -> String {
     let out = format!("{}\n\n{}\n", notice, map);
     debug_assert!(
-        out.len() <= super::decide::MAX_MAP_BYTES,
+        out.len() <= MAX_MAP_BYTES,
         "delivered {} bytes against a {} byte ceiling",
         out.len(),
-        super::decide::MAX_MAP_BYTES
+        MAX_MAP_BYTES
     );
     out
 }
@@ -196,18 +223,18 @@ mod tests {
     /// A map that spends the whole budget lands exactly on the ceiling, whichever
     /// notice leads it.
     ///
-    /// [`MAX_NOTICE_BYTES`] is what `decide` holds back for this function, so a
-    /// separator it adds and the constant does not count is a byte over the
+    /// [`MAX_NOTICE_BYTES`] is what [`MAP_BUDGET`] holds back for this function,
+    /// so a separator it adds and the constant does not count is a byte over the
     /// ceiling on every full-budget payload. Equality pins it in both directions:
     /// short, and the ceiling breaks; wide, and the map is smaller than it needed
     /// to be.
     #[test]
     fn a_full_budget_map_lands_exactly_on_the_ceiling() {
-        let map = "x".repeat(super::super::decide::MAP_BUDGET);
+        let map = "x".repeat(MAP_BUDGET);
         for channel in ALL_CHANNELS {
             let notice = notice_of(channel);
             let framed = payload(notice, &map).len();
-            let slack = super::super::decide::MAX_MAP_BYTES - framed;
+            let slack = MAX_MAP_BYTES - framed;
             assert_eq!(
                 slack,
                 MAX_NOTICE_BYTES - (notice.len() + SEPARATOR_BYTES),

--- a/src/hook/io.rs
+++ b/src/hook/io.rs
@@ -44,6 +44,10 @@ const AUGMENT_NOTICE: &str = "\
 # not return the file. Read a range with offset/limit, or run
 # `ast-bro show <file> <symbol>` for one symbol's body.";
 
+/// What [`payload`] adds around the notice: the blank line it puts between the
+/// notice and the map, and the newline it ends with.
+const SEPARATOR_BYTES: usize = 3;
+
 /// The most a notice plus its separators can add to a map in [`payload`].
 ///
 /// `decide` holds this back from its byte ceiling, so the ceiling bounds what is
@@ -52,7 +56,7 @@ pub(super) const MAX_NOTICE_BYTES: usize = widest(
     DENY_NOTICE.len(),
     REPLACE_NOTICE.len(),
     AUGMENT_NOTICE.len(),
-) + 3;
+) + SEPARATOR_BYTES;
 
 const fn widest(a: usize, b: usize, c: usize) -> usize {
     let ab = if a > b { a } else { b };
@@ -206,7 +210,7 @@ mod tests {
             let slack = super::super::decide::MAX_MAP_BYTES - framed;
             assert_eq!(
                 slack,
-                MAX_NOTICE_BYTES - (notice.len() + 3),
+                MAX_NOTICE_BYTES - (notice.len() + SEPARATOR_BYTES),
                 "{channel:?}: {framed} bytes delivered, and only the notice's own \
                  width may be under the ceiling"
             );

--- a/src/installers/claude_code.rs
+++ b/src/installers/claude_code.rs
@@ -9,7 +9,31 @@ use crate::prompt::{agent_prompt, agent_skill_md, EXPLORE_FRONTMATTER};
 
 pub struct ClaudeCode;
 
+/// The read has to be intercepted before it runs. `PreToolUse` is the only
+/// event that can do it, and it can only refuse the call, so the host reports a
+/// failure that did not happen — the complaint in issue #34.
+///
+/// The alternative that would report a success, `PostToolUse` with
+/// `updatedToolOutput`, is deliberately not registered: measured on Claude Code
+/// 2.1.223, that field replaces the result of an MCP tool and is ignored for
+/// the built-in `Read`, so registering it would deliver no map and send the
+/// whole file to the model instead.
 const HOOK_PATH: &[&str] = &["hooks", "PreToolUse"];
+
+/// A read the host refuses outright never reaches `PreToolUse`'s substitution —
+/// it fails on byte size, which no line threshold predicts — and would
+/// otherwise reach the model as a bare error. This event covers it. It cannot
+/// replace the result, only add context, which is all the map needs when the
+/// result carries no file contents.
+const FAILURE_HOOK_PATH: &[&str] = &["hooks", "PostToolUseFailure"];
+
+/// Events an install registers the entry under.
+const INSTALL_HOOK_PATHS: &[&[&str]] = &[HOOK_PATH, FAILURE_HOOK_PATH];
+
+/// Every event our entry has lived under, for uninstall. `status` asks about
+/// [`INSTALL_HOOK_PATHS`] instead, so a release that stops writing an event does
+/// not keep reporting it as required.
+const ALL_HOOK_PATHS: &[&[&str]] = &[HOOK_PATH, FAILURE_HOOK_PATH];
 
 /// Built-in Claude Code subagents that run in their own context and never see
 /// `CLAUDE.md`. Shadowing them with `.claude/agents/<Name>.md` is the official
@@ -110,7 +134,7 @@ impl Installer for ClaudeCode {
     fn install_hook(&self, scope: &Scope, opts: &InstallOpts) -> Result<Change, String> {
         common::install_json_hook_in(
             &self.settings_path(scope)?,
-            HOOK_PATH,
+            INSTALL_HOOK_PATHS,
             self.hook_entry(opts),
             matches_entry,
             opts,
@@ -150,9 +174,12 @@ impl Installer for ClaudeCode {
         if let Some(c) = common::uninstall_prompt_in(&self.prompt_path(scope)?, opts)? {
             changes.push(c);
         }
-        if let Some(c) =
-            common::uninstall_json_hook_in(&self.settings_path(scope)?, HOOK_PATH, matches_entry, opts)?
-        {
+        if let Some(c) = common::uninstall_json_hook_in(
+            &self.settings_path(scope)?,
+            ALL_HOOK_PATHS,
+            matches_entry,
+            opts,
+        )? {
             changes.push(c);
         }
         for name in SHADOWED_SUBAGENTS {
@@ -190,7 +217,7 @@ impl Installer for ClaudeCode {
         let mut s = common::status_for(
             self.prompt_path(scope).ok().as_deref(),
             self.settings_path(scope).ok().as_deref(),
-            HOOK_PATH,
+            INSTALL_HOOK_PATHS,
             matches_entry,
         );
         if let Ok(mcp_p) = self.mcp_path(scope) {
@@ -213,6 +240,7 @@ impl Installer for ClaudeCode {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::installers::json_hook;
     use tempfile::TempDir;
 
     fn local_scope(dir: &TempDir) -> Scope {
@@ -258,6 +286,76 @@ mod tests {
         let contents = std::fs::read_to_string(dir.path().join(".claude/settings.json")).unwrap();
         assert!(contents.contains("--protocol claude-code"));
         assert!(contents.contains("\"matcher\": \"Read\""));
+        let root: Value = serde_json::from_str(&contents).unwrap();
+        assert!(json_hook::is_installed(&root, HOOK_PATH, matches_entry));
+    }
+
+
+    /// The entry is registered under `PreToolUse`, which is the only event that
+    /// can intercept the read before it happens, and under
+    /// `PostToolUseFailure`, which covers the read the host refuses outright.
+    /// `PostToolUse` is deliberately absent: on Claude Code 2.1.223
+    /// `updatedToolOutput` is ignored for the built-in `Read`, so registering it
+    /// would deliver no map at all.
+    #[test]
+    fn install_hook_registers_pre_tool_use_and_the_failure_event() {
+        let dir = TempDir::new().unwrap();
+        let scope = local_scope(&dir);
+        ClaudeCode
+            .install_hook(&scope, &InstallOpts::default())
+            .unwrap();
+        let contents = std::fs::read_to_string(dir.path().join(".claude/settings.json")).unwrap();
+        let root: Value = serde_json::from_str(&contents).unwrap();
+        for path in INSTALL_HOOK_PATHS {
+            assert!(
+                json_hook::is_installed(&root, path, matches_entry),
+                "missing under {path:?}: {contents}"
+            );
+        }
+        assert!(
+            !contents.contains("\"PostToolUse\""),
+            "PostToolUse must not be registered: {contents}"
+        );
+    }
+
+    /// A settings file carrying only the pre-read entry — what every install
+    /// from before the failure event looks like — reports partial, not current.
+    /// Otherwise the new capability never reaches an existing install and the one
+    /// diagnostic that could say so asserts the opposite.
+    #[test]
+    fn status_reports_partial_for_an_install_missing_the_failure_event() {
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir_all(dir.path().join(".claude")).unwrap();
+        std::fs::write(
+            dir.path().join(".claude/settings.json"),
+            r#"{"hooks":{"PreToolUse":[{"matcher":"Read","hooks":[{"type":"command","command":"ast-bro hook --protocol claude-code --min-lines 200"}]}]}}"#,
+        )
+        .unwrap();
+        let scope = local_scope(&dir);
+        let s = ClaudeCode.status(&scope);
+        assert!(s.hook_installed, "the entry is there, just not everywhere");
+        assert!(s.hook_partial);
+    }
+
+    /// A complete install is not partial, or the warning means nothing — and a
+    /// reinstall over a partial one clears it.
+    #[test]
+    fn status_is_not_partial_after_install_completes_it() {
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir_all(dir.path().join(".claude")).unwrap();
+        std::fs::write(
+            dir.path().join(".claude/settings.json"),
+            r#"{"hooks":{"PreToolUse":[{"matcher":"Read","hooks":[{"type":"command","command":"ast-bro hook --protocol claude-code --min-lines 200"}]}]}}"#,
+        )
+        .unwrap();
+        let scope = local_scope(&dir);
+        assert!(ClaudeCode.status(&scope).hook_partial);
+        ClaudeCode
+            .install_hook(&scope, &InstallOpts::default())
+            .unwrap();
+        let s = ClaudeCode.status(&scope);
+        assert!(s.hook_installed);
+        assert!(!s.hook_partial, "install must complete the registration");
     }
 
     #[test]

--- a/src/installers/claude_code.rs
+++ b/src/installers/claude_code.rs
@@ -15,9 +15,10 @@ pub struct ClaudeCode;
 ///
 /// The alternative that would report a success, `PostToolUse` with
 /// `updatedToolOutput`, is deliberately not registered: measured on Claude Code
-/// 2.1.223, that field replaces the result of an MCP tool and is ignored for
+/// 2.1.223, that field replaced the result of an MCP tool and was ignored for
 /// the built-in `Read`, so registering it would deliver no map and send the
-/// whole file to the model instead.
+/// whole file to the model instead. See [`Channel::Replace`] for what the
+/// measurement does and does not settle.
 const HOOK_PATH: &[&str] = &["hooks", "PreToolUse"];
 
 /// A read the host refuses outright never reaches `PreToolUse`'s substitution —
@@ -27,13 +28,8 @@ const HOOK_PATH: &[&str] = &["hooks", "PreToolUse"];
 /// result carries no file contents.
 const FAILURE_HOOK_PATH: &[&str] = &["hooks", "PostToolUseFailure"];
 
-/// Events an install registers the entry under.
-const INSTALL_HOOK_PATHS: &[&[&str]] = &[HOOK_PATH, FAILURE_HOOK_PATH];
-
-/// Every event our entry has lived under, for uninstall. `status` asks about
-/// [`INSTALL_HOOK_PATHS`] instead, so a release that stops writing an event does
-/// not keep reporting it as required.
-const ALL_HOOK_PATHS: &[&[&str]] = &[HOOK_PATH, FAILURE_HOOK_PATH];
+/// The events our entry is registered under.
+const HOOK_PATHS: &[&[&str]] = &[HOOK_PATH, FAILURE_HOOK_PATH];
 
 /// Built-in Claude Code subagents that run in their own context and never see
 /// `CLAUDE.md`. Shadowing them with `.claude/agents/<Name>.md` is the official
@@ -134,7 +130,7 @@ impl Installer for ClaudeCode {
     fn install_hook(&self, scope: &Scope, opts: &InstallOpts) -> Result<Change, String> {
         common::install_json_hook_in(
             &self.settings_path(scope)?,
-            INSTALL_HOOK_PATHS,
+            HOOK_PATHS,
             self.hook_entry(opts),
             matches_entry,
             opts,
@@ -176,7 +172,7 @@ impl Installer for ClaudeCode {
         }
         if let Some(c) = common::uninstall_json_hook_in(
             &self.settings_path(scope)?,
-            ALL_HOOK_PATHS,
+            HOOK_PATHS,
             matches_entry,
             opts,
         )? {
@@ -217,7 +213,7 @@ impl Installer for ClaudeCode {
         let mut s = common::status_for(
             self.prompt_path(scope).ok().as_deref(),
             self.settings_path(scope).ok().as_deref(),
-            INSTALL_HOOK_PATHS,
+            HOOK_PATHS,
             matches_entry,
         );
         if let Ok(mcp_p) = self.mcp_path(scope) {
@@ -306,7 +302,7 @@ mod tests {
             .unwrap();
         let contents = std::fs::read_to_string(dir.path().join(".claude/settings.json")).unwrap();
         let root: Value = serde_json::from_str(&contents).unwrap();
-        for path in INSTALL_HOOK_PATHS {
+        for path in HOOK_PATHS {
             assert!(
                 json_hook::is_installed(&root, path, matches_entry),
                 "missing under {path:?}: {contents}"

--- a/src/installers/common.rs
+++ b/src/installers/common.rs
@@ -129,9 +129,13 @@ pub fn install_subagent_in(
     }
 }
 
+/// Writes our hook entry under every path in `hook_paths`.
+///
+/// One command can serve several events, so an adapter registers the same entry
+/// once per event it wants to hear about.
 pub fn install_json_hook_in<F>(
     path: &Path,
-    hook_path: &[&str],
+    hook_paths: &[&[&str]],
     entry: Value,
     matches: F,
     opts: &InstallOpts,
@@ -142,7 +146,12 @@ where
     let existing = read_optional(path)?.unwrap_or_else(|| "{}".into());
     let mut root: Value = serde_json::from_str(&existing)
         .map_err(|e| format!("parse {}: {}", path.display(), e))?;
-    let modified = json_hook::upsert(&mut root, hook_path, entry, matches);
+    let mut modified = false;
+    for hook_path in hook_paths {
+        if json_hook::upsert(&mut root, hook_path, entry.clone(), &matches) {
+            modified = true;
+        }
+    }
     if !modified {
         return Ok(Change::Skipped {
             path: path.to_path_buf(),
@@ -174,9 +183,13 @@ pub fn uninstall_prompt_in(path: &Path, opts: &InstallOpts) -> Result<Option<Cha
     Ok(Some(Change::Removed(path.to_path_buf())))
 }
 
+/// Drops our hook entry from every path in `hook_paths`.
+///
+/// The list spans the events the entry has ever been installed under, so an
+/// uninstall reaches an entry an older release wrote.
 pub fn uninstall_json_hook_in<F>(
     path: &Path,
-    hook_path: &[&str],
+    hook_paths: &[&[&str]],
     matches: F,
     opts: &InstallOpts,
 ) -> Result<Option<Change>, String>
@@ -188,7 +201,13 @@ where
     };
     let mut root: Value = serde_json::from_str(&existing)
         .map_err(|e| format!("parse {}: {}", path.display(), e))?;
-    if !json_hook::remove(&mut root, hook_path, matches) {
+    let mut removed = false;
+    for hook_path in hook_paths {
+        if json_hook::remove(&mut root, hook_path, &matches) {
+            removed = true;
+        }
+    }
+    if !removed {
         return Ok(None);
     }
     let new_contents = serde_json::to_string_pretty(&root).unwrap() + "\n";
@@ -372,10 +391,17 @@ pub fn uninstall_plain_file_in(
     Ok(Some(Change::Removed(path.to_path_buf())))
 }
 
+/// Reports on our hook entry across `hook_paths`, the events an install writes.
+///
+/// Installed means at least one of them holds the entry; partial means not all
+/// of them do. The distinction is what tells an existing install that an
+/// upgrade added an event — folding the paths with `any` alone would report a
+/// half-registered hook as current, and nothing would prompt the reinstall that
+/// completes it.
 pub fn status_for<F>(
     prompt_path: Option<&Path>,
     settings_path: Option<&Path>,
-    hook_path: &[&str],
+    hook_paths: &[&[&str]],
     matches: F,
 ) -> Status
 where
@@ -391,7 +417,12 @@ where
     if let Some(sp) = settings_path {
         if let Ok(Some(contents)) = read_optional(sp) {
             if let Ok(root) = serde_json::from_str::<Value>(&contents) {
-                s.hook_installed = json_hook::is_installed(&root, hook_path, matches);
+                let present = hook_paths
+                    .iter()
+                    .filter(|p| json_hook::is_installed(&root, p, &matches))
+                    .count();
+                s.hook_installed = present > 0;
+                s.hook_partial = present > 0 && present < hook_paths.len();
             }
         }
     }

--- a/src/installers/common.rs
+++ b/src/installers/common.rs
@@ -133,6 +133,10 @@ pub fn install_subagent_in(
 ///
 /// One command can serve several events, so an adapter registers the same entry
 /// once per event it wants to hear about.
+///
+/// A release that *moves* an event has to split this list from the one
+/// [`uninstall_json_hook_in`] and [`status_for`] are given: those two must still
+/// reach the abandoned event, and this one must not write it back.
 pub fn install_json_hook_in<F>(
     path: &Path,
     hook_paths: &[&[&str]],

--- a/src/installers/gemini.rs
+++ b/src/installers/gemini.rs
@@ -10,6 +10,14 @@ use crate::prompt::agent_prompt;
 pub struct Gemini;
 
 const HOOK_PATH: &[&str] = &["hooks", "BeforeTool"];
+/// Events an install registers the entry under.
+const INSTALL_HOOK_PATHS: &[&[&str]] = &[HOOK_PATH];
+
+/// Every event our entry has ever lived under, for uninstall and status. Kept
+/// separate from [`INSTALL_HOOK_PATHS`] even though the two agree today: a
+/// release that moves the event adds the old one here and must *not* add it
+/// there, or install would recreate the entry it just cleared.
+const ALL_HOOK_PATHS: &[&[&str]] = &[HOOK_PATH];
 const HOOK_NAME: &str = "ast-bro-read-interceptor";
 const MCP_KEY_PATH: &[&str] = &["mcpServers"];
 const MCP_SERVER_NAME: &str = "ast-bro";
@@ -85,7 +93,7 @@ impl Installer for Gemini {
     fn install_hook(&self, scope: &Scope, opts: &InstallOpts) -> Result<Change, String> {
         common::install_json_hook_in(
             &self.settings_path(scope)?,
-            HOOK_PATH,
+            INSTALL_HOOK_PATHS,
             self.hook_entry(opts),
             matches_entry,
             opts,
@@ -109,7 +117,7 @@ impl Installer for Gemini {
             changes.push(c);
         }
         if let Some(c) =
-            common::uninstall_json_hook_in(&self.settings_path(scope)?, HOOK_PATH, matches_entry, opts)?
+            common::uninstall_json_hook_in(&self.settings_path(scope)?, ALL_HOOK_PATHS, matches_entry, opts)?
         {
             changes.push(c);
         }
@@ -138,7 +146,7 @@ impl Installer for Gemini {
         let mut s = common::status_for(
             self.prompt_path(scope).ok().as_deref(),
             self.settings_path(scope).ok().as_deref(),
-            HOOK_PATH,
+            INSTALL_HOOK_PATHS,
             matches_entry,
         );
         if let Ok(sp) = self.settings_path(scope) {

--- a/src/installers/gemini.rs
+++ b/src/installers/gemini.rs
@@ -10,14 +10,8 @@ use crate::prompt::agent_prompt;
 pub struct Gemini;
 
 const HOOK_PATH: &[&str] = &["hooks", "BeforeTool"];
-/// Events an install registers the entry under.
-const INSTALL_HOOK_PATHS: &[&[&str]] = &[HOOK_PATH];
-
-/// Every event our entry has ever lived under, for uninstall and status. Kept
-/// separate from [`INSTALL_HOOK_PATHS`] even though the two agree today: a
-/// release that moves the event adds the old one here and must *not* add it
-/// there, or install would recreate the entry it just cleared.
-const ALL_HOOK_PATHS: &[&[&str]] = &[HOOK_PATH];
+/// The events our entry is registered under.
+const HOOK_PATHS: &[&[&str]] = &[HOOK_PATH];
 const HOOK_NAME: &str = "ast-bro-read-interceptor";
 const MCP_KEY_PATH: &[&str] = &["mcpServers"];
 const MCP_SERVER_NAME: &str = "ast-bro";
@@ -93,7 +87,7 @@ impl Installer for Gemini {
     fn install_hook(&self, scope: &Scope, opts: &InstallOpts) -> Result<Change, String> {
         common::install_json_hook_in(
             &self.settings_path(scope)?,
-            INSTALL_HOOK_PATHS,
+            HOOK_PATHS,
             self.hook_entry(opts),
             matches_entry,
             opts,
@@ -117,7 +111,7 @@ impl Installer for Gemini {
             changes.push(c);
         }
         if let Some(c) =
-            common::uninstall_json_hook_in(&self.settings_path(scope)?, ALL_HOOK_PATHS, matches_entry, opts)?
+            common::uninstall_json_hook_in(&self.settings_path(scope)?, HOOK_PATHS, matches_entry, opts)?
         {
             changes.push(c);
         }
@@ -146,7 +140,7 @@ impl Installer for Gemini {
         let mut s = common::status_for(
             self.prompt_path(scope).ok().as_deref(),
             self.settings_path(scope).ok().as_deref(),
-            INSTALL_HOOK_PATHS,
+            HOOK_PATHS,
             matches_entry,
         );
         if let Ok(sp) = self.settings_path(scope) {

--- a/src/installers/json_hook.rs
+++ b/src/installers/json_hook.rs
@@ -44,7 +44,38 @@ where
     };
     let before = arr.len();
     arr.retain(|v| !matches(v));
-    arr.len() != before
+    if arr.len() == before {
+        return false;
+    }
+    if arr.is_empty() {
+        prune_empty(root, path);
+    }
+    true
+}
+
+/// Deletes the key at `path`, and each ancestor the deletion left empty.
+///
+/// An event key we emptied is litter in a file the user owns: it reads as a hook
+/// configured for that event when none is. It disables nothing — Claude Code
+/// merges hook entries across settings levels rather than letting one level
+/// replace another — so what it costs is the next reader's time.
+fn prune_empty(root: &mut Value, path: &[&str]) {
+    for depth in (1..=path.len()).rev() {
+        let (parent_path, tail) = path[..depth].split_at(depth - 1);
+        let key = tail[0];
+        let Some(parent) = navigate_object_mut(root, parent_path) else {
+            return;
+        };
+        let empty = match parent.get(key) {
+            Some(Value::Array(a)) => a.is_empty(),
+            Some(Value::Object(o)) => o.is_empty(),
+            _ => return,
+        };
+        if !empty {
+            return;
+        }
+        parent.remove(key);
+    }
 }
 
 pub fn is_installed<F>(root: &Value, path: &[&str], matches: F) -> bool
@@ -87,6 +118,17 @@ fn navigate_array<'a>(root: &'a Value, path: &[&str]) -> Option<&'a Vec<Value>> 
         current = current.as_object()?.get(*key)?;
     }
     current.as_array()
+}
+
+fn navigate_object_mut<'a>(
+    root: &'a mut Value,
+    path: &[&str],
+) -> Option<&'a mut Map<String, Value>> {
+    let mut current = root;
+    for key in path {
+        current = current.as_object_mut()?.get_mut(*key)?;
+    }
+    current.as_object_mut()
 }
 
 fn navigate_array_mut<'a>(root: &'a mut Value, path: &[&str]) -> Option<&'a mut Vec<Value>> {
@@ -226,8 +268,11 @@ mod tests {
         );
     }
 
+    /// Removing the last entry takes the event key with it, and the `hooks`
+    /// object too when that was the last event. An emptied key is litter in a
+    /// file the user owns: it reads as a hook configured for that event.
     #[test]
-    fn legacy_entry_is_removed() {
+    fn legacy_entry_is_removed_and_leaves_no_empty_key() {
         let mut root = json!({
             "hooks": {
                 "PreToolUse": [
@@ -237,6 +282,25 @@ mod tests {
         });
         let removed = remove(&mut root, &["hooks", "PreToolUse"], predicate);
         assert!(removed);
-        assert!(root["hooks"]["PreToolUse"].as_array().unwrap().is_empty());
+        assert_eq!(root, json!({}), "left something behind: {root}");
+    }
+
+    /// Pruning stops at the first key that still holds something, so an event
+    /// the user configured for their own hooks survives ours being removed.
+    #[test]
+    fn remove_keeps_a_sibling_event_and_its_parent() {
+        let mut root = json!({
+            "hooks": {
+                "PreToolUse": [
+                    { "matcher": "Read", "hooks": [{"type": "command", "command": "ast-bro hook --protocol claude-code"}] }
+                ],
+                "PostToolUse": [
+                    { "matcher": "Bash", "hooks": [{"type": "command", "command": "echo mine"}] }
+                ]
+            }
+        });
+        assert!(remove(&mut root, &["hooks", "PreToolUse"], predicate));
+        assert!(root["hooks"].get("PreToolUse").is_none(), "{root}");
+        assert!(root["hooks"]["PostToolUse"].is_array(), "{root}");
     }
 }

--- a/src/installers/mod.rs
+++ b/src/installers/mod.rs
@@ -60,6 +60,10 @@ pub struct Status {
     pub prompt_installed: bool,
     pub prompt_version: Option<String>,
     pub hook_installed: bool,
+    /// Something of ours is registered, but not under every event an install
+    /// writes. An upgrade that adds an event leaves every existing install in
+    /// this state, and only re-running `install` moves it.
+    pub hook_partial: bool,
     pub mcp_installed: bool,
     pub skills_installed: bool,
 }

--- a/src/installers/tabnine.rs
+++ b/src/installers/tabnine.rs
@@ -10,6 +10,14 @@ use crate::prompt::agent_prompt;
 pub struct Tabnine;
 
 const HOOK_PATH: &[&str] = &["hooks", "BeforeTool"];
+/// Events an install registers the entry under.
+const INSTALL_HOOK_PATHS: &[&[&str]] = &[HOOK_PATH];
+
+/// Every event our entry has ever lived under, for uninstall and status. Kept
+/// separate from [`INSTALL_HOOK_PATHS`] even though the two agree today: a
+/// release that moves the event adds the old one here and must *not* add it
+/// there, or install would recreate the entry it just cleared.
+const ALL_HOOK_PATHS: &[&[&str]] = &[HOOK_PATH];
 const HOOK_NAME: &str = "ast-bro-read-interceptor";
 const OLD_HOOK_NAME: &str = "ast-outline-read-interceptor";
 
@@ -89,7 +97,7 @@ impl Installer for Tabnine {
     fn install_hook(&self, scope: &Scope, opts: &InstallOpts) -> Result<Change, String> {
         common::install_json_hook_in(
             &self.settings_path(scope)?,
-            HOOK_PATH,
+            INSTALL_HOOK_PATHS,
             self.hook_entry(opts),
             matches_entry,
             opts,
@@ -106,7 +114,7 @@ impl Installer for Tabnine {
             changes.push(c);
         }
         if let Some(c) =
-            common::uninstall_json_hook_in(&self.settings_path(scope)?, HOOK_PATH, matches_entry, opts)?
+            common::uninstall_json_hook_in(&self.settings_path(scope)?, ALL_HOOK_PATHS, matches_entry, opts)?
         {
             changes.push(c);
         }
@@ -117,7 +125,7 @@ impl Installer for Tabnine {
         common::status_for(
             self.prompt_path(scope).ok().as_deref(),
             self.settings_path(scope).ok().as_deref(),
-            HOOK_PATH,
+            INSTALL_HOOK_PATHS,
             matches_entry,
         )
     }

--- a/src/installers/tabnine.rs
+++ b/src/installers/tabnine.rs
@@ -10,14 +10,8 @@ use crate::prompt::agent_prompt;
 pub struct Tabnine;
 
 const HOOK_PATH: &[&str] = &["hooks", "BeforeTool"];
-/// Events an install registers the entry under.
-const INSTALL_HOOK_PATHS: &[&[&str]] = &[HOOK_PATH];
-
-/// Every event our entry has ever lived under, for uninstall and status. Kept
-/// separate from [`INSTALL_HOOK_PATHS`] even though the two agree today: a
-/// release that moves the event adds the old one here and must *not* add it
-/// there, or install would recreate the entry it just cleared.
-const ALL_HOOK_PATHS: &[&[&str]] = &[HOOK_PATH];
+/// The events our entry is registered under.
+const HOOK_PATHS: &[&[&str]] = &[HOOK_PATH];
 const HOOK_NAME: &str = "ast-bro-read-interceptor";
 const OLD_HOOK_NAME: &str = "ast-outline-read-interceptor";
 
@@ -97,7 +91,7 @@ impl Installer for Tabnine {
     fn install_hook(&self, scope: &Scope, opts: &InstallOpts) -> Result<Change, String> {
         common::install_json_hook_in(
             &self.settings_path(scope)?,
-            INSTALL_HOOK_PATHS,
+            HOOK_PATHS,
             self.hook_entry(opts),
             matches_entry,
             opts,
@@ -114,7 +108,7 @@ impl Installer for Tabnine {
             changes.push(c);
         }
         if let Some(c) =
-            common::uninstall_json_hook_in(&self.settings_path(scope)?, ALL_HOOK_PATHS, matches_entry, opts)?
+            common::uninstall_json_hook_in(&self.settings_path(scope)?, HOOK_PATHS, matches_entry, opts)?
         {
             changes.push(c);
         }
@@ -125,7 +119,7 @@ impl Installer for Tabnine {
         common::status_for(
             self.prompt_path(scope).ok().as_deref(),
             self.settings_path(scope).ok().as_deref(),
-            INSTALL_HOOK_PATHS,
+            HOOK_PATHS,
             matches_entry,
         )
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2211,8 +2211,13 @@ fn run_status(scope: &installers::Scope) {
         if s.hook_partial {
             // A qualification of a delivered answer, so stderr — stdout carries
             // the table, and a note wedged between two rows reads as a row.
+            //
+            // Worded as an observation rather than an instruction: a settings
+            // file can be short an event because the user removed it on purpose,
+            // and there is no way to tell that from an install that predates it.
             eprintln!(
-                "# note: {}: hook registered for only some events — re-run `ast-bro install` to complete it",
+                "# note: {}: our hook is registered for some of the events `install` writes, not all. \
+`ast-bro install` adds the rest; nothing else is needed if the missing one was removed deliberately.",
                 inst.name()
             );
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2187,7 +2187,9 @@ fn run_status(scope: &installers::Scope) {
         } else {
             "prompt -".to_string()
         };
-        let hook = if s.hook_installed {
+        let hook = if s.hook_partial {
+            "hook partial"
+        } else if s.hook_installed {
             "hook ✓"
         } else {
             "hook -"
@@ -2199,13 +2201,21 @@ fn run_status(scope: &installers::Scope) {
             "skills -"
         };
         println!(
-            "{:<14} {:<14} {:<8} {:<8} {}",
+            "{:<14} {:<14} {:<12} {:<8} {}",
             inst.name(),
             prompt,
             hook,
             mcp,
             skills
         );
+        if s.hook_partial {
+            // A qualification of a delivered answer, so stderr — stdout carries
+            // the table, and a note wedged between two rows reads as a row.
+            eprintln!(
+                "# note: {}: hook registered for only some events — re-run `ast-bro install` to complete it",
+                inst.name()
+            );
+        }
     }
 }
 

--- a/tests/hook_e2e.rs
+++ b/tests/hook_e2e.rs
@@ -7,6 +7,17 @@ fn binary() -> std::path::PathBuf {
     std::path::PathBuf::from(env!("CARGO_BIN_EXE_ast-bro"))
 }
 
+/// A file comfortably over the 200-line threshold every test here passes.
+fn big_file(dir: &TempDir) -> std::path::PathBuf {
+    let p = dir.path().join("big.rs");
+    let mut src = String::new();
+    for i in 0..300 {
+        src.push_str(&format!("fn f{}() {{}}\n", i));
+    }
+    std::fs::write(&p, &src).unwrap();
+    p
+}
+
 fn run_hook(protocol: &str, stdin: &str, args: &[&str]) -> (String, String, i32) {
     let mut cmd = Command::new(binary());
     cmd.arg("hook")
@@ -48,12 +59,7 @@ fn claude_code_pass_through_for_small_file() {
 #[test]
 fn claude_code_substitutes_for_big_file() {
     let dir = TempDir::new().unwrap();
-    let p = dir.path().join("big.rs");
-    let mut s = String::new();
-    for i in 0..300 {
-        s.push_str(&format!("fn f{}() {{}}\n", i));
-    }
-    std::fs::write(&p, &s).unwrap();
+    let p = big_file(&dir);
     let stdin = format!(
         r#"{{"tool_name":"Read","tool_input":{{"file_path":"{}"}}}}"#,
         p.display()
@@ -62,6 +68,89 @@ fn claude_code_substitutes_for_big_file() {
     assert_eq!(code, 0);
     assert!(stdout.contains("\"decision\":\"block\""));
     assert!(stdout.contains("ast-bro substituted"));
+}
+
+/// A `PostToolUse` event replaces the delivered result instead of refusing the
+/// call, so the host reports a success and the payload has no failure to
+/// disclaim (issue #34).
+#[test]
+fn claude_code_post_tool_use_replaces_the_result() {
+    let dir = TempDir::new().unwrap();
+    let p = big_file(&dir);
+    let stdin = format!(
+        r#"{{"hook_event_name":"PostToolUse","tool_name":"Read","tool_input":{{"file_path":"{}"}}}}"#,
+        p.display()
+    );
+    let (stdout, _, code) = run_hook("claude-code", &stdin, &["--min-lines", "200"]);
+    assert_eq!(code, 0);
+    assert!(
+        stdout.contains(r#""hookEventName":"PostToolUse""#),
+        "stdout: {}",
+        stdout
+    );
+    assert!(stdout.contains(r#""updatedToolOutput""#), "stdout: {}", stdout);
+    assert!(stdout.contains("ast-bro replaced the file contents"));
+    assert!(!stdout.contains("\"decision\""), "stdout: {}", stdout);
+    assert!(!stdout.contains("nothing failed"), "stdout: {}", stdout);
+}
+
+/// An entry still registered under `PreToolUse` keeps the refusal channel: the
+/// read has not run there, so a map can only arrive inside a rejection.
+#[test]
+fn claude_code_pre_tool_use_still_denies() {
+    let dir = TempDir::new().unwrap();
+    let p = big_file(&dir);
+    let stdin = format!(
+        r#"{{"hook_event_name":"PreToolUse","tool_name":"Read","tool_input":{{"file_path":"{}"}}}}"#,
+        p.display()
+    );
+    let (stdout, _, code) = run_hook("claude-code", &stdin, &["--min-lines", "200"]);
+    assert_eq!(code, 0);
+    assert!(stdout.contains("\"decision\":\"block\""), "stdout: {}", stdout);
+    assert!(stdout.contains("nothing failed"));
+}
+
+/// `PostToolUse` never fires for a read the host rejected, so the map has to
+/// ride `PostToolUseFailure`. That event cannot replace a result, only add
+/// context — which is all that is needed when the result carries no file.
+#[test]
+fn claude_code_post_tool_use_failure_augments_with_context() {
+    let dir = TempDir::new().unwrap();
+    let p = big_file(&dir);
+    let stdin = format!(
+        r#"{{"hook_event_name":"PostToolUseFailure","tool_name":"Read","tool_input":{{"file_path":"{}"}},"error":"File content (30000 tokens) exceeds maximum allowed tokens (25000)."}}"#,
+        p.display()
+    );
+    let (stdout, _, code) = run_hook("claude-code", &stdin, &["--min-lines", "200"]);
+    assert_eq!(code, 0);
+    assert!(
+        stdout.contains(r#""hookEventName":"PostToolUseFailure""#),
+        "stdout: {}",
+        stdout
+    );
+    assert!(stdout.contains(r#""additionalContext""#), "stdout: {}", stdout);
+    assert!(stdout.contains("because the Read did"), "stdout: {}", stdout);
+    // The notice must not repeat the host's error back as a diagnosis: the shim
+    // reads no error field, and the event fires for failures a retry would clear.
+    assert!(!stdout.contains("exceeds maximum"), "stdout: {}", stdout);
+    // No replacement field: PostToolUseFailure does not honor one, and sending
+    // it anyway would claim a capability the event does not have.
+    assert!(!stdout.contains("updatedToolOutput"), "stdout: {}", stdout);
+    assert!(!stdout.contains("\"decision\""), "stdout: {}", stdout);
+}
+
+#[test]
+fn claude_code_post_tool_use_passes_through_small_file() {
+    let dir = TempDir::new().unwrap();
+    let p = dir.path().join("small.rs");
+    std::fs::write(&p, "fn main() {}\n").unwrap();
+    let stdin = format!(
+        r#"{{"hook_event_name":"PostToolUse","tool_name":"Read","tool_input":{{"file_path":"{}"}}}}"#,
+        p.display()
+    );
+    let (stdout, _, code) = run_hook("claude-code", &stdin, &["--min-lines", "200"]);
+    assert_eq!(code, 0);
+    assert!(stdout.contains("\"continue\":true"), "stdout: {}", stdout);
 }
 
 #[test]
@@ -75,12 +164,7 @@ fn claude_code_pass_through_for_png() {
 #[test]
 fn claude_code_pass_through_when_offset_set() {
     let dir = TempDir::new().unwrap();
-    let p = dir.path().join("big.rs");
-    let mut s = String::new();
-    for i in 0..300 {
-        s.push_str(&format!("fn f{}() {{}}\n", i));
-    }
-    std::fs::write(&p, &s).unwrap();
+    let p = big_file(&dir);
     let stdin = format!(
         r#"{{"tool_name":"Read","tool_input":{{"file_path":"{}","offset":10,"limit":20}}}}"#,
         p.display()
@@ -93,12 +177,7 @@ fn claude_code_pass_through_when_offset_set() {
 #[test]
 fn gemini_substitutes_for_big_file() {
     let dir = TempDir::new().unwrap();
-    let p = dir.path().join("big.rs");
-    let mut s = String::new();
-    for i in 0..300 {
-        s.push_str(&format!("fn f{}() {{}}\n", i));
-    }
-    std::fs::write(&p, &s).unwrap();
+    let p = big_file(&dir);
     let stdin = format!(
         r#"{{"tool_name":"read_file","tool_input":{{"absolute_path":"{}"}}}}"#,
         p.display()


### PR DESCRIPTION
## Why

The hook replaces a large `Read` with the file's structure map. A file large enough that Claude Code refuses to read it at all never gets that far: the host rejects the call on its own, and the agent is left holding `File content … exceeds maximum allowed tokens` and nothing else. That is the worst case to lose the map on — the bigger the file, the more the map is worth and the more a full read would have cost.

Those refusals also land on files the hook's own threshold never sees, because the two count different things: `--min-lines` counts lines, the host's limit counts bytes. A 90-line file of 355 KB trips the host and no threshold of ours.

Separately, the map itself was never bounded. A minified bundle is one line holding thousands of declarations, so 255 KB of it mapped to 207 KB — roughly twice the tokens the refusal was about, and on the refusal channel that same map replaced a read the agent never paid for.

## What

- **A map for a read the host refuses.** The installer registers the hook under `PostToolUseFailure` too, and a new response channel delivers the map through `hookSpecificOutput.additionalContext`. Verified on a live host: the event fires for a `Read` the host rejected over its size limit, and the context reaches the model.
- **On that event the line-count and range gates drop.** The read is not happening again, lines are not what refused it, and the host's own error tells the agent to retry with `offset`/`limit` — so gating that retry out would leave the hole open. On the refusal channel both gates stay, where a substitution would replace what the caller asked for.
- **The map is bounded, shedding detail before cutting anything.** Order follows what each level costs: doc comments and attributes first, which are detail about a declaration, then fields and private items, which are declarations. Measured on Apache Calcite's `SqlFunctions.java` (7771 hand-written lines): 142,692 bytes in full, 74,607 with all 920 declarations once docs and attributes go. Both markers name what is missing and the command that returns it, because a silently short map reads as a file that ends early.
- **`status` reports `hook partial`** when only some of the events an install writes are registered — the state every existing install is in after this change — with the remedy on stderr, where the repo's contract puts qualifications of a delivered answer.
- **No empty hook events left behind.** `json_hook::remove` drops an event key once it is empty, so installing or uninstalling no longer leaves `"PreToolUse": []` in a file the user owns.
- **Internals that make the above possible.** `decide` returns the bare map and `io` owns the framing, so one command serves three events with three notices; `Channel::is_additive()` is the single place that says whether a payload replaces something or is added to it.

A normal large `Read` behaves as before: `PreToolUse` refuses the call and carries the map — now bounded.

## How to verify

`cargo test` — full suite green, `clippy --all-targets` clean.

Gates: `failed_ranged_read_is_substituted_but_a_successful_one_is_not` asserts both directions of the range gate, `failed_read_substitutes_below_the_line_threshold` the line gate, `failed_read_still_needs_a_parseable_file` that only those two gates moved. Bounding: `a_large_hand_written_file_sheds_detail_instead_of_declarations` builds a fixture whose full map exceeds the cap and asserts nothing was truncated, the shed is named, and the first and last declarations survive; `a_minified_bundle_is_trimmed_and_points_at_the_whole_map` covers the backstop. Registration: `install_hook_registers_pre_tool_use_and_the_failure_event` also asserts `PostToolUse` is *not* registered. Status: `status_reports_partial_for_an_install_missing_the_failure_event` and `status_is_not_partial_after_install_completes_it`. Notices: `every_notice_keeps_its_command_on_one_line` catches a wrap inside the backticks that would comment out the symbol argument.

By hand, on the file the host refuses:

```console
$ echo '{"hook_event_name":"PostToolUseFailure","tool_name":"Read","tool_input":{"file_path":"huge.rs"}}' | ast-bro hook --protocol claude-code --min-lines 200
{"hookSpecificOutput":{"hookEventName":"PostToolUseFailure","additionalContext":"# ast-bro supplies this structure map, with line ranges, because the Read did…"}}
```

Installing over a settings file leaves the user's own hooks untouched; uninstalling leaves no empty keys.

## Note on #34

#34 asks for a channel that reports the substitution as a success rather than a failed tool call. That channel does not exist for the built-in `Read` on Claude Code 2.1.223: `hookSpecificOutput.updatedToolOutput` replaces the result of an MCP tool and is ignored for `Read` and `Bash`. Measured with a hook returning `updatedToolOutput` and `additionalContext` in one object — the second lands every time, the first never does — with workspace trust, field name, and envelope parsing ruled out ([evidence](https://github.com/aeroxy/ast-bro/issues/34#issuecomment-5233506130)).

So `PreToolUse` remains the registered channel, and `Channel::Replace` stays in the code unregistered, carrying that measurement and reachable from a hand-written `PostToolUse` entry for anyone whose host honors the field. This PR does not close #34.

Refs #34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)