### PR TITLE
docs: note that the CLI and MCP surfaces carry one feature set

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,3 +18,7 @@ The architecture page links to eight deeper wiki files — read them on-demand w
 - [wiki/squeeze.md](wiki/squeeze.md) — log/text token compression (squeeze): multi-stage pipeline, reversible legend, degenerate fallback
 - [wiki/network-security.md](wiki/network-security.md) — model download, TLS policy, mirror fallback
 - [wiki/file-filtering.md](wiki/file-filtering.md) — what gets walked, ignore layers, escape hatches, shebang detection, test-file heuristics
+
+## CLI and MCP are one feature set
+
+Each MCP tool in `src/mcp/tools.rs` mirrors a CLI subcommand; only the maintenance commands (`install`, `uninstall`, `status`, `hook`, `prompt`, `mcp`) are CLI-only. A flag added, renamed, or redefaulted on one surface is unfinished until the other carries it — the documentation guards check that an existing argument describes itself, not that it exists on both sides. The two are declared in different places: clap derives in `src/lib.rs`, a hand-written JSON literal in `src/mcp/tools.rs`. Change them in the same commit, and state any intended asymmetry in the tool description.


### PR DESCRIPTION
## Why

#49 documented 62 CLI arguments, and then had to document 21 MCP properties in a second round, because the guard it added walks `Cli::command()` and can never reach the hand-written JSON literal in `src/mcp/tools.rs`. Both surfaces are now guarded, but only for *descriptions* — the tests check that an existing argument describes itself, not that it exists on both sides.

The argument sets themselves have already drifted. Comparing a live `tools/list` against `--help` on each subcommand:

| Tool | On the CLI | Missing from MCP |
| --- | --- | --- |
| `digest` | `--detail`, `--no-private` / `-fields` / `-docs` / `-attrs` / `-lines`, `--preset` | the whole three-axis form from #37 — the MCP schema still offers only `include_private` / `include_fields` |
| `map` | `--preset`, `--include-private`, `--include-fields` | — |
| `callers` | `--tests`, `--exclude-tests` | — |
| `reverse-deps` | `--tests`, `--exclude-tests` | — |
| `search`, `context`, `impact` | `--rebuild` | — |
| `show` | `<TARGET>...`, several targets | `path` is a single string |

Drift runs the other way too: the `rebuild` property #49 removed from `callers` / `callees` / `trace` was in the schema but absent from the args struct, so serde dropped it and the tool advertised a lever it did not have.

Defaults happen to agree everywhere I checked — `depth` 1 / 2 / 3 / 12, `limit` 200, `max_members` 50, `budget` 8000, `top_k` 10, `show --limit` 20 — but nothing holds them there.

Nothing in the repository said the two surfaces are meant to match, so this records it where a change to either one starts.

## What

One paragraph appended to `AGENTS.md` (which `CLAUDE.md` and `GEMINI.md` symlink to): the tools mirror the CLI subcommands, the six maintenance commands are deliberately CLI-only, the existing guards do not cover argument *existence*, and the two declarations live in different files, so they change in the same commit.

Documentation only — no code, no tests, no behavior change.

## How to verify

Reproduce the table above against a build of `main`:

```bash
printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' | ast-bro mcp
```

## Follow-up

The note is a convention, not a guard. The mechanical version is a `cli_mcp_parity` test that compares the argument names of `Cli::command()` against `tools::list()` and keeps an explicit allowlist of intended differences (`--compact`, the six maintenance commands, and `show`'s single target — if that one is a decision rather than an omission). Happy to open an issue for that plus the seven gaps above, if you want them tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
